### PR TITLE
Fixed key binding format bug.

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -387,10 +387,10 @@ A/M (for Alt/Meta). E.g.
 .TP
 bind S+Next    next10
 .P
-A key combination constituting shift and an alphabetic character can
-be specified simply as the capital version of the alphabetic
-character. For example, to bind <shift>+r to the 'reset' function,
-use
+A shorthand for specifying key combinations constituting shift and an
+alphabetic character is to simply give the uppercase version of the
+alphabetic character. For example, to bind <shift>+r to the 'reset'
+function, use
 .TP
 bind R reset
 .P

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -387,6 +387,13 @@ A/M (for Alt/Meta). E.g.
 .TP
 bind S+Next    next10
 .P
+A key combination constituting shift and an alphabetic character can
+be specified simply as the capital version of the alphabetic
+character. For example, to bind <shift>+r to the 'reset' function,
+use
+.TP
+bind R reset
+.P
 A list of all possible functions can be obtained
 via the \-L command line option.
 

--- a/src/classes/configFileReader.vala
+++ b/src/classes/configFileReader.vala
@@ -7,6 +7,7 @@
  * Copyright 2015 Robert Schroll
  * Copyright 2015 Andreas Bilke
  * Copyright 2016 Andy Barry
+ * Copyright 2016 Joakim Nilsson
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,6 +55,14 @@ namespace pdfpc {
                     }
                 }
                 code = conversor(fields[1]);
+            }
+            // 'X' adds keybinding shift+x
+            if ('A' <= code && code <= 'Z') { // If uppercase
+                modMask |= Gdk.ModifierType.SHIFT_MASK;
+            }
+            // 'S+x' adds keybinding shift+x
+            if ('a' <= code && code <= 'z' && ((modMask | Gdk.ModifierType.SHIFT_MASK) == modMask)) { // If lowercase without shift
+                code ^= (1 << 5); // Toggle case
             }
         }
 


### PR DESCRIPTION
Key bindings which include holding shift previously had to be
specified as 'S+X', where 'X' is the key to press. They can now be
specified either just as 'X' or as 'S+x'.