### PR TITLE
Updated cmake vala submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,9 @@ project("pdfpc" C)
 cmake_minimum_required(VERSION 2.6)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Vala_CMake/vala)
-include(ValaPrecompile)
-include(ValaVersion)
 
-find_package(Vala)
-
-ensure_vala_version("0.16.0" MINIMUM)
+find_package(Vala "0.16" REQUIRED)
+include(${VALA_USE_FILE})
 
 set(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/etc" CACHE FILEPATH "sysconfdir")
 


### PR DESCRIPTION
We used a commit from 2010 for the submodule.
Bumped to the latest commit and changed our
CMakeLists files to match the changes.