### PR TITLE
Shrink strict next/prev view to nothing of it is disabled by the user

### DIFF
--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -199,7 +199,7 @@ namespace pdfpc.Window {
             this.strict_next_view = new View.Pdf.from_metadata(
                 metadata,
                 (int) Math.floor(0.5 * current_allocated_width),
-                (int) Math.floor(0.19 * bottom_position) - 2,
+                (int) (Options.disable_auto_grouping ? 1 : (Math.floor(0.19 * bottom_position) - 2)),
                 Metadata.Area.CONTENT,
                 true,
                 false,
@@ -209,7 +209,7 @@ namespace pdfpc.Window {
             this.strict_prev_view = new View.Pdf.from_metadata(
                 metadata,
                 (int) Math.floor(0.5 * current_allocated_width),
-                (int) Math.floor(0.19 * bottom_position) - 2,
+                (int) (Options.disable_auto_grouping ? 1 : (Math.floor(0.19 * bottom_position) - 2)),
                 Metadata.Area.CONTENT,
                 true,
                 false,


### PR DESCRIPTION
This is so that I can set
```
option current-size 75
option current-height 100
```
without the progress par and timer moving off the screen.
