### PR TITLE
Revert "Use new instead of override keyword"

### DIFF
--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -387,7 +387,7 @@ namespace pdfpc.Window {
      */
     public class CellRendererHighlight: Gtk.CellRendererPixbuf {
 
-        public new void render(Cairo.Context cr, Gtk.Widget widget,
+        public override void render(Cairo.Context cr, Gtk.Widget widget,
                                     Gdk.Rectangle background_area, Gdk.Rectangle cell_area,
                                     Gtk.CellRendererState flags) {
             base.render(cr, widget, background_area, cell_area, flags);


### PR DESCRIPTION
That commit breaks the shading of the overview slides (at least for vala 0.26, GTK 3.10).

I believe override is correct here, since without it, the Gtk.CellRendererPixbuf.render() method is called by GTK, which is not what we want.  Note that abstract methods are ipso facto virtual.  If an abstract method is implemented as an override method, that virtualness is passed on, allowing subclasses to override the implementation.  I assume that this is what's going on with Gtk.CellRendererPixbuf.

Note that the error you were seeing is coming from the C-compilation phase, not the Vala compilation phase.  I generally ignore them, since they're the result of Vala-generated code and may represent a bug in valac itself.