### PR TITLE
Option to disable auto grouping of overlay slides.

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -75,6 +75,9 @@ Disable caching and pre-rendering of slides to save memory at the cost of speed.
 Disable the compression of slide images to trade memory consumption for speed.
 (Avg.  factor 30)
 .TP
+.BI "\-g, \-\-disable\-auto\-grouping"
+Disable auto detection of overlay groups. (Default: enabled)
+.TP
 .BI "\-b, \-\-black\-on\-end"
 Add an additional black slide at the end of the presentation
 .TP

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -322,19 +322,26 @@ namespace pdfpc.Metadata {
                 out this.original_page_height
             );
 
-            if (!skips_by_user) {
+            if (Options.disable_auto_grouping && !skips_by_user) {
+                // Ignore overlayed slides
+                for (int i = 0; i < this.page_count; ++i) {
+                    this.user_view_indexes += i;
+                }
+            }
+
+            if (!Options.disable_auto_grouping && !skips_by_user) {
                 // Auto-detect which pages to skip
                 string previous_label = null;
-                int user_pages = 0;
                 for (int i = 0; i < this.page_count; ++i) {
                     string this_label = this.document.get_page(i).label;
                     if (this_label != previous_label) {
                         this.user_view_indexes += i;
                         previous_label = this_label;
-                        ++user_pages;
                     }
                 }
-            } else {
+            }
+
+            if(skips_by_user) {
                 parse_skip_line(skip_line);
             }
 

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -60,6 +60,11 @@ namespace pdfpc {
         public static bool disable_cache_compression = false;
 
         /**
+         * Commandline option to disable the auto detection of overlay slides
+         */
+        public static bool disable_auto_grouping = false;
+
+        /**
          * Commandline option providing the talk duration, which will be used to
          * display a timer
          *

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -77,6 +77,7 @@ namespace pdfpc {
             { "switch-screens", 's', 0, 0, ref Options.display_switch, "Switch the presentation and the presenter screen.", null },
             { "disable-cache", 'c', 0, 0, ref Options.disable_caching, "Disable caching and pre-rendering of slides to save memory at the cost of speed.", null },
             { "disable-compression", 'z', 0, 0, ref Options.disable_cache_compression, "Disable the compression of slide images to trade memory consumption for speed. (Avg. factor 30)", null },
+            { "disable-auto-grouping", 'g', 0, 0, ref Options.disable_auto_grouping, "Disable auto detection and grouping of overlayed slides", null },
             { "black-on-end", 'b', 0, 0, ref Options.black_on_end, "Add an additional black slide at the end of the presentation", null },
             { "single-screen", 'S', 0, 0, ref Options.single_screen, "Force to use only one screen", null },
             { "list-actions", 'L', 0, 0, ref Options.list_actions, "List actions supported in the config file(s)", null},


### PR DESCRIPTION
When using latex beamer + overlays + notes the auto detection of
slides which belong together fails.

Added an option to disable the auto grouping.