### PR TITLE
Add hiding of presentation window

### DIFF
--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -1,5 +1,6 @@
 install(FILES
     blank.svg
+    hidden.svg
     snow.svg
     pause.svg
 DESTINATION

--- a/icons/hidden.svg
+++ b/icons/hidden.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="362"
+   height="342"
+   bbheight="341.57421875"
+   bbwidth="361.765625"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.0 r15299"
+   sodipodi:docname="hidden.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="915"
+     inkscape:window-height="1161"
+     id="namedview79"
+     showgrid="false"
+     inkscape:zoom="1.0276042"
+     inkscape:cx="186.46788"
+     inkscape:cy="130.78528"
+     inkscape:window-x="2601"
+     inkscape:window-y="37"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:pagecheckerboard="true">
+    <sodipodi:guide
+       orientation="0,1"
+       position="-34.274681,270.38915"
+       id="guide3948"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7164"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7162" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata7">image/svg+xml<rdf:RDF>
+  <cc:Work
+     rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+    <dc:title></dc:title>
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+  <g
+     style="display:inline"
+     label="Layer 1"
+     id="layer1"
+     transform="translate(-14.802243,-81.746591)"
+     display="inline" />
+  <rect
+     style="fill:#000000;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dashoffset:0;stroke:none;stroke-opacity:1;fill-opacity:1"
+     id="rect3313"
+     width="313.09097"
+     height="247.18306"
+     x="22.871443"
+     y="46.521236"
+     stroke-miterlimit="4" />
+  <rect
+     style="fill:none;stroke-width:15.9;stroke-miterlimit:4;stroke-dashoffset:0;stroke:#ffffff;stroke-opacity:1;stroke-dasharray:47.7, 15.90000000000000036"
+     id="rect3325"
+     width="274.9968"
+     height="200.1311"
+     x="41.918526"
+     y="69.610847"
+     stroke-miterlimit="4" />
+</svg>

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -151,6 +151,9 @@ Exit pdfpc
 .B b
 Turn off the presentation view (i.e.  fill it with a black color)
 .TP
+.B h
+Hide the presentation vindow (i.e. make other windows on the other screen visible)
+.TP
 .B n
 Edit note for current slide
 .TP

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -42,6 +42,7 @@ bind R         reset
 bind b         blank
 bind period    blank
 bind f         freeze
+bind h         hide
 
 # Presentation properties
 bind n         note

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -55,6 +55,11 @@ namespace pdfpc {
         public bool faded_to_black { get; protected set; default = false; }
 
         /**
+         * Stores if the view is hidden
+         */
+        public bool hidden { get; protected set; default = false; }
+
+        /**
          * Stores if the view is frozen
          */
         public bool frozen { get; protected set; default = false; }
@@ -492,6 +497,7 @@ namespace pdfpc {
                 if (!this.frozen)
                     this.toggle_freeze();
                 });
+            add_action("hide", this.hide_presentation);
 
             add_action("overlay", this.toggle_skip);
             add_action("note", this.controllables_edit_note);
@@ -1110,6 +1116,14 @@ namespace pdfpc {
          */
         protected void fade_to_black() {
             this.faded_to_black = !this.faded_to_black;
+            this.controllables_update();
+        }
+
+        /**
+         * Hide the presentation window
+         */
+        protected void hide_presentation() {
+            this.hidden = !this.hidden;
             this.controllables_update();
         }
 

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -99,6 +99,8 @@ namespace pdfpc.Window {
          * Update the display
          */
         public void update() {
+            this.visible = !this.presentation_controller.hidden;
+
             if (this.presentation_controller.faded_to_black) {
                 this.view.fade_to_black();
                 return;

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -82,6 +82,11 @@ namespace pdfpc.Window {
         protected Gtk.Image blank_icon;
 
         /**
+         * Indication that the presentation window is hidden
+         */
+        protected Gtk.Image hidden_icon;
+
+        /**
          * Indication that the presentation display is frozen
          */
         protected Gtk.Image frozen_icon;
@@ -262,6 +267,7 @@ namespace pdfpc.Window {
             int icon_height = (int)Math.round(bottom_height*0.9);;
 
             this.blank_icon = this.load_icon("blank.svg", icon_height);
+            this.hidden_icon = this.load_icon("hidden.svg", icon_height);
             this.frozen_icon = this.load_icon("snow.svg", icon_height);
             this.pause_icon = this.load_icon("pause.svg", icon_height);
 
@@ -344,6 +350,7 @@ namespace pdfpc.Window {
 
             var status = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 2);
             status.pack_start(this.blank_icon, false, false, 0);
+            status.pack_start(this.hidden_icon, false, false, 0);
             status.pack_start(this.frozen_icon, false, false, 0);
             status.pack_start(this.pause_icon, false, false, 0);
 
@@ -445,6 +452,12 @@ namespace pdfpc.Window {
                 this.blank_icon.show();
             else
                 this.blank_icon.hide();
+            if (this.presentation_controller.hidden) {
+                this.hidden_icon.show();
+                // Ensure the presenter window remains focused
+                this.present();
+            } else
+                this.hidden_icon.hide();
             if (this.presentation_controller.frozen)
                 this.frozen_icon.show();
             else


### PR DESCRIPTION
When 'h' key is pressed the visibility of the presentation window is
toggled.

This functionality allows me to interrupt the presentation, show live
examples and quickly continue the presentation. Without this, I had to
quit pdfpc, show the example and than start pdfpc again and manually
navigate to the last slide.