### PR TITLE
Print metadata to stderr if storing to disk fails

### DIFF
--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -229,7 +229,7 @@ namespace pdfpc.Metadata {
                     GLib.FileUtils.set_contents(this.pdfpc_fname, contents);
                 }
             } catch (Error e) {
-                GLib.printerr("%s\n", e.message);
+                GLib.printerr("Failed to store metadata on disk: %s\nThe metadata was:\n\n%s", e.message, contents);
                 Process.exit(1);
             }
         }


### PR DESCRIPTION
Same idea as in #201: If for some reason storing slide nodes fails, they should be printed to stderr to prevent users from loosing their data. This commit introduces the appropriate change if an error occurs while actually writing to disk, e.g., if the directory is write protected.