### PR TITLE
Fix progress bar display in Linux Mint

### DIFF
--- a/rc/pdfpc.css
+++ b/rc/pdfpc.css
@@ -22,12 +22,12 @@ progressbar trough {
     background-color: white;
 }
 
-GtkProgressBar * {
-    background-color: blue;
-}
-
 GtkProgressBar {
     background-color: white;
+}
+
+GtkProgressBar * {
+    background-color: blue;
 }
 
 /* The bottom text is automatically sized based on the resolution of


### PR DESCRIPTION
In the default Linux Mint theme, the progress bar does not work since  488d289d090b1bf3dd9e30accbc5d1b3844378ea. Instead of displaying progress, an all-white, completely filled progress bar is shown.

Replacing the order of the two definitions for the GtkProgressBar in the CSS fixes the progress bar for me:

    GtkProgressBar {
        background-color: white;
    }

    GtkProgressBar * {
        background-color: blue;
    }

**I did not test whether this breaks display in other GTK'ish themes/window managers/versions!**