### PR TITLE
Add Fedora package-manager installation instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,11 @@ Installation
 - On Ubuntu or Debian systems::
 
         sudo apt-get install pdf-presenter-console
+
+- On Fedora::
+
+        sudo dnf install pdfpc
+
 - `Compiling from source <#compile-and-install>`_
 - `Compiling from github <#compiling-from-github>`_
 


### PR DESCRIPTION
pdfpc is available in fedora repositories since fedora 22:
[https://admin.fedoraproject.org/pkgdb/package/rpms/pdfpc/](https://admin.fedoraproject.org/pkgdb/package/rpms/pdfpc/)