### PR TITLE
Use stack to switch between slide view and overview

### DIFF
--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -146,8 +146,6 @@ namespace pdfpc.Window {
             this.slides_view.key_press_event.connect( this.on_key_press );
             this.slides_view.selection_changed.connect( this.on_selection_changed );
             this.key_press_event.connect((event) => this.slides_view.key_press_event(event));
-            this.show.connect(this.on_show);
-            this.hide.connect(this.on_hide);
 
             this.aspect_ratio = this.metadata.get_page_width() / this.metadata.get_page_height();
         }
@@ -161,7 +159,7 @@ namespace pdfpc.Window {
         /**
          * Get keyboard focus.  This requires that the window has focus.
          */
-        public void on_show() {
+        public void ensure_focus() {
             Gtk.Window top = this.get_toplevel() as Gtk.Window;
             if (top != null)
                 top.present();
@@ -171,7 +169,7 @@ namespace pdfpc.Window {
         /*
          * Recalculate the structure, if needed.
          */
-        public void on_hide() {
+        public void ensure_structure() {
             if (this.n_slides != this.last_structure_n_slides)
                 this.fill_structure();
         }


### PR DESCRIPTION
When you switch between the slide view and overview, there can be a slight jump.  This is because we're showing and hiding widgets that aren't necessarily exactly the same size.  The modern way to do this is to use a Gtk.Stack, which takes multiple children but shows only one at a time.

There are two potential problems with this.  First, it requires Gtk 3.10 or greater.  I don't think that should be a problem for most people, but maybe it will cause problems for some.  Second, it requires the Overview to be added to the structure right away.  This wasn't done, as a fix for some unspecified bug.  I don't see any problem with doing this, but perhaps someone else will discover the original bug.

This commit is also part of #22.  I had forgotten it when I pushed everything, but it's really unrelated to the rest of the work there.  We might as well get in in separately to reduce the amount of stuff that needs review over there.