### PR TITLE
Always disable resizing of windows.

### DIFF
--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -70,6 +70,11 @@ namespace pdfpc.Window {
                 screen.get_monitor_geometry(current_screen, out this.screen_geometry);
             }
 
+            // We always render ouput to fit to an exact size.
+            // This also forces some tiling window managers like i3 to
+            // put the windows on the right screens.
+            this.resizable = false;
+
             if (!Options.windowed) {
                 // Move to the correct monitor
                 // This movement is done here and after mapping, to minimize flickering
@@ -91,7 +96,6 @@ namespace pdfpc.Window {
                         this.screen_geometry.width /= 2;
                         this.screen_geometry.height /= 2;
                 }
-                this.resizable = false;
             }
 
             this.add_events(Gdk.EventMask.POINTER_MOTION_MASK);


### PR DESCRIPTION
Because we always give a window, fullscreen or windowed a fixed size we
should not allow resizing windows at any point.
This also helps/forces tiling window managers like i3 to put the windows
to the right screens.

Here the discussion about it on i3 mailing list:
https://www.freelists.org/post/i3-discuss/pdfpc-presentation-setup