### PR TITLE
Adds --current-height and --next-height for adjusting presenter view

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -56,6 +56,12 @@ Display the time of the day
 .BI "\-u, \-\-current\-size"=N
 Percentage of the presenter screen to be used for the current slide.  (Default 60)
 .TP
+.BI "\-\-current\-height"=N
+Percentage of the height of the presenter screen to be used for the current slide. (Default 80)
+.TP
+.BI "\-\-next\-height"=N
+Percentage of the height of the presenter screen to be used for the next slide. (Default 70)
+.TP
 .BI "\-o, \-\-overview\-min\-size"=N
 Minimum width for the overview miniatures, in pixels. (Default 150)
 .TP

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -79,6 +79,18 @@ namespace pdfpc {
         public static uint current_size = 60;
 
         /**
+         * Commandline option providing the height of the current slide in
+         * the presenter window
+         **/
+        public static uint current_height = 80;
+
+        /**
+         * Commandline option providing the maximum height of the next slide
+         * in the presenter window
+         **/
+        public static uint next_height = 70;
+
+        /**
          * Minimum width for the overview miniatures
          */
         public static int min_overview_width = 150;

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -119,6 +119,11 @@ namespace pdfpc.Window {
         protected Metadata.Pdf metadata;
 
         /**
+         * Width of next/notes area
+         **/
+        protected int next_allocated_width;
+
+        /**
          * Base constructor instantiating a new presenter window
          */
         public Presenter(Metadata.Pdf metadata, int screen_num,
@@ -154,7 +159,7 @@ namespace pdfpc.Window {
             this.current_view = new View.Pdf.from_metadata(
                 metadata,
                 current_allocated_width,
-                (int) Math.floor(0.8 * bottom_position),
+                (int) Math.floor(Options.current_height * bottom_position / (double) 100),
                 Metadata.Area.NOTES,
                 Options.black_on_end,
                 true,
@@ -169,11 +174,12 @@ namespace pdfpc.Window {
             //current_allocated_width = cv_requisition.width;
             Gdk.Rectangle next_scale_rect;
             var next_allocated_width = this.screen_geometry.width - current_allocated_width - 4;
+            this.next_allocated_width = next_allocated_width;
             // We leave a bit of margin between the two views
             this.next_view = new View.Pdf.from_metadata(
                 metadata,
                 next_allocated_width,
-                (int) Math.floor(0.7 * bottom_position),
+                (int) Math.floor(Options.next_height * bottom_position / (double)100 ),
                 Metadata.Area.CONTENT,
                 true,
                 false,
@@ -206,6 +212,7 @@ namespace pdfpc.Window {
             var notes_font = Pango.FontDescription.from_string("Verdana");
             notes_font.set_size((int) Math.floor(20 * 0.75) * Pango.SCALE);
             this.notes_view = new Gtk.TextView();
+            this.notes_view.set_size_request(next_allocated_width, -1);
             this.notes_view.editable = false;
             this.notes_view.cursor_visible = false;
             this.notes_view.wrap_mode = Gtk.WrapMode.WORD;
@@ -326,10 +333,12 @@ namespace pdfpc.Window {
             slide_views.pack_start(current_view_and_stricts, true, true, 0);
 
             var nextViewWithNotes = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
+            nextViewWithNotes.set_size_request(this.next_allocated_width, -1);
             this.next_view.halign = Gtk.Align.CENTER;
             this.next_view.valign = Gtk.Align.CENTER;
             nextViewWithNotes.pack_start(next_view, false, false, 0);
             var notes_sw = new Gtk.ScrolledWindow(null, null);
+            notes_sw.set_size_request(this.next_allocated_width, -1);
             notes_sw.add(this.notes_view);
             notes_sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC);
             nextViewWithNotes.pack_start(notes_sw, true, true, 5);

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -69,6 +69,8 @@ namespace pdfpc {
             { "start-time", 't', 0, OptionArg.STRING, ref Options.start_time, "Start time of the presentation to be used as a countdown. (Format: HH:MM (24h))", "T" },
             { "time-of-day", 'C', 0, 0, ref Options.use_time_of_day, "Use the current time of the day for the timer", null},
             { "current-size", 'u', 0, OptionArg.INT, ref Options.current_size, "Percentage of the presenter screen to be used for the current slide. (Default 60)", "N" },
+            { "current-height", 0, 0, OptionArg.INT, ref Options.next_height, "Percentage of the height of the presenter screen to be used for the current slide. (Default 80)", "N" },
+            { "next-height", 0, 0, OptionArg.INT, ref Options.next_height, "Percentage of the height of the presenter screen to be used for the next slide. (Default 70)", "N" },
             { "overview-min-size", 'o', 0, OptionArg.INT, ref Options.min_overview_width, "Minimum width for the overview miniatures, in pixels. (Default 150)", "N" },
             { "switch-screens", 's', 0, 0, ref Options.display_switch, "Switch the presentation and the presenter screen.", null },
             { "disable-cache", 'c', 0, 0, ref Options.disable_caching, "Disable caching and pre-rendering of slides to save memory at the cost of speed.", null },


### PR DESCRIPTION
--current-height specifies the maximum percentage of the screen height
that the current slide view will use.

--next-height specifies the maximum percentage of the screen height
that the next slide view will use.  Setting this to a small number
leaves more room for notes.