### PR TITLE
Stop using using

### DIFF
--- a/src/classes/action/action_mapping.vala
+++ b/src/classes/action/action_mapping.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
-using pdfpc;
-
 namespace pdfpc {
     /**
      * Base action mapping, encapsulating actions that result from links or annotations.

--- a/src/classes/action/link_action.vala
+++ b/src/classes/action/link_action.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
-using pdfpc;
-
 namespace pdfpc {
     /**
      * Action for internal links in the PDF file.

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -180,7 +180,7 @@ namespace pdfpc {
                     string tmp_fn;
                     int fh;
                     try {
-                        fh = FileUtils.open_tmp(null, out tmp_fn);
+                        fh = FileUtils.open_tmp("pdfpc-XXXXXX", out tmp_fn);
                     } catch (FileError e) {
                         warning("Could not create temp file: %s", e.message);
                         return null;
@@ -283,7 +283,12 @@ namespace pdfpc {
          * Utility function for converting filenames to uris.
          */
         public string filename_to_uri(string file, string pdf_url) {
-            var uriRE = new Regex("^[a-z]*://");
+            Regex uriRE = null;
+            try {
+                uriRE = new Regex("^[a-z]*://");
+            } catch (Error error) {
+                // Won't happen
+            }
             if (uriRE.match(file))
                 return file;
             if (GLib.Path.is_absolute(file))

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -20,11 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gst;
-using Cairo;
-
-using pdfpc;
-
 namespace pdfpc {
     /**
      * An error in constructing a gstreamer pipeline.
@@ -36,8 +31,8 @@ namespace pdfpc {
     /**
      * Make a non-NULL gstreamer element, or raise an error.
      */
-    public Element gst_element_make(string factoryname, string? name) throws PipelineError {
-        var element = ElementFactory.make(factoryname, name);
+    public Gst.Element gst_element_make(string factoryname, string? name) throws PipelineError {
+        var element = Gst.ElementFactory.make(factoryname, name);
         if (element == null)
             throw new PipelineError.ElementConstruction(@"Could not make element $name of type $factoryname.");
         return element;
@@ -50,7 +45,7 @@ namespace pdfpc {
         /**
          * The gstreamer pipeline for playback.
          */
-        public dynamic Element pipeline;
+        public dynamic Gst.Element pipeline;
 
         /**
          * A flag to indicate when we've reached the End Of Stream, so we
@@ -230,10 +225,10 @@ namespace pdfpc {
          * Set up the gstreamer pipeline.
          */
         protected void establish_pipeline(string uri) {
-            var bin = new Bin("bin");
-            var tee = ElementFactory.make("tee", "tee");
+            var bin = new Gst.Bin("bin");
+            var tee = Gst.ElementFactory.make("tee", "tee");
             bin.add_many(tee);
-            bin.add_pad(new GhostPad("sink", tee.get_pad("sink")));
+            bin.add_pad(new Gst.GhostPad("sink", tee.get_pad("sink")));
             Gdk.Rectangle rect;
             int n = 0;
             uint xid;
@@ -241,21 +236,21 @@ namespace pdfpc {
                 xid = this.controller.overlay_pos(n, this.area, out rect);
                 if (xid == 0)
                     break;
-                var sink = ElementFactory.make("xvimagesink", @"sink$n");
-                var queue = ElementFactory.make("queue", @"queue$n");
+                var sink = Gst.ElementFactory.make("xvimagesink", @"sink$n");
+                var queue = Gst.ElementFactory.make("queue", @"queue$n");
                 bin.add_many(queue,sink);
                 tee.link(queue);
                 var ad_element = this.link_additional(n, queue, bin, rect);
                 ad_element.link(sink);
 
-                var xoverlay = sink as XOverlay;
+                var xoverlay = sink as Gst.XOverlay;
                 xoverlay.set_window_handle(xid);
                 xoverlay.handle_events(false);
                 xoverlay.set_render_rectangle(rect.x, rect.y, rect.width, rect.height);
                 n++;
             }
 
-            this.pipeline = ElementFactory.make("playbin2", "playbin");
+            this.pipeline = Gst.ElementFactory.make("playbin2", "playbin");
             this.pipeline.uri = uri;
             this.pipeline.video_sink = bin;
             var bus = this.pipeline.get_bus();
@@ -274,8 +269,8 @@ namespace pdfpc {
          *
          * This stub does nothing.
          */
-        protected virtual Element link_additional(int n, Element source, Bin bin,
-                                                  Gdk.Rectangle rect) {
+        protected virtual Gst.Element link_additional(int n, Gst.Element source, Gst.Bin bin,
+                                                      Gdk.Rectangle rect) {
             return source;
         }
 
@@ -304,33 +299,33 @@ namespace pdfpc {
         public virtual void play() {
             if (this.eos) {
                 this.eos = false;
-                this.pipeline.seek_simple(Gst.Format.TIME, SeekFlags.FLUSH, 0);
+                this.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH, 0);
             }
-            this.pipeline.set_state(State.PLAYING);
+            this.pipeline.set_state(Gst.State.PLAYING);
         }
 
         /**
          * Pause playback.
          */
         public virtual void pause() {
-            this.pipeline.set_state(State.PAUSED);
+            this.pipeline.set_state(Gst.State.PAUSED);
         }
 
         /**
          * Stop playback.
          */
         public virtual void stop() {
-            this.pipeline.set_state(State.NULL);
+            this.pipeline.set_state(Gst.State.NULL);
         }
 
         /**
          * Pause if playing, as vice versa.
          */
         public virtual void toggle_play() {
-            State state;
-            ClockTime time = util_get_timestamp();
+            Gst.State state;
+            Gst.ClockTime time = Gst.util_get_timestamp();
             this.pipeline.get_state(out state, null, time);
-            if (state == State.PLAYING)
+            if (state == Gst.State.PLAYING)
                 this.pause();
             else
                 this.play();
@@ -339,7 +334,7 @@ namespace pdfpc {
         /**
          * Basic printout of error messages on the pipeline.
          */
-        public virtual void on_message(Gst.Bus bus, Message message) {
+        public virtual void on_message(Gst.Bus bus, Gst.Message message) {
             GLib.Error err;
             string debug;
             message.parse_error(out err, out debug);
@@ -349,9 +344,9 @@ namespace pdfpc {
         /**
          * Mark reaching the end of stream, and set state to paused.
          */
-        public virtual void on_eos(Gst.Bus bus, Message message) {
+        public virtual void on_eos(Gst.Bus bus, Gst.Message message) {
             if (this.loop) {
-                this.pipeline.seek_simple(Gst.Format.TIME, SeekFlags.FLUSH, 0);
+                this.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH, 0);
             } else {
                 // Can't seek to beginning w/o updating output, so mark to seek later
                 this.eos = true;
@@ -440,27 +435,27 @@ namespace pdfpc {
         /**
          * Hook up the elements to draw the controls to the first output leg.
          */
-        protected override Element link_additional(int n, Element source, Bin bin,
-                                                   Gdk.Rectangle rect) {
+        protected override Gst.Element link_additional(int n, Gst.Element source, Gst.Bin bin,
+                                                       Gdk.Rectangle rect) {
             if (n != 0)
                 return source;
 
             this.rect = rect;
 
-            dynamic Element overlay;
-            Element adaptor2;
+            dynamic Gst.Element overlay;
+            Gst.Element adaptor2;
             try {
                 var scale = gst_element_make("videoscale", "scale");
                 var rate = gst_element_make("videorate", "rate");
                 var adaptor1 = gst_element_make("ffmpegcolorspace", "adaptor1");
                 adaptor2 = gst_element_make("ffmpegcolorspace", "adaptor2");
                 overlay = gst_element_make("cairooverlay", "overlay");
-                var caps = Caps.from_string(
+                var caps = Gst.Caps.from_string(
                     "video/x-raw-rgb," + // Same as cairooverlay; hope to minimize transformations
                     "framerate=[25/1,2147483647/1]," + // At least 25 fps
                     @"width=$(rect.width),height=$(rect.height)"
                 );
-                dynamic Element filter = gst_element_make("capsfilter", "filter");
+                dynamic Gst.Element filter = gst_element_make("capsfilter", "filter");
                 filter.caps = caps;
                 bin.add_many(adaptor1, adaptor2, overlay, scale, rate, filter);
                 if (!source.link_many(rate, scale, adaptor1, filter, overlay, adaptor2))
@@ -481,9 +476,9 @@ namespace pdfpc {
          * needs to be scaled to fit in the alloted area.  (This is only important
          * for the view with the controls.)
          */
-        public void on_prepare(Element overlay, Caps caps){
+        public void on_prepare(Gst.Element overlay, Gst.Caps caps){
             int width = -1, height = -1;
-            VideoFormat format = VideoFormat.UNKNOWN;
+            Gst.VideoFormat format = Gst.VideoFormat.UNKNOWN;
             Gst.video_format_parse_caps(caps, ref format, ref width, ref height);
             scalex = 1.0*width / rect.width;
             scaley = 1.0*height / rect.height;
@@ -496,7 +491,7 @@ namespace pdfpc {
         /**
          * Everytime we get a new frame, update the progress bar.
          */
-        public void on_draw(Element overlay, Context cr, uint64 timestamp, uint64 duration) {
+        public void on_draw(Gst.Element overlay, Cairo.Context cr, uint64 timestamp, uint64 duration) {
             // Transform to work from bottom left, in screen coordinates
             cr.translate(0, this.vheight);
             cr.scale(this.scalex, -this.scaley);
@@ -504,7 +499,7 @@ namespace pdfpc {
             this.draw_seek_bar(cr, timestamp);
         }
 
-        private void draw_seek_bar(Context cr, uint64 timestamp) {
+        private void draw_seek_bar(Cairo.Context cr, uint64 timestamp) {
             double fraction = 1.0*timestamp / this.duration;
             if (this.in_seek_bar || this.mouse_drag) {
                 var bar_end = fraction * (rect.width - 2*this.seek_bar_padding);
@@ -516,15 +511,15 @@ namespace pdfpc {
                 cr.set_source_rgba(1,1,1,0.8);
                 cr.fill();
 
-                var time_in_sec = (int)(timestamp / SECOND);
+                var time_in_sec = (int)(timestamp / Gst.SECOND);
                 var timestring = "%i:%02i".printf(time_in_sec/60, time_in_sec%60);
-                var dur_in_sec = (int)(this.duration / SECOND);
+                var dur_in_sec = (int)(this.duration / Gst.SECOND);
                 var durstring = "%i:%02i".printf(dur_in_sec/60, dur_in_sec%60);
-                TextExtents te;
-                FontOptions fo = new FontOptions();
-                fo.set_antialias(Antialias.GRAY);
+                Cairo.TextExtents te;
+                Cairo.FontOptions fo = new Cairo.FontOptions();
+                fo.set_antialias(Cairo.Antialias.GRAY);
                 cr.set_font_options(fo);
-                cr.select_font_face("sans", FontSlant.NORMAL, FontWeight.NORMAL);
+                cr.select_font_face("sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.NORMAL);
                 cr.set_font_size(this.seek_bar_height - 2*seek_bar_padding);
 
                 cr.text_extents(durstring, out te);
@@ -578,7 +573,7 @@ namespace pdfpc {
             if (seek_fraction < 0) seek_fraction = 0;
             if (seek_fraction > 1) seek_fraction = 1;
             var seek_time = (int64)(seek_fraction * this.duration);
-            this.pipeline.seek_simple(Gst.Format.TIME, SeekFlags.FLUSH, seek_time);
+            this.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH, seek_time);
             return seek_time;
         }
 
@@ -599,10 +594,10 @@ namespace pdfpc {
          * drag state.
          */
         public override bool on_button_press(Gtk.Widget widget, Gdk.EventButton event) {
-            State state;
-            ClockTime time = util_get_timestamp();
+            Gst.State state;
+            Gst.ClockTime time = Gst.util_get_timestamp();
             this.pipeline.get_state(out state, null, time);
-            if (state == State.NULL || widget != this.controller.main_view) {
+            if (state == Gst.State.NULL || widget != this.controller.main_view) {
                 this.toggle_play();
                 return true;
             }
@@ -613,7 +608,7 @@ namespace pdfpc {
                 this.toggle_play();
             else {
                 this.mouse_drag = true;
-                this.drag_was_playing = (this.pipeline.current_state == State.PLAYING);
+                this.drag_was_playing = (this.pipeline.current_state == Gst.State.PLAYING);
                 this.pause();
                 this.mouse_seek(x, y);
                 this.stop_refresh();
@@ -665,7 +660,7 @@ namespace pdfpc {
             if (this.refresh_timeout != 0)
                 Source.remove(this.refresh_timeout);
             this.refresh_timeout = Timeout.add(50, () => {
-                this.pipeline.seek_simple(Gst.Format.TIME, SeekFlags.FLUSH, curr_time);
+                this.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH, curr_time);
                 return true;
             } );
         }

--- a/src/classes/cache_status.vala
+++ b/src/classes/cache_status.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-using Gdk;
-using Cairo;
-
 namespace pdfpc {
     /**
      * Interface for showing the fill status of all registered pdf image caches

--- a/src/classes/configFileReader.vala
+++ b/src/classes/configFileReader.vala
@@ -125,10 +125,10 @@ namespace pdfpc {
 
         public void readConfig(string fname) {
             var file = File.new_for_path(fname);
-            var splitRegex = new Regex("\\s\\s*");
-            var commentRegex = new Regex("\\s*#.*$");
             uint8[] raw_datau8;
             try {
+                var splitRegex = new Regex("\\s\\s*");
+                var commentRegex = new Regex("\\s*#.*$");
                 file.load_contents(null, out raw_datau8, null);
                 string[] lines = ((string) raw_datau8).split("\n");
                 for (int i=0; i<lines.length; ++i) {

--- a/src/classes/metadata/base.vala
+++ b/src/classes/metadata/base.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
 namespace pdfpc {
     /**
      * Metadata base class describing the basic metadata needed for every

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
 namespace pdfpc.Metadata {
     /**
      * Metadata for Pdf files

--- a/src/classes/mutex_locks.vala
+++ b/src/classes/mutex_locks.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
 namespace pdfpc {
     /**
      * Static property container holding all mutex locks, which are needed

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -20,9 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Gee;
-
 namespace pdfpc {
     /**
      * Controller handling all the triggered events/signals
@@ -119,7 +116,7 @@ namespace pdfpc {
                 this.d = d;
             }
         }
-        protected HashMap<string, KeyAction> actionNames;
+        protected Gee.HashMap<string, KeyAction> actionNames;
         protected class KeyDef {
             public uint keycode { get; set; }
             public uint modMask { get; set; }
@@ -131,7 +128,7 @@ namespace pdfpc {
 
             public static uint hash(void *_a) {
                 KeyDef a = (KeyDef)_a;
-                var uintHashFunc = Functions.get_hash_func_for(Type.from_name("uint"));
+                var uintHashFunc = Gee.Functions.get_hash_func_for(Type.from_name("uint"));
                 return uintHashFunc(a.keycode | a.modMask); // | is probable the best combinator, but for this small application it should suffice
             }
 
@@ -141,8 +138,8 @@ namespace pdfpc {
                 return a.keycode == b.keycode && a.modMask == b.modMask;
             }
         }
-        protected HashMap<KeyDef, KeyAction> keyBindings;
-        protected HashMap<KeyDef, KeyAction> mouseBindings; // We abuse the KeyDef structure
+        protected Gee.HashMap<KeyDef, KeyAction> keyBindings;
+        protected Gee.HashMap<KeyDef, KeyAction> mouseBindings; // We abuse the KeyDef structure
 
         /*
          * "Main" view of current slide
@@ -188,8 +185,8 @@ namespace pdfpc {
             this.current_user_slide_number = 0;
 
             // The standard hash function for classes is to use the pointer, so we have to provide our own
-            this.keyBindings = new HashMap<KeyDef, KeyAction>(KeyDef.hash, KeyDef.equal);
-            this.mouseBindings = new HashMap<KeyDef, KeyAction>(KeyDef.hash, KeyDef.equal);
+            this.keyBindings = new Gee.HashMap<KeyDef, KeyAction>(KeyDef.hash, KeyDef.equal);
+            this.mouseBindings = new Gee.HashMap<KeyDef, KeyAction>(KeyDef.hash, KeyDef.equal);
             this.fillActionNames();
         }
 
@@ -206,7 +203,7 @@ namespace pdfpc {
         }
 
         protected void fillActionNames() {
-            this.actionNames = new HashMap<string, KeyAction>();
+            this.actionNames = new Gee.HashMap<string, KeyAction>();
             this.actionNames.set("next", new KeyAction(this.next_page));
             this.actionNames.set("next10", new KeyAction(this.jump10));
             this.actionNames.set("nextOverlay", new KeyAction(this.next_user_page));

--- a/src/classes/renderer/base.vala
+++ b/src/classes/renderer/base.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
 namespace pdfpc {
     /**
      * Renderer base class needed to be extended by every slide renderer.

--- a/src/classes/renderer/cache/base.vala
+++ b/src/classes/renderer/cache/base.vala
@@ -20,9 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Gdk;
-
 namespace pdfpc {
     /**
      * Base Cache store interface which needs to be implemented by every
@@ -56,13 +53,13 @@ namespace pdfpc {
         /**
          * Store a pixmap in the cache using the given index as identifier
          */
-        public abstract void store( uint index, Pixmap pixmap );
+        public abstract void store( uint index, Gdk.Pixmap pixmap );
 
         /**
          * Retrieve a stored pixmap from the cache.
          *
          * If no item with the given index is available null is returned
          */
-        public abstract Pixmap? retrieve( uint index );
+        public abstract Gdk.Pixmap? retrieve( uint index );
     }
 }

--- a/src/classes/renderer/cache/option_factory.vala
+++ b/src/classes/renderer/cache/option_factory.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
-using pdfpc;
-
 namespace pdfpc.Renderer {
     /**
      * Creates cache engines based on the global commandline options

--- a/src/classes/renderer/cache/png/engine.vala
+++ b/src/classes/renderer/cache/png/engine.vala
@@ -20,12 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Gdk;
-using Cairo;
-
-using pdfpc;
-
 namespace pdfpc.Renderer.Cache {
     /**
      * Cache store which holds all given items in memory as compressed png
@@ -58,7 +52,7 @@ namespace pdfpc.Renderer.Cache {
         /**
          * Store a pixmap in the cache using the given index as identifier
          */
-        public override void store( uint index, Pixmap pixmap ) {
+        public override void store( uint index, Gdk.Pixmap pixmap ) {
             int pixmap_width, pixmap_height;
             pixmap.get_size( out pixmap_width, out pixmap_height );
 
@@ -67,14 +61,14 @@ namespace pdfpc.Renderer.Cache {
             // the return value of this function. If a new pixbuf is created by
             // the function directly it will have a refcount of 2 afterwards
             // and thereby will not be freed.
-            var pixbuf = new Pixbuf(
-                Colorspace.RGB,
+            var pixbuf = new Gdk.Pixbuf(
+                Gdk.Colorspace.RGB,
                 false,
                 8,
                 pixmap_width,
                 pixmap_height
             );
-            pixbuf_get_from_drawable(
+            Gdk.pixbuf_get_from_drawable(
                 pixbuf,
                 pixmap,
                 null,
@@ -104,13 +98,13 @@ namespace pdfpc.Renderer.Cache {
          *
          * If no item with the given index is available null is returned
          */
-        public override Pixmap? retrieve( uint index ) {
+        public override Gdk.Pixmap? retrieve( uint index ) {
             var item = this.storage[index];
             if ( item == null ) {
                 return null;
             }
 
-            var loader = new PixbufLoader();
+            var loader = new Gdk.PixbufLoader();
             try {
                 loader.write( item.get_png_data() );
                 loader.close();
@@ -128,7 +122,7 @@ namespace pdfpc.Renderer.Cache {
                 24
             );
 
-            Context cr = Gdk.cairo_create( pixmap );
+            Cairo.Context cr = Gdk.cairo_create( pixmap );
             Gdk.cairo_set_source_pixbuf( cr, pixbuf, 0, 0 );
             cr.rectangle(
                 0,

--- a/src/classes/renderer/cache/png/item.vala
+++ b/src/classes/renderer/cache/png/item.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
 namespace pdfpc.Renderer.Cache {
     /**
      * PNG picture data stored by the PNG cache engine.

--- a/src/classes/renderer/cache/simple/engine.vala
+++ b/src/classes/renderer/cache/simple/engine.vala
@@ -20,11 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Gdk;
-
-using pdfpc;
-
 namespace pdfpc.Renderer.Cache {
     /**
      * Cache store which simply holds all given items in memory.
@@ -33,7 +28,7 @@ namespace pdfpc.Renderer.Cache {
         /**
          * In memory storage for all the given pixmaps
          */
-        protected Pixmap[] storage = null;
+        protected Gdk.Pixmap[] storage = null;
 
         /**
          * Mutex used to limit access to storage array to one thread at a time.
@@ -49,14 +44,14 @@ namespace pdfpc.Renderer.Cache {
             base( metadata );
 
             this.mutex.lock();
-            this.storage = new Pixmap[this.metadata.get_slide_count()];
+            this.storage = new Gdk.Pixmap[this.metadata.get_slide_count()];
             this.mutex.unlock();
         }
 
         /**
          * Store a pixmap in the cache using the given index as identifier
          */
-        public override void store( uint index, Pixmap pixmap ) {
+        public override void store( uint index, Gdk.Pixmap pixmap ) {
             this.mutex.lock();
             this.storage[index] = pixmap;
             this.mutex.unlock();
@@ -67,7 +62,7 @@ namespace pdfpc.Renderer.Cache {
          *
          * If no item with the given index is available null is returned
          */
-        public override Pixmap? retrieve( uint index ) {
+        public override Gdk.Pixmap? retrieve( uint index ) {
             return this.storage[index];
         }
     }

--- a/src/classes/renderer/pdf.vala
+++ b/src/classes/renderer/pdf.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Gdk;
-using Cairo;
-
 namespace pdfpc {
     /**
      * Pdf slide renderer
@@ -111,8 +107,8 @@ namespace pdfpc {
 
             // A lot of Pdfs have transparent backgrounds defined. We render
             // every page before a white background because of this.
-            Pixmap pixmap = new Pixmap( null, this.width, this.height, 24 );
-            Context cr = Gdk.cairo_create( pixmap );
+            Gdk.Pixmap pixmap = new Gdk.Pixmap( null, this.width, this.height, 24 );
+            Cairo.Context cr = Gdk.cairo_create( pixmap );
 
             cr.set_source_rgb( 255, 255, 255 );
             cr.rectangle( 0, 0, this.width, this.height );
@@ -133,8 +129,8 @@ namespace pdfpc {
         }
 
       public override Gdk.Pixmap fade_to_black() {
-            Pixmap pixmap = new Pixmap( null, this.width, this.height, 24 );
-            Context cr = Gdk.cairo_create( pixmap );
+            Gdk.Pixmap pixmap = new Gdk.Pixmap( null, this.width, this.height, 24 );
+            Cairo.Context cr = Gdk.cairo_create( pixmap );
 
             cr.set_source_rgb( 0, 0, 0 );
             cr.rectangle( 0, 0, this.width, this.height );

--- a/src/classes/timer_label.vala
+++ b/src/classes/timer_label.vala
@@ -20,9 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-using Gdk;
-
 namespace pdfpc {
 
     /**
@@ -65,7 +62,7 @@ namespace pdfpc {
          * This property is public and not accesed using a setter to be able to use
          * Color.parse directly on it.
          */
-        public Color normal_color;
+        public Gdk.Color normal_color;
 
         /**
          * Color used for pre-talk timer rendering
@@ -73,7 +70,7 @@ namespace pdfpc {
          * This property is public and not accesed using a setter to be able to use
          * Color.parse directly on it.
          */
-        public Color pretalk_color;
+        public Gdk.Color pretalk_color;
 
         /**
          * Default constructor taking the initial time as argument, as well as
@@ -86,8 +83,8 @@ namespace pdfpc {
         public TimerLabel( time_t start_time = 0 ) {
             this.start_time = start_time;
 
-            Color.parse( "white", out this.normal_color );
-            Color.parse( "green", out this.pretalk_color );
+            Gdk.Color.parse( "white", out this.normal_color );
+            Gdk.Color.parse( "green", out this.pretalk_color );
         }
 
         /**
@@ -220,7 +217,7 @@ namespace pdfpc {
          * This property is public and not accesed using a setter to be able to use
          * Color.parse directly on it.
          */
-        public Color last_minutes_color;
+        public Gdk.Color last_minutes_color;
 
         /**
          * Color used to represent negative number (time is over)
@@ -228,15 +225,15 @@ namespace pdfpc {
          * This property is public and not accesed using a setter to be able to use
          * Color.parse directly on it.
          */
-        public Color negative_color;
+        public Gdk.Color negative_color;
 
         public CountdownTimer( int duration, uint last_minutes, time_t start_time = 0 ) {
             base(start_time);
             this.duration = duration;
             this.last_minutes = last_minutes;
 
-            Color.parse( "orange", out this.last_minutes_color );
-            Color.parse( "red", out this.negative_color );
+            Gdk.Color.parse( "orange", out this.last_minutes_color );
+            Gdk.Color.parse( "red", out this.negative_color );
         }
 
         /**
@@ -257,7 +254,7 @@ namespace pdfpc {
                 prefix = "-";
                 timeInSecs = -this.time;
                 this.modify_fg(
-                    StateType.NORMAL,
+                    Gtk.StateType.NORMAL,
                     this.pretalk_color
                 );
             } else {
@@ -266,13 +263,13 @@ namespace pdfpc {
                     // Still on presentation time
                     if ( timeInSecs < this.last_minutes * 60 ) {
                         this.modify_fg(
-                            StateType.NORMAL,
+                            Gtk.StateType.NORMAL,
                             this.last_minutes_color
                         );
                     }
                     else {
                         this.modify_fg(
-                            StateType.NORMAL,
+                            Gtk.StateType.NORMAL,
                             this.normal_color
                         );
                     }
@@ -281,7 +278,7 @@ namespace pdfpc {
                 else {
                     // Time is over!
                     this.modify_fg(
-                        StateType.NORMAL,
+                        Gtk.StateType.NORMAL,
                         this.negative_color
                     );
                     timeInSecs = this.time - duration;
@@ -355,13 +352,13 @@ namespace pdfpc {
                 prefix = "-";
                 timeInSecs = -this.time;
                 this.modify_fg(
-                               StateType.NORMAL,
+                               Gtk.StateType.NORMAL,
                                this.pretalk_color
                               );
             } else {
                 timeInSecs = this.time;
                 this.modify_fg(
-                               StateType.NORMAL,
+                               Gtk.StateType.NORMAL,
                                this.normal_color
                               );
             }

--- a/src/classes/view/base.vala
+++ b/src/classes/view/base.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
 namespace pdfpc {
     /**
      * Base class for every slide view

--- a/src/classes/view/behaviour/base.vala
+++ b/src/classes/view/behaviour/base.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
-using pdfpc;
-
 namespace pdfpc.View {
     /**
      * Abstract base every View Behaviour implementation has to extend.

--- a/src/classes/view/behaviour/pdf_link.vala
+++ b/src/classes/view/behaviour/pdf_link.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
-using pdfpc;
-
 namespace pdfpc.View.Behaviour {
     /**
      * Access provider to all signals related to PDF links.

--- a/src/classes/view/default.vala
+++ b/src/classes/view/default.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Cairo;
-using Gdk;
-
 namespace pdfpc {
     /**
      * Basic view class which is usable with any renderer.
@@ -230,7 +226,7 @@ namespace pdfpc {
          * the window surface.
          */
         public override bool expose_event ( Gdk.EventExpose event ) {
-            Context cr = Gdk.cairo_create( this.window );
+            Cairo.Context cr = Gdk.cairo_create( this.window );
             Gdk.cairo_set_source_pixmap(
                 cr,
                 this.current_slide,

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -20,9 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-using Gdk;
-
 namespace pdfpc {
     /**
      * View spezialized to work with Pdf renderers.
@@ -60,7 +57,7 @@ namespace pdfpc {
                                               Metadata.Area area,
                                               bool allow_black_on_end, bool clickable_links,
                                               PresentationController presentation_controller,
-                                              out Rectangle scale_rect = null ) {
+                                              out Gdk.Rectangle scale_rect = null ) {
             var scaler = new Scaler(
                 metadata.get_page_width(),
                 metadata.get_page_height()

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -20,9 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-using Gdk;
-
 namespace pdfpc.Window {
     /**
      * Window extension implementing all the needed functionality, to be
@@ -35,7 +32,7 @@ namespace pdfpc.Window {
         /**
          * The geometry data of the screen this window is on
          */
-        protected Rectangle screen_geometry;
+        protected Gdk.Rectangle screen_geometry;
 
         /**
          * Timer id which monitors mouse motion to hide the cursor after 5
@@ -58,7 +55,7 @@ namespace pdfpc.Window {
 
             if ( screen_num >= 0 ) {
                 // Start in the given monitor
-                screen = Screen.get_default();
+                screen = Gdk.Screen.get_default();
                 screen.get_monitor_geometry( screen_num, out this.screen_geometry );
             } else {
                 // Start in the monitor the cursor is in
@@ -95,7 +92,7 @@ namespace pdfpc.Window {
 
             }
 
-            this.add_events(EventMask.POINTER_MOTION_MASK);
+            this.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
             this.motion_notify_event.connect( this.on_mouse_move );
 
             // Start the 5 seconds timeout after which the mouse curosr is
@@ -117,7 +114,7 @@ namespace pdfpc.Window {
          * movement commands before the window has been displayed for the first
          * time.
          */
-        protected void on_size_allocate( Gtk.Widget source, Rectangle r ) {
+        protected void on_size_allocate( Gtk.Widget source, Gdk.Rectangle r ) {
             if ( this.is_mapped() ) {
                 // We are only interested to handle this event AFTER the window has
                 // been mapped.
@@ -153,7 +150,7 @@ namespace pdfpc.Window {
         /**
          * Called every time the mouse cursor is moved
          */
-        public bool on_mouse_move( Gtk.Widget source, EventMotion event ) {
+        public bool on_mouse_move( Gtk.Widget source, Gdk.EventMotion event ) {
             // Restore the mouse cursor to its default value
             this.window.set_cursor( null );
 

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -20,11 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-using Gdk;
-
-using pdfpc;
-
 namespace pdfpc.Window {
     /**
      * An overview of all the slides in the form of a table
@@ -34,11 +29,11 @@ namespace pdfpc.Window {
         /*
          * The store of all the slides.
          */
-        protected ListStore slides;
+        protected Gtk.ListStore slides;
         /*
          * The view of the above.
          */
-        protected IconView slides_view;
+        protected Gtk.IconView slides_view;
 
         /**
          * We will need the metadata mainly for converting from user slides to
@@ -102,7 +97,7 @@ namespace pdfpc.Window {
         private int _current_slide = 0;
         public int current_slide {
             get { return _current_slide; }
-            set { var path = new TreePath.from_indices(value);
+            set { var path = new Gtk.TreePath.from_indices(value);
                   this.slides_view.select_path(path);
                   // _current_slide set in on_selection_changed, below
                   this.slides_view.set_cursor(path, null, false);
@@ -131,9 +126,9 @@ namespace pdfpc.Window {
          * Constructor
          */
         public Overview( Metadata.Pdf metadata, PresentationController presentation_controller, Presenter presenter ) {
-            this.slides = new ListStore(1, typeof(Pixbuf));
-            this.slides_view = new IconView.with_model(this.slides);
-            this.slides_view.selection_mode = SelectionMode.SINGLE;
+            this.slides = new Gtk.ListStore(1, typeof(Gdk.Pixbuf));
+            this.slides_view = new Gtk.IconView.with_model(this.slides);
+            this.slides_view.selection_mode = Gtk.SelectionMode.SINGLE;
             var renderer = new CellRendererHighlight();
             this.slides_view.pack_start(renderer, true);
             this.slides_view.add_attribute(renderer, "pixbuf", 0);
@@ -141,15 +136,15 @@ namespace pdfpc.Window {
             this.add(this.slides_view);
             this.show_all();
 
-            Color black;
-            Color white;
-            Color.parse("black", out black);
-            Color.parse("white", out white);
-            this.slides_view.modify_base(StateType.NORMAL, black);
+            Gdk.Color black;
+            Gdk.Color white;
+            Gdk.Color.parse("black", out black);
+            Gdk.Color.parse("white", out white);
+            this.slides_view.modify_base(Gtk.StateType.NORMAL, black);
             Gtk.Scrollbar vscrollbar = (Gtk.Scrollbar) this.get_vscrollbar();
-            vscrollbar.modify_bg(StateType.NORMAL, white);
-            vscrollbar.modify_bg(StateType.ACTIVE, black);
-            vscrollbar.modify_bg(StateType.PRELIGHT, white);
+            vscrollbar.modify_bg(Gtk.StateType.NORMAL, white);
+            vscrollbar.modify_bg(Gtk.StateType.ACTIVE, black);
+            vscrollbar.modify_bg(Gtk.StateType.PRELIGHT, white);
 
             this.metadata = metadata;
             this.presentation_controller = presentation_controller;
@@ -178,7 +173,7 @@ namespace pdfpc.Window {
          * handler.  Note that if the Overview is reparented, it will still be
          * connected to signals from its old parent.  So don't do that.
          */
-        public void on_parent_set(Widget? old_parent) {
+        public void on_parent_set(Gtk.Widget? old_parent) {
             if (this.parent != null) {
                 this.parent.show.connect( this.on_show );
                 this.parent.hide.connect( this.on_hide );
@@ -252,7 +247,7 @@ namespace pdfpc.Window {
             } else {
                 this.slides_view.columns = tc;
             }
-            this.set_policy(PolicyType.NEVER, PolicyType.AUTOMATIC);
+            this.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC);
             this.target_height = (int)Math.round(this.target_width / this.aspect_ratio);
             rows = (int)Math.ceil((float)this.n_slides / this.slides_view.columns);
             int full_height = rows*(this.target_height + 2*padding + 2*row_spacing) + 2*margin;
@@ -263,9 +258,10 @@ namespace pdfpc.Window {
             this.last_structure_n_slides = this.n_slides;
 
             this.slides.clear();
-            var pixbuf = new Pixbuf(Colorspace.RGB, true, 8, this.target_width, this.target_height);
+            var pixbuf = new Gdk.Pixbuf(Gdk.Colorspace.RGB, true, 8, this.target_width,
+                this.target_height);
             pixbuf.fill(0x7f7f7fff);
-            var iter = TreeIter();
+            var iter = Gtk.TreeIter();
             for (int i=0; i<this.n_slides; i++) {
                 this.slides.append(out iter);
                 this.slides.set_value(iter, 0, pixbuf);
@@ -304,7 +300,7 @@ namespace pdfpc.Window {
             var pixbuf_scaled = pixbuf.scale_simple(this.target_width, this.target_height,
                                                     Gdk.InterpType.BILINEAR);
 
-            var iter = TreeIter();
+            var iter = Gtk.TreeIter();
             this.slides.get_iter_from_string(out iter, @"$(this.next_undone_preview)");
             this.slides.set_value(iter, 0, pixbuf_scaled);
 
@@ -342,7 +338,7 @@ namespace pdfpc.Window {
          */
         public void remove_current(int newn) {
             this.n_slides = newn;
-            var iter = TreeIter();
+            var iter = Gtk.TreeIter();
             this.slides.get_iter_from_string(out iter, @"$(this.current_slide)");
             this.slides.remove(iter);
             if (this.current_slide >= this.n_slides)
@@ -354,7 +350,7 @@ namespace pdfpc.Window {
          * the standard IconView controls, the rest are passed back to the
          * PresentationController.
          */
-        public bool on_key_press(Gtk.Widget source, EventKey key) {
+        public bool on_key_press(Gtk.Widget source, Gdk.EventKey key) {
             bool handled = false;
             switch ( key.keyval ) {
                 case 0xff51: /* Cursor left */
@@ -380,8 +376,8 @@ namespace pdfpc.Window {
         /*
          * Update the selection when the mouse moves over a new slides.
          */
-        public bool on_mouse_move(Gtk.Widget source, EventMotion event) {
-            TreePath path;
+        public bool on_mouse_move(Gtk.Widget source, Gdk.EventMotion event) {
+            Gtk.TreePath path;
             path = this.slides_view.get_path_at_pos((int)event.x, (int)event.y);
             if (path != null && path.get_indices()[0] != this.current_slide)
                 this.current_slide = path.get_indices()[0];
@@ -393,7 +389,7 @@ namespace pdfpc.Window {
          * click, the button_press event will have set the current slide.  On
          * a drag, the current slide will have been updated by the motion.
          */
-        public bool on_mouse_release(EventButton event) {
+        public bool on_mouse_release(Gdk.EventButton event) {
             if (event.button == 1)
                 this.presentation_controller.goto_user_page(this.current_slide + 1);
             return false;
@@ -403,13 +399,13 @@ namespace pdfpc.Window {
     /*
      * Render a pixbuf that is slightly shaded, unless it is the selected one.
      */
-    public class CellRendererHighlight: CellRendererPixbuf {
+    public class CellRendererHighlight: Gtk.CellRendererPixbuf {
 
-        public override void render(Gdk.Window window, Widget widget,
-                                    Rectangle background_area, Rectangle cell_area,
-                                    Rectangle expose_area, CellRendererState flags) {
+        public override void render(Gdk.Window window, Gtk.Widget widget,
+                                    Gdk.Rectangle background_area, Gdk.Rectangle cell_area,
+                                    Gdk.Rectangle expose_area, Gtk.CellRendererState flags) {
             base.render(window, widget, background_area, cell_area, expose_area, flags);
-            if (flags != CellRendererState.SELECTED) {
+            if (flags != Gtk.CellRendererState.SELECTED) {
                 var cr = Gdk.cairo_create(window);
                 Gdk.cairo_rectangle(cr, expose_area);
                 cr.clip();

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -20,11 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-using Gdk;
-
-using pdfpc;
-
 namespace pdfpc.Window {
     /**
      * Window showing the currently active slide to be presented on a beamer
@@ -54,15 +49,15 @@ namespace pdfpc.Window {
 
             this.presentation_controller = presentation_controller;
 
-            Color black;
-            Color.parse( "black", out black );
-            this.modify_bg( StateType.NORMAL, black );
+            Gdk.Color black;
+            Gdk.Color.parse( "black", out black );
+            this.modify_bg( Gtk.StateType.NORMAL, black );
 
-            var fixedLayout = new Fixed();
+            var fixedLayout = new Gtk.Fixed();
             fixedLayout.set_size_request(this.screen_geometry.width, this.screen_geometry.height);
             this.add( fixedLayout );
 
-            Rectangle scale_rect;
+            Gdk.Rectangle scale_rect;
 
             if (width < 0) {
                 width = this.screen_geometry.width;
@@ -99,9 +94,9 @@ namespace pdfpc.Window {
                 scale_rect.y
             );
 
-            this.add_events(EventMask.KEY_PRESS_MASK);
-            this.add_events(EventMask.BUTTON_PRESS_MASK);
-            this.add_events(EventMask.SCROLL_MASK);
+            this.add_events(Gdk.EventMask.KEY_PRESS_MASK);
+            this.add_events(Gdk.EventMask.BUTTON_PRESS_MASK);
+            this.add_events(Gdk.EventMask.SCROLL_MASK);
 
             this.key_press_event.connect( this.on_key_pressed );
             this.button_press_event.connect( this.on_button_press );
@@ -114,7 +109,7 @@ namespace pdfpc.Window {
          * Handle keypress vents on the window and, if neccessary send them to the
          * presentation controller
          */
-        protected bool on_key_pressed( EventKey key ) {
+        protected bool on_key_pressed( Gdk.EventKey key ) {
             if ( this.presentation_controller != null ) {
                 this.presentation_controller.key_press( key );
             }
@@ -125,7 +120,7 @@ namespace pdfpc.Window {
          * Handle mouse button events on the window and, if neccessary send
          * them to the presentation controller
          */
-        protected bool on_button_press( EventButton button ) {
+        protected bool on_button_press( Gdk.EventButton button ) {
             if ( this.presentation_controller != null ) {
                 this.presentation_controller.button_press( button );
             }
@@ -136,7 +131,7 @@ namespace pdfpc.Window {
          * Handle mouse scrolling events on the window and, if neccessary send
          * them to the presentation controller
          */
-        protected bool on_scroll( Gtk.Widget source, EventScroll scroll ) {
+        protected bool on_scroll( Gtk.Widget source, Gdk.EventScroll scroll ) {
             if ( this.presentation_controller != null ) {
                 this.presentation_controller.scroll( scroll );
             }

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -20,11 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-using Gdk;
-
-using pdfpc;
-
 namespace pdfpc.Window {
     /**
      * Window showing the currently active and next slide.
@@ -63,9 +58,9 @@ namespace pdfpc.Window {
         /**
          * Slide progress label ( eg. "23/42" )
          */
-        protected Entry slide_progress;
+        protected Gtk.Entry slide_progress;
 
-        protected ProgressBar prerender_progress;
+        protected Gtk.ProgressBar prerender_progress;
 
         /**
          * Indication that the slide is blanked (faded to black)
@@ -85,12 +80,12 @@ namespace pdfpc.Window {
         /**
          * Text box for displaying notes for the slides
          */
-        protected TextView notes_view;
+        protected Gtk.TextView notes_view;
 
         /**
          * The views of the slides + notes
          */
-        protected HBox slideViews = null;
+        protected Gtk.HBox slideViews = null;
 
         /**
          * The overview of slides
@@ -101,7 +96,7 @@ namespace pdfpc.Window {
          * The container that shows the overview. This is the one that has to
          * be shown or hidden
          */
-        protected Alignment centered_overview = null;
+        protected Gtk.Alignment centered_overview = null;
 
         /**
          * There may be problems in some configurations if adding the overview
@@ -113,7 +108,7 @@ namespace pdfpc.Window {
          * We will also need to store the layout where we have to add the
          * overview (see the comment above)
          */
-        protected VBox fullLayout = null;
+        protected Gtk.VBox fullLayout = null;
 
         /**
          * Number of slides inside the presentation
@@ -131,8 +126,8 @@ namespace pdfpc.Window {
         /**
          * Useful colors
          */
-        protected Color black;
-        protected Color white;
+        protected Gdk.Color black;
+        protected Gdk.Color white;
 
         /**
          * Base constructor instantiating a new presenter window
@@ -149,10 +144,10 @@ namespace pdfpc.Window {
 
             this.metadata = metadata;
 
-            Color.parse( "black", out this.black );
-            Color.parse( "white", out this.white );
+            Gdk.Color.parse( "black", out this.black );
+            Gdk.Color.parse( "white", out this.white );
 
-            this.modify_bg( StateType.NORMAL, this.black );
+            this.modify_bg( Gtk.StateType.NORMAL, this.black );
 
             // We need the value of 90% height a lot of times. Therefore store it
             // in advance
@@ -164,7 +159,7 @@ namespace pdfpc.Window {
             // should use as a percentage value. The maximal height is 90% of
             // the screen, as we need a place to display the timer and slide
             // count.
-            Rectangle current_scale_rect;
+            Gdk.Rectangle current_scale_rect;
             int current_allocated_width = (int)Math.floor(
                 this.screen_geometry.width * Options.current_size / (double)100
             );
@@ -184,7 +179,7 @@ namespace pdfpc.Window {
             //Requisition cv_requisition;
             //this.current_view.size_request(out cv_requisition);
             //current_allocated_width = cv_requisition.width;
-            Rectangle next_scale_rect;
+            Gdk.Rectangle next_scale_rect;
             var next_allocated_width = this.screen_geometry.width - current_allocated_width-4; // We leave a bit of margin between the two views
             this.next_view = View.Pdf.from_metadata(
                 metadata,
@@ -223,13 +218,13 @@ namespace pdfpc.Window {
             notes_font.set_size(
                 (int)Math.floor( 20 * 0.75 ) * Pango.SCALE
             );
-            this.notes_view = new TextView();
+            this.notes_view = new Gtk.TextView();
             this.notes_view.editable = false;
             this.notes_view.cursor_visible = false;
-            this.notes_view.wrap_mode = WrapMode.WORD;
+            this.notes_view.wrap_mode = Gtk.WrapMode.WORD;
             this.notes_view.modify_font(notes_font);
-            this.notes_view.modify_base(StateType.NORMAL, black);
-            this.notes_view.modify_text(StateType.NORMAL, white);
+            this.notes_view.modify_base(Gtk.StateType.NORMAL, black);
+            this.notes_view.modify_text(Gtk.StateType.NORMAL, white);
             this.notes_view.buffer.text = "";
             this.notes_view.key_press_event.connect( this.on_key_press_notes_view );
 
@@ -243,29 +238,29 @@ namespace pdfpc.Window {
             // The countdown timer is centered in the 90% bottom part of the screen
             // It takes 3/4 of the available width
             this.timer = this.presentation_controller.getTimer();
-            this.timer.set_justify( Justification.CENTER );
+            this.timer.set_justify( Gtk.Justification.CENTER );
             this.timer.modify_font( font );
 
 
             // The slide counter is centered in the 90% bottom part of the screen
             // It takes 1/4 of the available width on the right
-            this.slide_progress = new Entry();
+            this.slide_progress = new Gtk.Entry();
             this.slide_progress.set_alignment(1f);
-            this.slide_progress.modify_base(StateType.NORMAL, this.black);
-            this.slide_progress.modify_text(StateType.NORMAL, this.white);
+            this.slide_progress.modify_base(Gtk.StateType.NORMAL, this.black);
+            this.slide_progress.modify_text(Gtk.StateType.NORMAL, this.white);
             this.slide_progress.modify_font( font );
             this.slide_progress.editable = false;
             this.slide_progress.has_frame = false;
             this.slide_progress.key_press_event.connect( this.on_key_press_slide_progress );
-            this.slide_progress.inner_border = new Border();
+            this.slide_progress.inner_border = new Gtk.Border();
 
-            this.prerender_progress = new ProgressBar();
+            this.prerender_progress = new Gtk.ProgressBar();
             this.prerender_progress.text = "Prerendering...";
             this.prerender_progress.modify_font( notes_font );
-            this.prerender_progress.modify_bg( StateType.NORMAL, this.black );
-            this.prerender_progress.modify_bg( StateType.PRELIGHT, this.white );
-            this.prerender_progress.modify_fg( StateType.NORMAL, this.white );
-            this.prerender_progress.modify_fg( StateType.PRELIGHT, this.black );
+            this.prerender_progress.modify_bg( Gtk.StateType.NORMAL, this.black );
+            this.prerender_progress.modify_bg( Gtk.StateType.PRELIGHT, this.white );
+            this.prerender_progress.modify_fg( Gtk.StateType.NORMAL, this.white );
+            this.prerender_progress.modify_fg( Gtk.StateType.PRELIGHT, this.black );
             this.prerender_progress.no_show_all = true;
 
             int icon_height = bottom_height - 10;
@@ -298,9 +293,9 @@ namespace pdfpc.Window {
                 this.pause_icon = new Gtk.Image.from_icon_name("image-missing", Gtk.IconSize.LARGE_TOOLBAR);
             }
 
-            this.add_events(EventMask.KEY_PRESS_MASK);
-            this.add_events(EventMask.BUTTON_PRESS_MASK);
-            this.add_events(EventMask.SCROLL_MASK);
+            this.add_events(Gdk.EventMask.KEY_PRESS_MASK);
+            this.add_events(Gdk.EventMask.BUTTON_PRESS_MASK);
+            this.add_events(Gdk.EventMask.SCROLL_MASK);
 
             this.key_press_event.connect( this.on_key_pressed );
             this.button_press_event.connect( this.on_button_press );
@@ -348,50 +343,50 @@ namespace pdfpc.Window {
         }
 
         protected void build_layout() {
-            this.slideViews = new HBox(false, 4);
+            this.slideViews = new Gtk.HBox(false, 4);
 
-            var strict_views = new HBox(false, 0);
+            var strict_views = new Gtk.HBox(false, 0);
             strict_views.pack_start(this.strict_prev_view, false, false, 0);
             strict_views.pack_end(this.strict_next_view, false, false, 0);
 
-            var center_current_view = new Alignment(0.5f, 0.5f, 0, 0);
+            var center_current_view = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
             center_current_view.add(this.current_view);
 
-            var current_view_and_stricts = new VBox(false, 2);
+            var current_view_and_stricts = new Gtk.VBox(false, 2);
             current_view_and_stricts.pack_start(center_current_view, false, false, 2);
             current_view_and_stricts.pack_start(strict_views, false, false, 2);
 
 
             this.slideViews.add( current_view_and_stricts );
 
-            var nextViewWithNotes = new VBox(false, 0);
-            var center_next_view = new Alignment(0.5f, 0.5f, 0, 0);
+            var nextViewWithNotes = new Gtk.VBox(false, 0);
+            var center_next_view = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
             center_next_view.add(this.next_view);
             nextViewWithNotes.pack_start( center_next_view, false, false, 0 );
-            var notes_sw = new ScrolledWindow(null, null);
-            Scrollbar notes_scrollbar = (Gtk.Scrollbar) notes_sw.get_vscrollbar();
-            notes_scrollbar.modify_bg(StateType.NORMAL, white);
-            notes_scrollbar.modify_bg(StateType.ACTIVE, black);
-            notes_scrollbar.modify_bg(StateType.PRELIGHT, white);
+            var notes_sw = new Gtk.ScrolledWindow(null, null);
+            Gtk.Scrollbar notes_scrollbar = (Gtk.Scrollbar) notes_sw.get_vscrollbar();
+            notes_scrollbar.modify_bg(Gtk.StateType.NORMAL, white);
+            notes_scrollbar.modify_bg(Gtk.StateType.ACTIVE, black);
+            notes_scrollbar.modify_bg(Gtk.StateType.PRELIGHT, white);
             notes_sw.add( this.notes_view );
-            notes_sw.set_policy( PolicyType.AUTOMATIC, PolicyType.AUTOMATIC );
+            notes_sw.set_policy( Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC );
             nextViewWithNotes.pack_start( notes_sw, true, true, 5 );
             this.slideViews.add(nextViewWithNotes);
 
-            var bottomRow = new HBox(true, 0);
+            var bottomRow = new Gtk.HBox(true, 0);
 
-            var status = new HBox(false, 2);
+            var status = new Gtk.HBox(false, 2);
             //blank_label_alignment.add( this.blank_label );
             status.pack_start( this.blank_icon, false, false, 0 );
             status.pack_start( this.frozen_icon, false, false, 0 );
             status.pack_start( this.pause_icon, false, false, 0 );
 
-            var timer_alignment = new Alignment(0.5f, 0.5f, 0, 0);
+            var timer_alignment = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
             timer_alignment.add( this.timer );
 
-            var progress_alignment = new HBox(false, 0);
+            var progress_alignment = new Gtk.HBox(false, 0);
             progress_alignment.pack_end(this.slide_progress);
-            var prerender_alignment = new Alignment(0, 0.5f, 1, 0);
+            var prerender_alignment = new Gtk.Alignment(0, 0.5f, 1, 0);
             prerender_alignment.add(this.prerender_progress);
             progress_alignment.pack_start(prerender_alignment);
 
@@ -400,14 +395,14 @@ namespace pdfpc.Window {
             bottomRow.pack_end( progress_alignment, true, true, 0);
 
             //var fullLayout = new VBox(false, 0);
-            this.fullLayout = new VBox(false, 0);
+            this.fullLayout = new Gtk.VBox(false, 0);
             this.fullLayout.set_size_request(this.screen_geometry.width, this.screen_geometry.height);
             this.fullLayout.pack_start( this.slideViews, true, true, 0 );
             this.fullLayout.pack_end( bottomRow, false, false, 0 );
 
             this.add( fullLayout );
 
-            this.centered_overview = new Alignment(0.5f, 0.5f, 0, 0);
+            this.centered_overview = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
             this.centered_overview.add(this.overview);
         }
 
@@ -415,7 +410,7 @@ namespace pdfpc.Window {
          * Handle keypress events on the window and, if neccessary send them to the
          * presentation controller
          */
-        protected bool on_key_pressed( Gtk.Widget source, EventKey key ) {
+        protected bool on_key_pressed( Gtk.Widget source, Gdk.EventKey key ) {
             if ( this.presentation_controller != null ) {
                 return this.presentation_controller.key_press( key );
             } else {
@@ -428,7 +423,7 @@ namespace pdfpc.Window {
          * Handle mouse button events on the window and, if neccessary send
          * them to the presentation controller
          */
-        protected bool on_button_press( Gtk.Widget source, EventButton button ) {
+        protected bool on_button_press( Gtk.Widget source, Gdk.EventButton button ) {
             if ( this.presentation_controller != null ) {
                 this.presentation_controller.button_press( button );
             }
@@ -439,7 +434,7 @@ namespace pdfpc.Window {
          * Handle mouse scrolling events on the window and, if neccessary send
          * them to the presentation controller
          */
-        protected bool on_scroll( Gtk.Widget source, EventScroll scroll ) {
+        protected bool on_scroll( Gtk.Widget source, Gdk.EventScroll scroll ) {
             if ( this.presentation_controller != null ) {
                 this.presentation_controller.scroll( scroll );
             }
@@ -542,7 +537,7 @@ namespace pdfpc.Window {
         /**
          * Handle key events for the slide_progress entry field
          */
-        protected bool on_key_press_slide_progress( Gtk.Widget source, EventKey key ) {
+        protected bool on_key_press_slide_progress( Gtk.Widget source, Gdk.EventKey key ) {
             if ( key.keyval == 0xff0d ) {
                 // Try to parse the input
                string input_text = this.slide_progress.text;
@@ -573,7 +568,7 @@ namespace pdfpc.Window {
         /**
          * Handle key presses when editing a note
          */
-        protected bool on_key_press_notes_view( Gtk.Widget source, EventKey key ) {
+        protected bool on_key_press_notes_view( Gtk.Widget source, Gdk.EventKey key ) {
             if ( key.keyval == 0xff1b) { /* Escape */
                 this.notes_view.editable = false;
                 this.notes_view.cursor_visible = false;

--- a/src/interfaces/view/behaviour/decoratable.vala
+++ b/src/interfaces/view/behaviour/decoratable.vala
@@ -20,10 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using GLib;
-
-using pdfpc;
-
 namespace pdfpc.View {
     /**
      * Every View which supports Behaviours needs to implement this interface.

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -20,8 +20,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-using Gtk;
-
 namespace pdfpc {
     /**
      * Pdf Presenter Console main application class


### PR DESCRIPTION
One of the Yorba style rules that I wholeheartedly agree with is to not use the "using" statement.  This makes it more obvious where each thing comes from, and it helps avoid confusion between Gdk.Rectangle and Cairo.Rectangle, for example.

Many of the using statements were completely useless.  "using GLib" is implied automatically, and "using pdfpc" is unnecessary when every file is wrapped in "namespace pdfpc".  Other files had using statements for some module, but used the prefix anyway.  There were really only about three files that actually made significant use of this, but I think the explicitness more than makes up for the extra keystrokes.

There's a small commit to remove some previously-existing warnings, so I could be sure I didn't introduce any new ones with the main commit.