### PR TITLE
Made the progress bar optional with an "noprogress" flag.

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -309,9 +309,12 @@ supported. (Also, run ps2pdf with the \-dNOSAFER flag.)
 .PP
 As a perhaps simpler option, pdfpc will play back movies linked from a
 hyperlink of type "launch".  A query string may be added to the URL of the
-movie to enable the "autostart" and "loop" properties.  (E.g., a link to
-"movie.avi?autostart&loop" will start playing automatically, and loop when
-it reaches the end.)  In LaTeX, such links are created with
+movie to enable the "autostart", "loop" and "noprogress" properties, if
+necessary.  (E.g., a link to "movie.avi?autostart&loop&noprogress" will add a
+video that starts playing automatically, loops when it reaches the end, and
+does not show the progress bar.)
+
+In LaTeX, such links are created with
 
 .RS
 \\usepackage{hyperref}

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -563,9 +563,7 @@ namespace pdfpc {
             cr.translate(0, this.vheight);
             cr.scale(this.scalex, -this.scaley);
 
-            if (this.noprogress == false) {
-                this.draw_seek_bar(cr, timestamp);
-            }
+            this.draw_seek_bar(cr, timestamp);
 
             // if a stop time is defined, stop there (but still let
             // the user manually seek *after* this timestamp)
@@ -651,7 +649,7 @@ namespace pdfpc {
                 cr.show_text(timestring);
                 cr.restore();
 
-            } else {
+            } else if (this.noprogress == false) {
                 cr.rectangle(0, 0, rect.width, 4);
                 cr.set_source_rgba(0, 0, 0, 0.8);
                 cr.fill();
@@ -661,7 +659,7 @@ namespace pdfpc {
                 cr.rectangle(start_bar, 0, stop_bar - start_bar, 4);
                 cr.set_source_rgba(1,1,1,0.5);
                 cr.fill();
-             }
+            }
         }
 
         /**

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -64,6 +64,11 @@ namespace pdfpc {
          */
         protected bool loop;
 
+        /**
+         * A flag to indicated whether the progress bar should be supressed.
+         */
+        protected bool noprogress = false;
+
          /**
          * A flag to indicate whether the audio should be played or not.
          */
@@ -98,10 +103,11 @@ namespace pdfpc {
          */
         public virtual void init_other(ActionMapping other, Poppler.Rectangle area,
                 PresentationController controller, Poppler.Document document,
-                string uri, bool autostart, bool loop, bool noaudio, int start = 0, int stop = 0, bool temp=false) {
+                string uri, bool autostart, bool loop, bool noprogress, bool noaudio, int start = 0, int stop = 0, bool temp=false) {
             other.init(area, controller, document);
             Movie movie = (Movie) other;
             movie.loop = loop;
+            movie.noprogress = noprogress;
             movie.noaudio = noaudio;
             movie.starttime = start;
             movie.stoptime = stop;
@@ -157,6 +163,7 @@ namespace pdfpc {
             bool autostart = "autostart" in queryarray;
             bool noaudio = "noaudio" in queryarray;
             bool loop = "loop" in queryarray;
+            bool noprogress = "noprogress" in queryarray;
             var start = 0;
             var stop = 0;
             foreach (string param in queryarray) {
@@ -176,7 +183,7 @@ namespace pdfpc {
 
             Type type = Type.from_instance(this);
             ActionMapping new_obj = (ActionMapping) GLib.Object.new(type);
-            this.init_other(new_obj, mapping.area, controller, document, uri, autostart, loop, noaudio, start, stop);
+            this.init_other(new_obj, mapping.area, controller, document, uri, autostart, loop, noprogress, noaudio, start, stop);
             return new_obj;
         }
 
@@ -264,7 +271,7 @@ namespace pdfpc {
 
             Type type = Type.from_instance(this);
             ActionMapping new_obj = (ActionMapping) GLib.Object.new(type);
-            this.init_other(new_obj, mapping.area, controller, document, uri, false, false, false, 0, 0, temp);
+            this.init_other(new_obj, mapping.area, controller, document, uri, false, false, false, false, 0, 0, temp);
             return new_obj;
         }
 
@@ -484,8 +491,8 @@ namespace pdfpc {
          */
         public override void init_other(ActionMapping other, Poppler.Rectangle area,
                 PresentationController controller, Poppler.Document document, string file,
-                bool autostart, bool loop, bool noaudio, int start = 0, int stop = 0, bool temp=false) {
-            base.init_other(other, area, controller, document, file, autostart, loop, noaudio, start, stop, temp);
+                bool autostart, bool loop, bool noprogress, bool noaudio, int start = 0, int stop = 0, bool temp=false) {
+            base.init_other(other, area, controller, document, file, autostart, loop, noprogress, noaudio, start, stop, temp);
             ControlledMovie movie = (ControlledMovie) other;
             controller.main_view.motion_notify_event.connect(movie.on_motion);
             controller.main_view.button_release_event.connect(movie.on_button_release);
@@ -556,7 +563,9 @@ namespace pdfpc {
             cr.translate(0, this.vheight);
             cr.scale(this.scalex, -this.scaley);
 
-            this.draw_seek_bar(cr, timestamp);
+            if (this.noprogress == false) {
+                this.draw_seek_bar(cr, timestamp);
+            }
 
             // if a stop time is defined, stop there (but still let
             // the user manually seek *after* this timestamp)


### PR DESCRIPTION
I use the video feature for animations in scientific presentations. For this, I usually use "?autostart&loop", but I think the progress bar is annoying in this use case. (My animations are only a few seconds long and then repeat, leading to a "blinking" effect of the progress bar.)

I implemented support for another flag, "noprogress" to suppress the progress bar. If the video is included with "?noprogress" (or, in my case "?autostart&loop&noprogress"), then the progress bar is not displayed.