### PR TITLE
Fix previous slide action

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -684,18 +684,14 @@ namespace pdfpc {
          * Was the previous slide a skip one?
          */
         public bool skip_previous() {
-            return this.current_slide_number > this.metadata.user_slide_to_real_slide(
-                this.current_user_slide_number);
+            return this.current_slide_number > 0 && this.metadata.real_slide_to_user_slide(this.current_slide_number - 1) == this.metadata.real_slide_to_user_slide(this.current_slide_number);
         }
 
         /**
          * Is the next slide a skip one?
          */
         public bool skip_next() {
-            return (this.current_user_slide_number >= this.metadata.get_user_slide_count() - 1
-                && this.current_slide_number < this.n_slides)
-                || (this.current_slide_number + 1 < this.metadata.user_slide_to_real_slide(
-                this.current_user_slide_number + 1));
+            return this.current_slide_number < this.n_slides && this.metadata.real_slide_to_user_slide(this.current_slide_number) == this.metadata.real_slide_to_user_slide(this.current_slide_number + 1);
         }
 
         /**

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -811,11 +811,7 @@ namespace pdfpc {
             // there is a next slide
             if (this.current_slide_number < this.n_slides - 1) {
                 ++this.current_slide_number;
-
-                // if the next slide is also a new user slide
-                if (this.current_slide_number == this.metadata.user_slide_to_real_slide(this.current_user_slide_number + 1)) {
-                    ++this.current_user_slide_number;
-                }
+                this.current_user_slide_number = this.metadata.real_slide_to_user_slide(this.current_slide_number);
 
                 if (!this.frozen) {
                     this.faded_to_black = false;
@@ -893,12 +889,8 @@ namespace pdfpc {
             this.timer.start();
 
             if (this.current_slide_number > 0) {
-                if (this.current_slide_number == this.metadata.user_slide_to_real_slide(this.current_user_slide_number)) {
-                    --this.current_user_slide_number;
-                    this.current_slide_number = this.metadata.user_slide_to_real_slide(this.current_user_slide_number);
-                } else {
-                    --this.current_slide_number;
-                }
+                --this.current_slide_number;
+                this.current_user_slide_number = this.metadata.real_slide_to_user_slide(this.current_slide_number);
 
                 if (!this.frozen) {
                     this.faded_to_black = false;


### PR DESCRIPTION
The "previous slide" action does currently not actually go back one page in the PDF, but returns to the beginning of the previous user slide. This change fixes that behaviour.

With open PR #141 in mind I've also changed how the "next page" command is implemented - namely, I've replaced the logic in both with the easiest/most robust variant: Increase or decrease the page number, then use the `real_slide_to_user_slide` API to recalculate the associated user slide.