### PR TITLE
Use icon view key bindings in overview

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -324,6 +324,9 @@ namespace pdfpc {
         public bool key_press( Gdk.EventKey key ) {
             if (key.time != last_key_event && !ignore_keyboard_events ) {
                 last_key_event = key.time;
+                if (this.overview_shown && this.overview.key_press_event(key))
+                    return true;
+
                 var action = this.keyBindings.get(new KeyDef(key.keyval,key.state & this.accepted_key_mods));
                 if (action != null)
                     action.d();

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -133,8 +133,8 @@ namespace pdfpc.Window {
             this.slides_view.pack_start(renderer, true);
             this.slides_view.add_attribute(renderer, "pixbuf", 0);
             this.slides_view.set_item_padding(0);
+            this.slides_view.show();
             this.add(this.slides_view);
-            this.show_all();
 
             this.metadata = metadata;
             this.presentation_controller = presentation_controller;
@@ -145,7 +145,9 @@ namespace pdfpc.Window {
             this.slides_view.button_release_event.connect( this.on_mouse_release );
             this.slides_view.key_press_event.connect( this.on_key_press );
             this.slides_view.selection_changed.connect( this.on_selection_changed );
-            this.parent_set.connect( this.on_parent_set );
+            this.key_press_event.connect((event) => this.slides_view.key_press_event(event));
+            this.show.connect(this.on_show);
+            this.hide.connect(this.on_hide);
 
             this.aspect_ratio = this.metadata.get_page_width() / this.metadata.get_page_height();
         }
@@ -156,24 +158,13 @@ namespace pdfpc.Window {
             this.fill_structure();
         }
 
-        /*
-         * Due to a change, the Overview is no longer shown or hidden; instead, its
-         * parent is.  So we need to connect to its parent's show and hide signals.
-         * But we can't do that until the parent has been set.  Thus this signal
-         * handler.  Note that if the Overview is reparented, it will still be
-         * connected to signals from its old parent.  So don't do that.
-         */
-        public void on_parent_set(Gtk.Widget? old_parent) {
-            if (this.parent != null) {
-                this.parent.show.connect( this.on_show );
-                this.parent.hide.connect( this.on_hide );
-            }
-        }
-
         /**
-         * Get keyboard focus.
+         * Get keyboard focus.  This requires that the window has focus.
          */
         public void on_show() {
+            Gtk.Window top = this.get_toplevel() as Gtk.Window;
+            if (top != null)
+                top.present();
             this.slides_view.grab_focus();
         }
 


### PR DESCRIPTION
Key handling in the overview has been pretty broken.  The overview has some explicit key handling, but it also relies on built-in features for handling navigation keys.  However, it never gets keyboard events, since they're all captured at the window level.

This patch feeds keyboard events to the overview when it's shown.  In order for the overview to handle the built-in bindings, the iconview must have focus (as must its window), so we ensure that's the case when switching to overview.  The user could mess this up my changing the focus once in the overview mode, but that shouldn't happen by accident.