### PR TITLE
Provided a hack to match the video size to the poster image size better.

### DIFF
--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -99,6 +99,15 @@ namespace pdfpc {
         public virtual void init_other(ActionMapping other, Poppler.Rectangle area,
                 PresentationController controller, Poppler.Document document,
                 string uri, bool autostart, bool loop, bool noaudio, int start = 0, int stop = 0, bool temp=false) {
+
+            // A small hack to make videos fit the size of the poster image better.
+            // I presume the mapping area is a bit larger than the actual image size.
+
+            area.x1 += 4.9;
+            area.y1 += 0.9;
+            area.x2 -= 0.9;
+            area.y2 -= 0.8;
+
             other.init(area, controller, document);
             Movie movie = (Movie) other;
             movie.loop = loop;


### PR DESCRIPTION
I am not sure about the origin of the problem, but when I use videos, they don't match the poster image perfectly in size, leading to flickering effects.

I changed the size of the video area to prevent this flickering. Now the videos are nicely aligned with the poster image.

Maybe someone figures out the origin of the problem (does poppler add a margin around link object areas?), but until then, this hack should work for most people.