### PR TITLE
Set the CWD to be the directory of the .pdfpc file

### DIFF
--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -177,7 +177,7 @@ namespace pdfpc.Metadata {
         void fill_path_info(string fname) {
             int l = fname.length;
 
-            if (l > 6 && fname[l-6:l] != ".pdfpc") {
+            if (l < 6 || fname[l-6:l] != ".pdfpc") {
                 this.pdf_fname = fname;
                 int extension_index = fname.last_index_of(".");
                 this.pdfpc_fname = fname[0:extension_index] + ".pdfpc";

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -180,7 +180,10 @@ namespace pdfpc.Metadata {
             if (l < 6 || fname[l-6:l] != ".pdfpc") {
                 this.pdf_fname = fname;
                 int extension_index = fname.last_index_of(".");
-                this.pdfpc_fname = fname[0:extension_index] + ".pdfpc";
+                if (extension_index > -1)
+                    this.pdfpc_fname = fname[0:extension_index] + ".pdfpc";
+                else
+                    this.pdfpc_fname = fname + ".pdfpc";
             } else {
                 this.pdfpc_fname = fname;
             }

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -236,8 +236,10 @@ namespace pdfpc {
                 Options.windowed = true;
             }
 
+            GLib.Environment.set_current_dir(GLib.Path.get_dirname(pdfFilename));
+
             pdfpc.Metadata.NotesPosition notes_position = pdfpc.Metadata.NotesPosition.from_string(Options.notes_position);
-            var metadata = new Metadata.Pdf( pdfFilename, notes_position );
+            var metadata = new Metadata.Pdf(GLib.Path.get_basename(pdfFilename), notes_position);
             if ( Options.duration != 987654321u )
                 metadata.set_duration(Options.duration);
 


### PR DESCRIPTION
I started working on #94, but my plans started ballooning as I was figuring out how to track the location of the .pdf file relative to both the current directory and the directory of the .pdfpc file.  Then I realized that there's no need to stay in the directory we happened to be launched from!  If we change to the directory containing the .pdfpc file, the distinction is no longer important.

I've tested a few different configurations, and everything seems to work.  But I'd appreciate a bit of sanity checking from others.