### PR TITLE
Namespace constant paths

### DIFF
--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -290,21 +290,20 @@ namespace pdfpc.Window {
 
             // attempt to load from a local path (if the user hasn't installed)
             // if that fails, attempt to load from the global path
-            string load_icon_path = source_path + "/icons/" + filename;
+            string load_icon_path = Path.build_filename(Paths.SOURCE_PATH, "icons", filename);
             File icon_file = File.new_for_path(load_icon_path);
             if (!icon_file.query_exists()) {
-                load_icon_path = icon_path + filename;
+                load_icon_path = Path.build_filename(Paths.ICON_PATH, filename);
             }
 
             Gtk.Image icon;
             try {
-                Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file_at_size(icon_path + filename,
+                Gdk.Pixbuf pixbuf = new Gdk.Pixbuf.from_file_at_size(load_icon_path,
                     (int) Math.floor(1.06 * icon_height), icon_height);
                 icon = new Gtk.Image.from_pixbuf(pixbuf);
                 icon.no_show_all = true;
             } catch (Error e) {
-                stderr.printf("Warning: Could not load icon %s (%s)\n",
-                    icon_path + "blank.svg", e.message);
+                stderr.printf("Warning: Could not load icon %s (%s)\n", load_icon_path, e.message);
                 icon = new Gtk.Image.from_icon_name("image-missing", Gtk.IconSize.LARGE_TOOLBAR);
             }
             return icon;

--- a/src/paths.in
+++ b/src/paths.in
@@ -1,3 +1,6 @@
-const string icon_path = "@CMAKE_INSTALL_PREFIX@/share/pixmaps/pdfpc/";
-const string source_path = "@CMAKE_SOURCE_DIR@";
-const string etc_path = "@SYSCONFDIR@";
+namespace pdfpc.Paths {
+    public const string ICON_PATH = "@CMAKE_INSTALL_PREFIX@/share/pixmaps/pdfpc/";
+    public const string SOURCE_PATH = "@CMAKE_SOURCE_DIR@";
+    public const string CONF_PATH = "@SYSCONFDIR@";
+}
+

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -234,9 +234,10 @@ namespace pdfpc {
 
             ConfigFileReader configFileReader = new ConfigFileReader(this.controller);
 
-            configFileReader.readConfig(source_path + "/rc/pdfpcrc");
-            configFileReader.readConfig(etc_path + "/pdfpcrc");
-            configFileReader.readConfig(Environment.get_home_dir() + "/.pdfpcrc");
+            configFileReader.readConfig(Path.build_filename(Paths.SOURCE_PATH, "rc/pdfpcrc"));
+            configFileReader.readConfig(Path.build_filename(Paths.CONF_PATH, "pdfpcrc"));
+            configFileReader.readConfig(Path.build_filename(Environment.get_home_dir(),
+                ".pdfpcrc"));
 
             set_styling();
 


### PR DESCRIPTION
I was surprised when refactoring some other code to discover that icon_path was in fact a global variable.  We should namespace it and make it upper case to make this obvious.

Also, if we use Path.build_filename(), we don't have to worry about making sure we have separators between path elements.