### PR TITLE
Implements a window-height based font-size for the bottom controls.

### DIFF
--- a/rc/pdfpc.css
+++ b/rc/pdfpc.css
@@ -11,9 +11,14 @@
     background-color: white;
 }
 
-.bottomText {
-    font-size: 5em;
-}
+/* The bottom text is automatically sized based on the resolution of
+ * the presenter's screen but setting this value in the user's custom
+ * CSS will override the auto-sizing.  See the man page for more
+ * details.
+    .bottomText {
+        font-size: 5em;
+    }
+ */
 
 GtkProgressBar {
     color: gray;

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -272,6 +272,17 @@ namespace pdfpc.Window {
             this.button_press_event.connect(this.presentation_controller.button_press);
             this.scroll_event.connect(this.presentation_controller.scroll);
 
+            // resize the bottom text based on the window height
+            // (see http://stackoverflow.com/a/35237445/730138)
+            var bottom_text_css_provider = new Gtk.CssProvider();
+            Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
+                bottom_text_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+            const string bottom_text_css_template = ".bottomText { font-size: %fpx; }";
+            var target_size_height = (double) this.screen_geometry.height / 400.0 * 12.0;
+            var bottom_css = bottom_text_css_template.printf(target_size_height);
+            bottom_text_css_provider.load_from_data(bottom_css, -1);
+
             // Store the slide count once
             this.slide_count = metadata.get_slide_count();
 

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -276,12 +276,17 @@ namespace pdfpc.Window {
             // (see http://stackoverflow.com/a/35237445/730138)
             var bottom_text_css_provider = new Gtk.CssProvider();
             Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(),
-                bottom_text_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+                bottom_text_css_provider, Gtk.STYLE_PROVIDER_PRIORITY_FALLBACK);
 
-            const string bottom_text_css_template = ".bottomText { font-size: %fpx; }";
-            var target_size_height = (double) this.screen_geometry.height / 400.0 * 12.0;
+            const string bottom_text_css_template = ".bottomText { font-size: %dpx; }";
+            var target_size_height = (int) ((double)this.screen_geometry.height / 400.0 * 12.0);
             var bottom_css = bottom_text_css_template.printf(target_size_height);
-            bottom_text_css_provider.load_from_data(bottom_css, -1);
+
+            try {
+                bottom_text_css_provider.load_from_data(bottom_css, -1);
+            } catch (Error e) {
+                stderr.printf("Warning: failed to set CSS for auto-sized bottom controls.\n");
+            }
 
             // Store the slide count once
             this.slide_count = metadata.get_slide_count();


### PR DESCRIPTION
Addresses #117 by implementing a window-height based font size inside the CSS framework.  Correctly sizes the bottom controls for every resolution available on my laptop at 1024x748 and above.

The user can still use the ````.bottomText```` control to set the height, as now described in the CSS's comments.  This one cost me some reputation on statck overflow, but I'm glad we got it :)

see: http://stackoverflow.com/q/35138228/730138

Test it out and let me know what you think.