### PR TITLE
Make movie support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(MANDIR "share/man/man1" CACHE FILEPATH "mandir")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+option(MOVIES "Compile support for movie playback (requires gdk-x11)" ON)
+
 add_subdirectory(src)
 add_subdirectory(icons)
 add_subdirectory(man)

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,11 @@ that, for example to be installed under */usr/*, with config files under
 
     cmake -DCMAKE_INSTALL_PREFIX="/usr" -DSYSCONFDIR=/etc ..
 
+By default, pdfpc includes support for movie playback.  This requires several
+gstreamer dependencies as well as gdk-x11.  The requirement for these packages
+can be removed by compiling without support for movie playback by passing
+*-DMOVIES=OFF* to the cmake command.
+
 Compiling from github
 ---------------------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,20 @@ pkg_check_modules(GEE REQUIRED gee-0.8)
 pkg_check_modules(POPPLER REQUIRED poppler-glib)
 pkg_check_modules(GTK REQUIRED gtk+-3.0)
 pkg_check_modules(GTHREAD REQUIRED gthread-2.0)
-pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
-pkg_check_modules(GSTBASE REQUIRED gstreamer-base-1.0)
-pkg_check_modules(GSTAUDIO REQUIRED gstreamer-audio-1.0)
-pkg_check_modules(GSTVIDEO REQUIRED gstreamer-video-1.0)
-pkg_check_modules(GDKX11 REQUIRED gdk-x11-3.0)
+if (MOVIES)
+    pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
+    pkg_check_modules(GSTBASE REQUIRED gstreamer-base-1.0)
+    pkg_check_modules(GSTAUDIO REQUIRED gstreamer-audio-1.0)
+    pkg_check_modules(GSTVIDEO REQUIRED gstreamer-video-1.0)
+    pkg_check_modules(GDKX11 REQUIRED gdk-x11-3.0)
+    set(MOVIE_PACKAGES
+        gstreamer-1.0
+        gstreamer-base-1.0
+        gstreamer-audio-1.0
+        gstreamer-video-1.0
+        gdk-x11-3.0
+    )
+endif ()
 
 set(CFLAGS
     ${GOBJECT_CFLAGS} ${GOBJECT_CFLAGS_OTHER}
@@ -56,6 +65,11 @@ link_directories(${LIB_PATHS})
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/paths.in ${CMAKE_CURRENT_SOURCE_DIR}/paths.vala)
 
 file (GLOB_RECURSE VALA_SRC RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.vala)
+if (MOVIES)
+    set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D MOVIES)
+else ()
+    LIST(REMOVE_ITEM VALA_SRC classes/action/movie.vala)
+endif ()
 
 vala_precompile(VALA_C
     ${VALA_SRC}
@@ -65,15 +79,12 @@ PACKAGES
     poppler-glib
     gtk+-3.0
     posix
-    gstreamer-1.0
-    gstreamer-base-1.0
-    gstreamer-audio-1.0
-    gstreamer-video-1.0
-    gdk-x11-3.0
+    ${MOVIE_PACKAGES}
 OPTIONS
     --thread
     --debug
     --enable-experimental
+    ${EXTRA_VALA_OPTIONS}
 GENERATE_HEADER
     presenter
 GENERATE_VAPI

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -584,7 +584,12 @@ namespace pdfpc.Metadata {
          */
         private int mapping_page_num = -1;
         private GLib.List<ActionMapping> action_mapping;
-        private ActionMapping[] blanks = {new ControlledMovie(), new LinkAction()};
+        private ActionMapping[] blanks = {
+#if MOVIES
+            new ControlledMovie(),
+#endif
+            new LinkAction()
+        };
         public weak PresentationController controller = null;
 
         /**

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -906,6 +906,7 @@ namespace pdfpc {
             return tm.mktime();
         }
 
+#if MOVIES
         /**
          * Give the Gdk.Rectangle corresponding to the Poppler.Rectangle for the nth
          * controllable's main view.  Also, return the XID for the view's window,
@@ -925,5 +926,6 @@ namespace pdfpc {
             rect = view.convert_poppler_rectangle_to_gdk_rectangle(area);
             return (uint*) ((Gdk.X11.Window) view.get_window()).get_xid();
         }
+#endif
     }
 }

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -195,9 +195,9 @@ namespace pdfpc {
                 print_version();
                 Posix.exit(0);
             }
-
+#if MOVIES
             Gst.init( ref args );
-
+#endif
             if (Options.list_actions) {
                 stdout.printf("Config file commands accepted by pdfpc:\n");
                 string[] actions = PresentationController.getActionDescriptions();


### PR DESCRIPTION
As we see in #74, the movie dependencies can be problematic.  By default, movies are supported; turn them off with `cmake -DMOVIES=OFF`.