### PR TITLE
Adds support for icons and keymap when running locally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ include(${VALA_USE_FILE})
 
 set(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/etc" CACHE FILEPATH "sysconfdir")
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 add_subdirectory(src)
 add_subdirectory(icons)
 add_subdirectory(man)

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -239,6 +239,7 @@ namespace pdfpc.Window {
             this.prerender_progress.no_show_all = true;
 
             int icon_height = bottom_height - 10;
+
             this.blank_icon = this.load_icon("blank.svg", icon_height);
             this.frozen_icon = this.load_icon("snow.svg", icon_height);
             this.pause_icon = this.load_icon("pause.svg", icon_height);
@@ -295,6 +296,15 @@ namespace pdfpc.Window {
         }
 
         protected Gtk.Image load_icon(string filename, int icon_height) {
+
+            // attempt to load from a local path (if the user hasn't installed)
+            // if that fails, attempt to load from the global path
+            string load_icon_path = source_path + "/icons/" + filename;
+            File icon_file = File.new_for_path(load_icon_path);
+            if (!icon_file.query_exists()) {
+                load_icon_path = icon_path + filename;
+            }
+
             Gtk.Image icon;
             try {
                 Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file_at_size(icon_path + filename,

--- a/src/paths.in
+++ b/src/paths.in
@@ -1,2 +1,3 @@
 const string icon_path = "@CMAKE_INSTALL_PREFIX@/share/pixmaps/pdfpc/";
+const string source_path = "@CMAKE_SOURCE_DIR@";
 const string etc_path = "@SYSCONFDIR@";

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -233,9 +233,11 @@ namespace pdfpc {
             this.cache_status = new CacheStatus();
 
             ConfigFileReader configFileReader = new ConfigFileReader(this.controller);
+
+            configFileReader.readConfig(source_path + "/rc/pdfpcrc");
             configFileReader.readConfig(etc_path + "/pdfpcrc");
             configFileReader.readConfig(Environment.get_home_dir() + "/.pdfpcrc");
-            
+
             set_styling();
 
             var screen = Gdk.Screen.get_default();


### PR DESCRIPTION
Resolves #5 by adding support for:
*  a default keymap when no pdfpcrc file is found
* loading icons when building in the build directory
* a bin/ directory on  build

Style note: these commits seem relatively self-contained, so I didn't rebase them all into one.  The pull request does somewhat serve the purpose of a single explaination for things in that way -- what do you guys think?  Should we rebase this kind of thing or leave it?