### PR TITLE
Added valac dependency to README file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ requirements need to be met:
 
 On Ubuntu systems, you can install these dependencies with:
 
-    sudo apt-get install cmake libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgee-0.8-dev librsvg2-dev libpoppler-glib-dev libgtk2.0-dev libgtk-3-dev
+    sudo apt-get install cmake libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgee-0.8-dev librsvg2-dev libpoppler-glib-dev libgtk2.0-dev libgtk-3-dev valac
 
 and you should consider installing all the available gstreamer codecs:
 


### PR DESCRIPTION
In the README file, `valac` was not included in the `apt-get install` command, which was missing from my fresh Ubuntu installation and required to build pdfpc.