### PR TITLE
Disable auto grouping if --notes option is used

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -79,7 +79,7 @@ Run in windowed mode
 Size of the presentation window in width:height format (forces windowed mode)
 .TP
 .BI "\-n, \-\-notes"=P
-Position of notes on the PDF page. Position can be either left, right, top or bottom (Default: none)
+Position of notes on the PDF page. Position can be either left, right, top or bottom. Disable slide auto-grouping (Default: none)
 .TP
 .BI "\-h, \-\-help"
 Shows the help

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -186,6 +186,12 @@ namespace pdfpc {
                 print_version();
                 Posix.exit(0);
             }
+
+            if (Options.notes_position != null) {
+                Options.disable_auto_grouping = true;
+                stderr.printf("--notes option detected. Disable auto grouping.\n");
+            }
+
             ConfigFileReader configFileReader = new ConfigFileReader();
             configFileReader.readConfig(Path.build_filename(Paths.SOURCE_PATH, "rc/pdfpcrc"));
             configFileReader.readConfig(Path.build_filename(Paths.CONF_PATH, "pdfpcrc"));


### PR DESCRIPTION
beamer (and specially pgfpages) have a bug which mess up the pdf page
labels within the document. As a result, pdfpc mis-detected grouped
pdf pages.

Since this bug is in pgfpages we can't do anything about it. It is
safer to disable auto grouping instead of having wrong grouping.