### PR TITLE
Add SHIFT modifier for overview window

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -167,6 +167,22 @@ Reset presentation (reset timer and go back to first slide)
 .TP
 .B e
 Define end slide
+
+.P
+Within overview mode the following key bindings are used
+.TP
+.B Return / Left mouse button
+Goto currently selected page (last page of overlay)
+.TP
+.B Shift + Return / Shift + Left mouse button
+Goto currently selected page (first page of overlay)
+.TP
+.B Cursor left / Page up
+Select previous slide
+.TP
+.B Cursor right / Page down
+Select next slide
+
 .P
 See
 .B CONFIG FILE

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -443,9 +443,12 @@ namespace pdfpc.Metadata {
 
         /**
          * Transform from user slide numbers to real slide numbers
+         *
+         * If lastSlide is true, the last page of an overlay will be return,
+         * otherwise, the first one
          */
-        public int user_slide_to_real_slide(int number) {
-            if (number + 1 < user_view_indexes.length) {
+        public int user_slide_to_real_slide(int number, bool lastSlide = true) {
+            if (lastSlide && number + 1 < user_view_indexes.length) {
                 return this.user_view_indexes[number+1] - 1;
             } else if (number < user_view_indexes.length) {
                 return this.user_view_indexes[number];

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -995,7 +995,7 @@ namespace pdfpc {
         /**
          * Goto a slide in user page numbers. page_number is 1 indexed.
          */
-        public void goto_user_page(int page_number) {
+        public void goto_user_page(int page_number, bool useLast = true) {
             this.timer.start();
 
             if (this.current_user_slide_number != page_number - 1) {
@@ -1011,7 +1011,7 @@ namespace pdfpc {
                 destination = n_user_slides - 1;
             }
             this.current_user_slide_number = destination;
-            this.current_slide_number = this.metadata.user_slide_to_real_slide(this.current_user_slide_number);
+            this.current_slide_number = this.metadata.user_slide_to_real_slide(this.current_user_slide_number, useLast);
             if (!this.frozen) {
                 this.faded_to_black = false;
             }

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -355,7 +355,9 @@ namespace pdfpc.Window {
                     handled = true;
                     break;
                 case 0xff0d: /* Return */
-                    this.presentation_controller.goto_user_page(this.current_slide + 1);
+                    bool gotoFirst = (key.state & Gdk.ModifierType.SHIFT_MASK) != 0;
+                    this.presentation_controller.goto_user_page(this.current_slide + 1, !gotoFirst);
+                    handled = true;
                     break;
             }
 
@@ -379,8 +381,10 @@ namespace pdfpc.Window {
          * a drag, the current slide will have been updated by the motion.
          */
         public bool on_mouse_release(Gdk.EventButton event) {
-            if (event.button == 1)
-                this.presentation_controller.goto_user_page(this.current_slide + 1);
+            if (event.button == 1) {
+                bool gotoFirst = (event.state & Gdk.ModifierType.SHIFT_MASK) != 0;
+                this.presentation_controller.goto_user_page(this.current_slide + 1, !gotoFirst);
+            }
             return false;
         }
     }


### PR DESCRIPTION
If the user presses SHIFT to select a slide in overview mode, the
first slide of an overlay will be displayed (instead of the last)