### PR TITLE
Give more information when a PDF file is not found

### DIFF
--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -571,7 +571,8 @@ namespace pdfpc.Metadata {
                     null
                 );
             } catch(GLib.Error e) {
-                GLib.printerr("Unable to open pdf file: %s\n", e.message);
+                GLib.printerr("Unable to open pdf file \"%s\": %s\n",
+                              fname, e.message);
                 Posix.exit(1);
             }
 

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -213,7 +213,7 @@ namespace pdfpc {
                 warning("Error: No pdf file given\n");
                 Posix.exit(1);
             } else if (!GLib.FileUtils.test(pdfFilename, (GLib.FileTest.IS_REGULAR))) {
-                warning("Error: pdf file not found\n");
+                warning("Error: pdf file \"%s\" not found\n", pdfFilename);
                 Posix.exit(1);
             }
 


### PR DESCRIPTION
The error messages uses in such cases provide the name of the missing file as well.

This patch was triggered by a problem which bugged me for a few hours yesterday. I copied a presentation I made last year into a new folder and changed the name of every file to reflect the new date in which I am going to give it (the .tex, the .pdf, the .pdfpc, and so on). When I started `pdfpc`, I got the error message

    $ pdfpc presentation-2015-10-29.pdf
    Unable to open pdf file: No such file or directory
    $

Only after a couple of hours I finally realized that the file `presentation-2015-10-29.pdfpc` (which I renamed as well) still contained a reference to the old file name `presentation-2014-10-30.pdf`.

With this patch the program includes the name of the file it's looking for:

    $ pdfpc presentation-2015-10-29.pdf
    Unable to open pdf file "lezione-2014-11-20.pdf": No such file or directory
    $

I modified the program so that it includes the file name even if the missing file is the one the user specified on the command line. This might help in cases where the user misses a dash `-` before a short option:

    $ pdfpc b my_presentation.pdf  # Should have been "-b"
    ** (pdfpc:11584): WARNING **: pdfpc.vala:216: Error: pdf file "b" not found