### PR TITLE
Add jump points

### DIFF
--- a/src/classes/metadata/jump_points.vala
+++ b/src/classes/metadata/jump_points.vala
@@ -51,8 +51,11 @@ namespace pdfpc.Metadata {
           for (int i = 0 ; i < lines.length ; i++) {
             string line = lines[i];
             string[] tokens = line.split("=");
+            if (tokens.length != 2) {
+              continue;
+            }
             uint key = Gdk.keyval_from_name(tokens[0].strip());
-            int slide_no = int.parse(tokens[1]);
+            int slide_no = int.parse(tokens[1]) - 1;
 
             this.points.set(key, slide_no);
           }

--- a/src/classes/metadata/jump_points.vala
+++ b/src/classes/metadata/jump_points.vala
@@ -1,11 +1,10 @@
 /**
- * Storage for the notes of a presentation
+ * Storage for the jump points of a presentation
  *
  * This file is part of pdfpc.
  *
- * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
- * Copyright 2012 David Vilar
  * Copyright 2015 Andreas Bilke
+ * Original Author: Lukas Barth
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/classes/metadata/jump_points.vala
+++ b/src/classes/metadata/jump_points.vala
@@ -1,0 +1,61 @@
+/**
+ * Storage for the notes of a presentation
+ *
+ * This file is part of pdfpc.
+ *
+ * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
+ * Copyright 2012 David Vilar
+ * Copyright 2015 Andreas Bilke
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc.Metadata {
+    /**
+     * Class for providing storage for the notes associate with a presentation
+     */
+    public class jump_points: Object {
+      protected Gee.HashMap<uint, int> points = new Gee.HashMap<unichar, int>();
+        /**
+         * Returns the string that should be written to the pdfpc file
+         */
+        public string format_to_save() {
+            var builder = new GLib.StringBuilder();
+            foreach (Gee.Map.Entry<unichar, int> entry in this.points.entries) {
+              string key_name = Gdk.keyval_name(entry.key);
+              builder.append(@"$(key_name) = $(entry.value)\n");
+            }
+            return builder.str;
+        }
+
+        public Gee.HashMap<uint, int> get_points() {
+          return this.points;
+        }
+
+        /**
+         * Parse the jump points
+         */
+        public void parse_lines(string[] lines) {
+          for (int i = 0 ; i < lines.length ; i++) {
+            string line = lines[i];
+            string[] tokens = line.split("=");
+            uint key = Gdk.keyval_from_name(tokens[0].strip());
+            int slide_no = int.parse(tokens[1]);
+
+            this.points.set(key, slide_no);
+          }
+        }
+    }
+}

--- a/src/classes/metadata/slides_notes.vala
+++ b/src/classes/metadata/slides_notes.vala
@@ -1,11 +1,11 @@
 /**
- * Storage for the jump points
+ * Storage for the notes of a presentation
  *
  * This file is part of pdfpc.
  *
- * The original author of this file is Lukas Barth
- *
- * Copyright 2016 Andreas Bilke
+ * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
+ * Copyright 2012 David Vilar
+ * Copyright 2015 Andreas Bilke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/classes/metadata/slides_notes.vala
+++ b/src/classes/metadata/slides_notes.vala
@@ -1,11 +1,11 @@
 /**
- * Storage for the notes of a presentation
+ * Storage for the jump points
  *
  * This file is part of pdfpc.
  *
- * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
- * Copyright 2012 David Vilar
- * Copyright 2015 Andreas Bilke
+ * The original author of this file is Lukas Barth
+ *
+ * Copyright 2016 Andreas Bilke
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hi,

first things first: This is work in progress. I do not expect this to be merged as-is. Please see this as a request for comments.

I implemented what I call "jump points". Basically, the per-pdf config file can specify (key,slide)-pairs in the "[jump_points]" section, resulting in the respective key being bound to the action "jump to that slide". I sometimes have multiple endings for my presentations (depending on how much time is left). For that to work, at a certain point I need to "jump" to the track of slides that start the correct ending. I know I can use the overview, but that is way more clumsy than just pressing one of "1", "2" or "3". ;)

Regarding the implementation: I'm not sure if the way I set up the actions is the way it should be. I also thought about having just one action for all jump-related things, and passing a variant to this action specifying either which slide to jump to, or which key was pressed. But in either case, that means I'll have to do a key -> slide lookup when the action is dispatched. I think I like it more the way it is now.

Also, I have not yet implemented a way of specifying jump points in pdfpc. What you currently have to do is write something like this into your .pdfpc-file:

```
[jump_points]
1 = 10
2 = 15
```

I'm not sure what a nice way of specifying these in pdfpc would be, but since I will probably try to have this be generated by my LaTeX files (via a modified version of pdfpcnotes.sty), this is not a pressing matter for me..

What do you think? 
