### PR TITLE
Allow for specifying the manpage installation dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(Vala "0.26" REQUIRED)
 include(${VALA_USE_FILE})
 
 set(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/etc" CACHE FILEPATH "sysconfdir")
+set(MANDIR "share/man/man1" CACHE FILEPATH "mandir")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -3,5 +3,5 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/pdfpc.in ${CMAKE_CURRENT_SOURCE_DIR}/
 install(FILES
     pdfpc.1
 DESTINATION
-    share/man/man1
+    ${MANDIR}
 )


### PR DESCRIPTION
This is required for OpenBSD as the manual pages are installed into `man/man1` instead of `share/man/man1`