### PR TITLE
Support for cache persistence

### DIFF
--- a/src/classes/cache_status.vala
+++ b/src/classes/cache_status.vala
@@ -54,6 +54,8 @@ namespace pdfpc {
         public void update() {
             // Only draw if the widget is actually added to some parent
             if (this.current_value == this.max_value) {
+                // If the progress is at its maximum, tell the caches to persist to disk
+                pdfpc.Renderer.Cache.Base.persist_all();
                 update_complete();
             } else {
                 update_progress((double)this.current_value / this.max_value);

--- a/src/classes/metadata/base.vala
+++ b/src/classes/metadata/base.vala
@@ -54,6 +54,13 @@ namespace pdfpc {
         }
 
         /**
+         * Return the registered file name
+         */
+        public string get_fname() {
+            return this.fname;
+        }
+
+        /**
          * Return the number of slides defined by the given url
          */
         public abstract uint get_slide_count();

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -58,6 +58,11 @@ namespace pdfpc {
         public static bool disable_caching = false;
 
         /**
+         * Commandline option which allows to persist the cache in a file
+         */
+        public static bool persist_cache = false;
+
+        /**
          * Commandline option to disable the compression of cached slides. This
          * trades speed for memory. A lot of memory ;) It's about factor 30
          * bigger for normal presentations.

--- a/src/classes/renderer/cache/base.vala
+++ b/src/classes/renderer/cache/base.vala
@@ -58,7 +58,7 @@ namespace pdfpc.Renderer.Cache {
          * on-disk slide cache
          */
         public static void persist_all() {
-            if(!cache_update_required) {
+            if(!cache_update_required || !Options.persist_cache) {
                 return;
             }
 

--- a/src/classes/renderer/cache/base.vala
+++ b/src/classes/renderer/cache/base.vala
@@ -35,10 +35,90 @@ namespace pdfpc.Renderer.Cache {
         protected Metadata.Base metadata;
 
         /**
+         * File name for the file where the persistent cache is stored
+         */
+        private static string? persist_cache_fname = null;
+
+        /**
+         * Common DataInputStream with the persistent cache. This needs to be
+         * static to allow all instanciated caches to share one file without
+         * having to expose the persistence capabilities to the user.
+         */
+        private static DataInputStream? cache_input_stream = null;
+
+        /**
+         * List of all cache instances for persistent caching; see cache_input_stream.
+         *
+         * Caches are stored and loaded in the order they are constructed.
+         */
+        private static List<unowned Base> cache_instances = new List<unowned Base>();
+
+        /**
+         * Make all instanciated/active caches persist their data to the
+         * on-disk slide cache
+         */
+        public static void persist_all() {
+            if(!cache_update_required) {
+                return;
+            }
+
+            var cache_file = File.new_for_commandline_arg(persist_cache_fname);
+
+            try {
+                var output_stream = new DataOutputStream(cache_file.replace(null, false, FileCreateFlags.NONE));
+
+                foreach(Base element in cache_instances) {
+                    element.persist(output_stream);
+                }
+            }
+            catch( Error e ) {
+                print( "Failed to persist the cache: %s\n", e.message );
+
+                try { cache_file.delete(); }
+                catch( Error e2 ) {}
+            }
+        }
+
+        /**
+         * Flag indicating whether the cache needs to be stored
+         */
+        protected static bool cache_update_required = true;
+
+        /**
          * Initialize the cache store
          */
         public Base(Metadata.Base metadata) {
             this.metadata = metadata;
+
+            if(Options.persist_cache) {
+                if(persist_cache_fname == null) {
+                    persist_cache_fname = metadata.get_fname() + "pc_cache";
+                }
+                if(cache_input_stream == null) {
+                    try {
+                        var cache_file = File.new_for_commandline_arg(persist_cache_fname);
+                        var cache_file_info = cache_file.query_info(FileAttribute.TIME_MODIFIED, 0);
+                        var cache_age = cache_file_info.get_modification_time();
+
+                        var pdf_file = File.new_for_commandline_arg(metadata.get_fname());
+                        var pdf_file_info = pdf_file.query_info(FileAttribute.TIME_MODIFIED, 0);
+                        var pdf_age = pdf_file_info.get_modification_time();
+
+                        if(pdf_age.tv_sec <= cache_age.tv_sec) {
+                            cache_input_stream = new DataInputStream(cache_file.read());
+                        }
+                    }
+                    catch( Error e ) { /* Ignore cache errors */ }
+                }
+
+                if(cache_input_stream != null) {
+                    load_from_disk(cache_input_stream);
+                }
+                else {
+                    cache_update_required = true;
+                }
+                cache_instances.append(this);
+            }
         }
 
         /**
@@ -64,6 +144,16 @@ namespace pdfpc.Renderer.Cache {
          * If no item with the given index is available null is returned
          */
         public abstract Cairo.ImageSurface? retrieve(uint index);
+
+        /**
+         * Store the cache to disk
+         */
+        protected abstract void persist(DataOutputStream cache) throws Error;
+
+        /**
+         * Load the cache from disk
+         */
+        protected abstract void load_from_disk(DataInputStream cache) throws Error;
     }
 
     /**

--- a/src/classes/renderer/cache/png/engine.vala
+++ b/src/classes/renderer/cache/png/engine.vala
@@ -38,7 +38,9 @@ namespace pdfpc.Renderer.Cache {
          */
         public Engine( Metadata.Base metadata ) {
             base( metadata );
-            this.storage = new PNG.Item[this.metadata.get_slide_count()];
+            if( this.storage.length == 0 ) {
+                this.storage = new PNG.Item[this.metadata.get_slide_count()];
+            }
         }
 
         /**
@@ -89,6 +91,36 @@ namespace pdfpc.Renderer.Cache {
             cr.fill();
 
             return surface;
+        }
+
+        /**
+         * Store the cache to disk
+         */
+        public override void persist(DataOutputStream cache) throws Error {
+            cache.put_int32(1); /* Mark this as a version 1 cache for the PNG engine */
+            cache.put_int32(storage.length);
+            for(var i=0; i<storage.length; i++) {
+                cache.put_uint32(this.storage[i].get_length());
+                cache.write(this.storage[i].get_png_data());
+            }
+        }
+
+        /**
+         * Load the cache from disk
+         */
+        public override void load_from_disk(DataInputStream cache) throws Error {
+            if(cache.read_int32() != 1) {
+                error("Invalid cache file.");
+            }
+            var length = cache.read_int32();
+            this.storage = new PNG.Item[length];
+            for(var i=0; i<length; i++) {
+                var data_length = cache.read_uint32();
+                uint8[] data = new uint8[data_length];
+                cache.read(data);
+                var item = new PNG.Item(data);
+                this.storage[i] = item;
+            }
         }
     }
 }

--- a/src/classes/renderer/cache/png/engine.vala
+++ b/src/classes/renderer/cache/png/engine.vala
@@ -47,6 +47,7 @@ namespace pdfpc.Renderer.Cache {
          * Store a surface in the cache using the given index as identifier
          */
         public override void store( uint index, Cairo.ImageSurface surface ) {
+            cache_update_required = true;
             Gdk.Pixbuf pixbuf = Gdk.pixbuf_get_from_surface(surface, 0, 0, surface.get_width(),
                 surface.get_height());
             uint8[] buffer;

--- a/src/classes/renderer/cache/simple/engine.vala
+++ b/src/classes/renderer/cache/simple/engine.vala
@@ -37,7 +37,9 @@ namespace pdfpc.Renderer.Cache {
          */
         public Engine( Metadata.Base metadata ) {
             base( metadata );
-            this.storage = new Cairo.ImageSurface[this.metadata.get_slide_count()];
+            if( this.storage.length == 0 ) {
+                this.storage = new Cairo.ImageSurface[this.metadata.get_slide_count()];
+            }
         }
 
         /**
@@ -54,6 +56,53 @@ namespace pdfpc.Renderer.Cache {
          */
         public override Cairo.ImageSurface? retrieve( uint index ) {
             return this.storage[index];
+        }
+
+        /**
+         * Store the cache to disk
+         */
+        public override void persist(DataOutputStream cache) throws Error {
+            cache.put_int32(0); /* Mark this as a version 1 cache for the simple engine */
+            cache.put_int32(this.storage.length);
+            for(var i=0; i<this.storage.length; i++) {
+                cache.put_int32(this.storage[i].get_format());
+                cache.put_int32(this.storage[i].get_width());
+                cache.put_int32(this.storage[i].get_height());
+                cache.put_int32(this.storage[i].get_stride());
+
+                this.storage[i].flush();
+                unowned uchar[] image_data = this.storage[i].get_data();
+
+                /* TODO For some reason, image_data.length is always zero, so
+                 * caching does not work yet for the simple cache. */
+
+                cache.put_uint32(image_data.length);
+                cache.write(image_data);
+            }
+
+            cache.flush();
+        }
+
+        /**
+         * Load the cache from disk
+         */
+        public override void load_from_disk(DataInputStream cache) throws Error {
+            if(cache.read_int32() != 0) {
+                error("Invalid cache file.");
+            }
+            var length = cache.read_int32();
+            for(var i=0; i<length; i++) {
+                var format = cache.read_int32();
+                var width = cache.read_int32();
+                var height = cache.read_int32();
+                var stride = cache.read_int32();
+                var data_length = cache.read_uint32();
+
+                uint8[] data = new uint8[data_length];
+                cache.read(data);
+
+                this.storage[i] = new Cairo.ImageSurface.for_data(data, (Cairo.Format) format, width, height, stride);
+            }
         }
     }
 }

--- a/src/classes/renderer/cache/simple/engine.vala
+++ b/src/classes/renderer/cache/simple/engine.vala
@@ -46,6 +46,7 @@ namespace pdfpc.Renderer.Cache {
          * Store a surface in the cache using the given index as identifier
          */
         public override void store( uint index, Cairo.ImageSurface surface ) {
+            cache_update_required = true;
             this.storage[index] = surface;
         }
 

--- a/src/classes/renderer/pdf.vala
+++ b/src/classes/renderer/pdf.vala
@@ -83,7 +83,9 @@ namespace pdfpc {
             if (this.cache != null) {
                 Cairo.ImageSurface cache_content;
                 if ((cache_content = this.cache.retrieve(slide_number)) != null) {
-                    return cache_content;
+                    if(cache_content.get_width() == width && cache_content.get_height() == height) {
+                        return cache_content;
+                    }
                 }
             }
 

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -59,6 +59,7 @@ namespace pdfpc {
             { "time-of-day", 'C', 0, 0, ref Options.use_time_of_day, "Use the current time of the day for the timer", null},
             { "switch-screens", 's', 0, 0, ref Options.display_switch, "Switch the presentation and the presenter screen.", null },
             { "disable-cache", 'c', 0, 0, ref Options.disable_caching, "Disable caching and pre-rendering of slides to save memory at the cost of speed.", null },
+            { "persist-cache", 'p', 0, 0, ref Options.persist_cache, "Store the cache in a separate file for fast startup upon reviewing the presentation.", null },
             { "disable-compression", 'z', 0, 0, ref Options.disable_cache_compression, "Disable the compression of slide images to trade memory consumption for speed. (Avg. factor 30)", null },
             { "disable-auto-grouping", 'g', 0, 0, ref Options.disable_auto_grouping, "Disable auto detection and grouping of overlayed slides", null },
             { "single-screen", 'S', 0, 0, ref Options.single_screen, "Force to use only one screen", null },


### PR DESCRIPTION
I'd like to propose a change to pdfpc that allows persisting the cache on disk for faster startup.

## Rationale

The use case for this is probably obvious, still, here's a short motivation: Typically, I *have* to start pdfpc a few moments before I start giving a talk. This is because at conferences I cannot connect the notebook to the beamer any earlier. Resizing/moving an existing pdfpc window afterwards isn't particularly great either. Especially with long presentations and on the powersave CPU govenor (which my notebook automatically uses if it's not on AC) pdfpc is very unresponsive in the beginning of a presentation, because it is busy prerendering. Storing the cache on disk mitigates this, because "prerendering" is then reduced to loading the cache from disk into memory.

## Please note while reviewing

* I am not an experienced vala programmer. I'd appreciate comments in the code review and will do my best to improve the code quality. Feel free to apply changes yourself.
* Persisting the *uncompressed* cache does not work yet, because `Cairo.ImageSurface.get_data` does not actually return any data. I do not know why this is the case. (I personally do not care whether this works so I'd tend to just comment the code and only cache the compresssed version, but I thought I'd leave the code in there for now in case someone knows where I went wrong..)

## Design choices

pdfpc instantiates multiple cache instances. This makes persisting the cache into *one* file something that cannot be achieved easily from within the cache class, at least unless each cache instance is given a unique, deterministic ID. The cleanest solution, in my opinion, would be to create a container class for the various caches which takes care of persisting them. As I've said, I'm not very experienced with Vala, so I thought it'd be easier and more practical for now to instead within the base cache class create a static list of references to all cache instances in the order in which they are instantiated and persist all instances from a static method call. Reading is performed using *one* static input stream. This ensures that the order is maintained between writes and reads. The downside I see is that it is no longer possible to have simultaneous caches for data from different files, and opening multiple files is something I can imagine could be a feature someday.

Should you concur and feel that it is a bad idea to merge this PR because of that, feel free to still use parts of my code for a cleaner implementation.