### PR TITLE
Inhibit screensaver while presentation is being displayed

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -20,6 +20,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+[DBus (name = "org.freedesktop.ScreenSaver")]
+public interface ScreenSaver : Object {
+    public abstract uint32 inhibit(string application_name, string reason) throws IOError;
+    public abstract void un_inhibit(uint32 cookie) throws IOError;
+}
+
 namespace pdfpc {
     /**
      * Controller handling all the triggered events/signals
@@ -167,6 +173,12 @@ namespace pdfpc {
         public View.Pdf main_view = null;
 
         /**
+         * DBus interface to screensaver
+         */
+        protected ScreenSaver? screensaver = null;
+        protected uint32 screensaver_cookie = 0;
+
+        /**
          * Instantiate a new controller
          */
         public PresentationController(Metadata.Pdf metadata, bool allow_black_on_end) {
@@ -199,6 +211,16 @@ namespace pdfpc {
             this.current_user_slide_number = 0;
 
             this.add_actions();
+            
+            this.screensaver = Bus.get_proxy_sync(BusType.SESSION, "org.freedesktop.ScreenSaver",
+                "/org/freedesktop/ScreenSaver");
+            try {
+                this.screensaver_cookie = this.screensaver.inhibit("pdfpc",
+                    "Showing a presentation");
+                stdout.printf("Screensaver inhibited\n");
+            } catch (Error error) {
+                // pass
+            }
         }
 
         /*
@@ -206,6 +228,14 @@ namespace pdfpc {
          */
         public void quit() {
             this.metadata.quit();
+            if (this.screensaver != null && this.screensaver_cookie != 0) {
+                try {
+                    this.screensaver.un_inhibit(this.screensaver_cookie);
+                    stdout.printf("Screensaver reactivated\n");
+                } catch (Error error) {
+                    // pass
+                }
+            }
             Gtk.main_quit();
         }
 


### PR DESCRIPTION
This inhibits the screensaver through the org.freedesktop.ScreenSaver DBus target.  Right now, it always does so.  Should this be something that can be turned off?