### PR TITLE
Distort movies to fill available rectangle

### DIFF
--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -246,6 +246,7 @@ namespace pdfpc {
                 tee.link(queue);
                 Gst.Element ad_element = this.link_additional(n, queue, bin, rect);
                 ad_element.link(sink);
+                sink.set("force_aspect_ratio", false);
 
                 Gst.Video.Overlay xoverlay = (Gst.Video.Overlay) sink;
                 xoverlay.set_window_handle(xid);
@@ -256,7 +257,7 @@ namespace pdfpc {
 
             this.pipeline = Gst.ElementFactory.make("playbin", "playbin");
             this.pipeline.set("uri", uri);
-            this.pipeline.set("force_aspect_ratio", false);
+            this.pipeline.set("force_aspect_ratio", false);  // Else overrides last overlay
             this.pipeline.set("video_sink", bin);
             Gst.Bus bus = this.pipeline.get_bus();
             bus.add_signal_watch();

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -47,7 +47,7 @@ namespace pdfpc {
         /**
          * The gstreamer pipeline for playback.
          */
-        public dynamic Gst.Element pipeline;
+        public Gst.Element pipeline;
 
         /**
          * A flag to indicate when we've reached the End Of Stream, so we
@@ -255,9 +255,9 @@ namespace pdfpc {
             }
 
             this.pipeline = Gst.ElementFactory.make("playbin", "playbin");
-            this.pipeline.uri = uri;
-            this.pipeline.force_aspect_ratio = false;
-            this.pipeline.video_sink = bin;
+            this.pipeline.set("uri", uri);
+            this.pipeline.set("force_aspect_ratio", false);
+            this.pipeline.set("video_sink", bin);
             Gst.Bus bus = this.pipeline.get_bus();
             bus.add_signal_watch();
             bus.message["error"] += this.on_message;
@@ -461,8 +461,8 @@ namespace pdfpc {
                     "framerate=[25/1,2147483647/1]," + // At least 25 fps
                     @"width=$(rect.width),height=$(rect.height)"
                 );
-                dynamic Gst.Element filter = gst_element_make("capsfilter", "filter");
-                filter.caps = caps;
+                Gst.Element filter = gst_element_make("capsfilter", "filter");
+                filter.set("caps", caps);
                 bin.add_many(adaptor1, adaptor2, overlay, scale, rate, filter);
                 if (!source.link_many(rate, scale, adaptor1, filter, overlay, adaptor2))
                     throw new PipelineError.Linking("Could not link pipeline.");


### PR DESCRIPTION
This was the way it used to work in GStreamer 0.10.  This is one way to fix #44.  There was also a discussion about getting letterboxing working with the controls.  If this is desired, let's do that in another bug.

The third commit is the functional one.  The first two just do some code style cleanup.