### PR TITLE
Graceful shutdown if pdf file does not exist

### DIFF
--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -198,6 +198,9 @@ namespace pdfpc {
             if (pdfFilename == null) {
                 warning("Error: No pdf file given\n");
                 Posix.exit(1);
+            } else if (!GLib.FileUtils.test(pdfFilename, (GLib.FileTest.IS_REGULAR))) {
+                warning("Error: pdf file not found\n");
+                Posix.exit(1);
             }
 
             // parse size option


### PR DESCRIPTION
In case of a non existent pdf file passed by command line arguments, shutdown program with a useful error message.