### PR TITLE
Extend the GTK legacy condition for compiling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if (MOVIES)
     )
 endif ()
 
-if ("${GTK_VERSION}" LESS 3.18)
+if ("${GTK_VERSION}" LESS 3.18 OR "${VALA_VERSION}" LESS 0.30)
     message(WARNING "Using legacy GTK API")
     set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D GTK_LEGACY)
 endif ()


### PR DESCRIPTION
Also check the valac version for gtk legacy mode. Older valac version
might not have the bindings for newer gtk apis.