### PR TITLE
Bugfixes for window sizing

### DIFF
--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -136,14 +136,21 @@ namespace pdfpc.Window {
                 // The first movement might not have worked as expected, because of
                 // the before mentioned maximized window problem. Therefore it is
                 // done again
-
-                // First, unfullscreen otherwise we could be too large
-                // for the other screen, preventing a successful move
-                // to that screen
-                this.unfullscreen();
-
                 this.move(this.screen_geometry.x, this.screen_geometry.y);
 
+                this.fullscreen();
+
+                // Check to see if that move was successful
+                this.get_position(out x, out y);
+                if (x == this.screen_geometry.x && y == this.screen_geometry.y) {
+                    return;
+                }
+
+                // That move failed.  Now unfullscreen in case the window
+                // is too large for the other screen, preventing a
+                // successful move to that screen and try again.
+                this.unfullscreen();
+                this.move(this.screen_geometry.x, this.screen_geometry.y);
                 this.fullscreen();
             }
         }

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -136,6 +136,12 @@ namespace pdfpc.Window {
                 // The first movement might not have worked as expected, because of
                 // the before mentioned maximized window problem. Therefore it is
                 // done again
+
+                // First, unfullscreen otherwise we could be too large
+                // for the other screen, preventing a successful move
+                // to that screen
+                this.unfullscreen();
+
                 this.move(this.screen_geometry.x, this.screen_geometry.y);
 
                 this.fullscreen();

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -246,7 +246,15 @@ namespace pdfpc.Window {
             this.prerender_progress = new Gtk.ProgressBar();
             this.prerender_progress.name = "prerenderProgress";
             this.prerender_progress.show_text = true;
-            this.prerender_progress.text = "Prerendering...";
+
+            // Don't display prerendering text if the user has disabled
+            // it, but still create the control to ensure the layout
+            // doesn't change.
+            if (Options.disable_caching) {
+                this.prerender_progress.text = "";
+            } else {
+                this.prerender_progress.text = "Prerendering...";
+            }
             this.prerender_progress.no_show_all = true;
 
             int icon_height = bottom_height - 10;

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -255,6 +255,7 @@ namespace pdfpc.Window {
             } else {
                 this.prerender_progress.text = "Prerendering...";
             }
+            this.prerender_progress.set_ellipsize(Pango.EllipsizeMode.END);
             this.prerender_progress.no_show_all = true;
 
             int icon_height = bottom_height - 10;


### PR DESCRIPTION
This fixes three bugs:
 1. Windows fail to move to the correct screen in some cases
 2. "Prerendering" text shouldn't be displayed if prerendering is disabled
 3. Slide counter was cut off in some cases depending on screen resolution and font sizes.