### PR TITLE
Added fontscale feature

### DIFF
--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -118,5 +118,10 @@ namespace pdfpc {
          * Flag if the version string should be printed on startup
          */
         public static bool version = false;
+
+        /**
+         * Scale factor for timer-fonts in presenter window
+         */
+        public static double fontscale = 1.0;
     }
 }

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -121,7 +121,7 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presenter window
          */
-        public Presenter(Metadata.Pdf metadata, int screen_num, double fontscale,
+        public Presenter(Metadata.Pdf metadata, int screen_num,
             PresentationController presentation_controller) {
             base(screen_num);
             this.role = "presenter";
@@ -215,7 +215,7 @@ namespace pdfpc.Window {
             // Initial font needed for the labels
             // We approximate the point size using pt = px * .75
             var font = Pango.FontDescription.from_string("Verdana");
-            font.set_size((int) Math.floor(bottom_height * fontscale * 0.8 * 0.75) * Pango.SCALE);
+            font.set_size((int) Math.floor(bottom_height * Options.fontscale * 0.8 * 0.75) * Pango.SCALE);
 
             // The countdown timer is centered in the 90% bottom part of the screen
             // It takes 3/4 of the available width

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -121,12 +121,11 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presenter window
          */
-        public Presenter(Metadata.Pdf metadata, int screen_num,
+        public Presenter(Metadata.Pdf metadata, int screen_num, double fontscale,
             PresentationController presentation_controller) {
             base(screen_num);
             this.role = "presenter";
             this.title = "pdfpc - presenter (%s)".printf(metadata.get_document().get_title());
-
             this.destroy.connect((source) => presentation_controller.quit());
 
             this.presentation_controller = presentation_controller;
@@ -216,7 +215,7 @@ namespace pdfpc.Window {
             // Initial font needed for the labels
             // We approximate the point size using pt = px * .75
             var font = Pango.FontDescription.from_string("Verdana");
-            font.set_size((int) Math.floor(bottom_height * 0.8 * 0.75) * Pango.SCALE);
+            font.set_size((int) Math.floor(bottom_height * fontscale * 0.8 * 0.75) * Pango.SCALE);
 
             // The countdown timer is centered in the 90% bottom part of the screen
             // It takes 3/4 of the available width

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -160,8 +160,8 @@ namespace pdfpc {
          * Create and return a PresenterWindow using the specified monitor
          * while displaying the given file
          */
-        private Window.Presenter create_presenter_window( Metadata.Pdf metadata, int monitor, double fontscale ) {
-            var presenter_window = new Window.Presenter( metadata, monitor, fontscale, this.controller );
+        private Window.Presenter create_presenter_window( Metadata.Pdf metadata, int monitor ) {
+            var presenter_window = new Window.Presenter( metadata, monitor, this.controller );
             //controller.register_controllable( presenter_window );
             presenter_window.set_cache_observer( this.cache_status );
 
@@ -263,18 +263,18 @@ namespace pdfpc {
                     presenter_monitor    = (screen.get_primary_monitor() + 1) % 2;
                 presentation_monitor = (presenter_monitor + 1) % 2;
                 this.presenter_window =
-				this.create_presenter_window( metadata, presenter_monitor, Options.fontscale );
+                    this.create_presenter_window( metadata, presenter_monitor );
                 this.presentation_window =
                     this.create_presentation_window( metadata, presentation_monitor, width, height );
             } else if (Options.windowed && !Options.single_screen) {
                 this.presenter_window =
-				this.create_presenter_window( metadata, -1, Options.fontscale );
+                    this.create_presenter_window( metadata, -1 );
                 this.presentation_window =
                     this.create_presentation_window( metadata, -1, width, height );
             } else {
                     if ( !Options.display_switch)
                         this.presenter_window =
-					this.create_presenter_window( metadata, -1, Options.fontscale );
+                            this.create_presenter_window( metadata, -1 );
                     else
                         this.presentation_window =
                             this.create_presentation_window( metadata, -1, width, height );

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -79,6 +79,7 @@ namespace pdfpc {
             { "size", 'Z', 0, OptionArg.STRING, ref Options.size, "Size of the presenter console in width:height format (forces windowed mode)", null},
             { "notes", 'n', 0, OptionArg.STRING, ref Options.notes_position, "Position of notes on the pdf page (either left, right, top or bottom)", "P"},
             { "version", 'v', 0, 0, ref Options.version, "Print the version string and copyright statement", null },
+            { "fontscale", 'f', 0, OptionArg.DOUBLE, ref Options.fontscale, "Scale timer font by fontscale (for high DPI screens)", null },
             { null }
         };
 
@@ -159,8 +160,8 @@ namespace pdfpc {
          * Create and return a PresenterWindow using the specified monitor
          * while displaying the given file
          */
-        private Window.Presenter create_presenter_window( Metadata.Pdf metadata, int monitor ) {
-            var presenter_window = new Window.Presenter( metadata, monitor, this.controller );
+        private Window.Presenter create_presenter_window( Metadata.Pdf metadata, int monitor, double fontscale ) {
+            var presenter_window = new Window.Presenter( metadata, monitor, fontscale, this.controller );
             //controller.register_controllable( presenter_window );
             presenter_window.set_cache_observer( this.cache_status );
 
@@ -262,18 +263,18 @@ namespace pdfpc {
                     presenter_monitor    = (screen.get_primary_monitor() + 1) % 2;
                 presentation_monitor = (presenter_monitor + 1) % 2;
                 this.presenter_window =
-                    this.create_presenter_window( metadata, presenter_monitor );
+				this.create_presenter_window( metadata, presenter_monitor, Options.fontscale );
                 this.presentation_window =
                     this.create_presentation_window( metadata, presentation_monitor, width, height );
             } else if (Options.windowed && !Options.single_screen) {
                 this.presenter_window =
-                    this.create_presenter_window( metadata, -1 );
+				this.create_presenter_window( metadata, -1, Options.fontscale );
                 this.presentation_window =
                     this.create_presentation_window( metadata, -1, width, height );
             } else {
                     if ( !Options.display_switch)
                         this.presenter_window =
-                            this.create_presenter_window( metadata, -1 );
+					this.create_presenter_window( metadata, -1, Options.fontscale );
                     else
                         this.presentation_window =
                             this.create_presentation_window( metadata, -1, width, height );


### PR DESCRIPTION
On Hight DPI screens the font used for the timer is waaay to big. This new command line switch allows you to scale the font down (or up) to something more reasonable.

USAGE: pdfpc -f 0.5 demo.pdf