### PR TITLE
Allow session save/restore

### DIFF
--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -2,6 +2,8 @@ install(FILES
     blank.svg
     snow.svg
     pause.svg
+    saved.svg
+    loaded.svg
 DESTINATION
     share/pixmaps/pdfpc
 )

--- a/icons/loaded.svg
+++ b/icons/loaded.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="362"
+   height="342"
+   bbheight="341.57421875"
+   bbwidth="361.765625"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="loaded.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1416"
+     id="namedview79"
+     showgrid="false"
+     inkscape:zoom="1.050338"
+     inkscape:cx="-507.11844"
+     inkscape:cy="196.69141"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       orientation="0,1"
+       position="-34.274681,270.38915"
+       id="guide3948" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">image/svg+xml<rdf:RDF>
+  <cc:Work
+     rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+  <g
+     style="display:inline"
+     label="Layer 1"
+     id="layer1"
+     transform="translate(-14.802243,-81.746591)"
+     display="inline" />
+  <rect
+     style="fill:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dashoffset:0"
+     id="rect3313"
+     width="313.09097"
+     height="247.18306"
+     x="22.871443"
+     y="46.521236"
+     stroke-miterlimit="4" />
+  <rect
+     style="fill:#000000;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dashoffset:0"
+     id="rect3325"
+     width="274.9968"
+     height="200.1311"
+     x="41.918526"
+     y="69.610847"
+     stroke-miterlimit="4" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:16.74287224px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="57.740185"
+     y="178.25702"
+     id="text4140"
+     sodipodi:linespacing="125%"
+     transform="scale(0.92078637,1.0860282)"><tspan
+       sodipodi:role="line"
+       id="tspan4142"
+       x="57.740185"
+       y="178.25702"
+       style="font-size:75.3429184px;fill:#ffffff">Loaded</tspan></text>
+</svg>

--- a/icons/saved.svg
+++ b/icons/saved.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="362"
+   height="342"
+   bbheight="341.57421875"
+   bbwidth="361.765625"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="save.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1416"
+     id="namedview79"
+     showgrid="false"
+     inkscape:zoom="1.050338"
+     inkscape:cx="-288.61735"
+     inkscape:cy="196.69141"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       orientation="0,1"
+       position="-34.274681,270.38915"
+       id="guide3948" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">image/svg+xml<rdf:RDF>
+  <cc:Work
+     rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+  <g
+     style="display:inline"
+     label="Layer 1"
+     id="layer1"
+     transform="translate(-14.802243,-81.746591)"
+     display="inline" />
+  <rect
+     style="fill:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dashoffset:0"
+     id="rect3313"
+     width="313.09097"
+     height="247.18306"
+     x="22.871443"
+     y="46.521236"
+     stroke-miterlimit="4" />
+  <rect
+     style="fill:#000000;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dashoffset:0"
+     id="rect3325"
+     width="274.9968"
+     height="200.1311"
+     x="41.918526"
+     y="69.610847"
+     stroke-miterlimit="4" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:18.18323135px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="51.944496"
+     y="193.59215"
+     id="text4140"
+     sodipodi:linespacing="125%"><tspan
+       sodipodi:role="line"
+       id="tspan4142"
+       x="51.944496"
+       y="193.59215"
+       style="font-size:81.82453918px;fill:#ffffff">Saved</tspan></text>
+</svg>

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -170,6 +170,16 @@ Reset presentation (reset timer and go back to first slide)
 .TP
 .B e
 Define end slide
+.TP
+.B R
+Restore last saved session. Goto the slide which was saved with
+.B S
+before
+.TP
+.B S
+Save the current session. Store the current slide in the
+.B .pdfpc
+file for later usage
 
 .P
 Within overview mode the following key bindings are used

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -47,6 +47,8 @@ bind f         freeze
 bind n         note
 bind o         overlay
 bind e         endSlide
+bind S+s       lastSlide
+bind S+r       jumpLastSlide
 
 # Font scaling
 bind plus      increaseFontSize

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -11,6 +11,7 @@
  * Copyright 2013 Stefan Tauner
  * Copyright 2015 Maurizio Tomasi
  * Copyright 2015 endzone
+ * Copyright 2017 Olivier Pantalé
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -90,6 +91,11 @@ namespace pdfpc.Metadata {
         private int end_user_slide = -1;
 
         /**
+         * The "last displayed" defined by the user
+         */
+        private int last_saved_slide = -1;
+
+        /**
          * Were the skips modified by the user?
          */
         protected bool skips_by_user;
@@ -150,6 +156,10 @@ namespace pdfpc.Metadata {
                         }
                         case "[font_size]": {
                             this.font_size = int.parse(section_content);
+                            break;
+                        }
+                        case "[last_saved_slide]": {
+                            this.last_saved_slide = int.parse(section_content);
                             break;
                         }
                         case "[last_minutes]": {
@@ -254,6 +264,7 @@ namespace pdfpc.Metadata {
             string contents =   format_command_line_options()
                               + format_skips()
                               + format_end_user_slide()
+			      + format_last_saved_slide()
                               + format_font_size()
                               + format_notes();
             try {
@@ -292,6 +303,15 @@ namespace pdfpc.Metadata {
             string contents = "";
             if (this.end_user_slide >= 0) {
                 contents += "[end_user_slide]\n%d\n".printf(this.end_user_slide);
+            }
+
+            return contents;
+        }
+
+        protected string format_last_saved_slide() {
+            string contents = "";
+            if (this.last_saved_slide >= 0) {
+                contents += "[last_saved_slide]\n%d\n".printf(this.last_saved_slide);
             }
 
             return contents;
@@ -446,6 +466,21 @@ namespace pdfpc.Metadata {
         }
 
         /**
+         * Return the last displayed slide defined by the user. It may be different as
+         * get_user_slide_count()!
+         */
+        public int get_last_saved_slide() {
+            return this.last_saved_slide;
+        }
+
+        /**
+         * Set the last slide defined by the user
+         */
+        public void set_last_saved_slide(int slide) {
+            this.last_saved_slide = slide;
+        }
+
+         /**
          * Toggle the skip flag for one slide
          *
          * We require to be provided also with the user_slide_number, as this

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -11,6 +11,7 @@
  * Copyright 2012 Thomas Tschager
  * Copyright 2015 Andreas Bilke
  * Copyright 2015 Andy Barry
+ * Copyright 2017 Olivier Pantalé
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -496,6 +497,8 @@ namespace pdfpc {
             add_action("overlay", this.toggle_skip);
             add_action("note", this.controllables_edit_note);
             add_action("endSlide", this.set_end_user_slide);
+            add_action("lastSlide", this.set_last_saved_slide);
+            add_action("jumpLastSlide", this.goto_last_saved_slide);
 
             add_action("increaseFontSize", this.increase_font_size);
             add_action("decreaseFontSize", this.decrease_font_size);
@@ -539,6 +542,8 @@ namespace pdfpc {
                 "overlay", "Mark current slide as overlay slide",
                 "note", "Edit note for current slide",
                 "endSlide", "Set current slide as end slide",
+                "lastSlide", "Set last displayed slide",
+                "jumpLastSlide", "Goto last displayed slide",
                 "increaseFontSize", "Increase the current font size by 10%",
                 "decreaseFontSize", "Decrease the current font size by 10%",
                 "togglePointer", "Toggle pointer mode",
@@ -718,6 +723,23 @@ namespace pdfpc {
         public void set_end_user_slide_overview() {
             int user_selected = this.overview.current_slide;
             this.metadata.set_end_user_slide(user_selected + 1);
+        }
+
+        /**
+         * Set the last slide as defined by the user
+         */
+        public void set_last_saved_slide() {
+            this.metadata.set_last_saved_slide(this.current_user_slide_number + 1);
+            this.controllables_update();
+	    presenter.session_saved();
+        }
+
+        /**
+         * Set the last slide as defined by the user
+         */
+        public void set_last_saved_slide_overview() {
+            int user_selected = this.overview.current_slide;
+            this.metadata.set_last_saved_slide(user_selected + 1);
         }
 
         /**
@@ -947,6 +969,29 @@ namespace pdfpc {
                 this.faded_to_black = false;
             }
             this.controllables_update();
+        }
+
+        /**
+         * Go to the last displayed slide
+         */
+        public void goto_last_saved_slide() {
+
+            if (this.metadata.get_last_saved_slide() == -1) {
+                return;
+            }
+
+            // Start the timer
+            this.timer.start();
+
+            this.current_user_slide_number = this.metadata.get_last_saved_slide() - 1;
+            this.current_slide_number = this.metadata.user_slide_to_real_slide(this.current_user_slide_number);
+
+            if (!this.frozen) {
+                this.faded_to_black = false;
+            }
+
+            this.controllables_update();
+            presenter.session_loaded();
         }
 
         /**

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -10,6 +10,7 @@
  * Copyright 2013 Gabor Adam Toth
  * Copyright 2015-2016 Andy Barry
  * Copyright 2015 Jeremy Maitin-Shepard
+ * Copyright 2017 Olivier Pantalé
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -90,6 +91,16 @@ namespace pdfpc.Window {
          * Indication that the timer is paused
          */
         protected Gtk.Image pause_icon;
+
+        /**
+         * Indication that the slide is saved
+         */
+        protected Gtk.Image saved_icon;
+
+        /**
+         * Indication that the slide position has been loaded
+         */
+        protected Gtk.Image loaded_icon;
 
         /**
          * Text box for displaying notes for the slides
@@ -264,6 +275,8 @@ namespace pdfpc.Window {
             this.blank_icon = this.load_icon("blank.svg", icon_height);
             this.frozen_icon = this.load_icon("snow.svg", icon_height);
             this.pause_icon = this.load_icon("pause.svg", icon_height);
+            this.saved_icon = this.load_icon("saved.svg", icon_height);
+            this.loaded_icon = this.load_icon("loaded.svg", icon_height);
 
             this.add_events(Gdk.EventMask.KEY_PRESS_MASK);
             this.add_events(Gdk.EventMask.BUTTON_PRESS_MASK);
@@ -346,6 +359,8 @@ namespace pdfpc.Window {
             status.pack_start(this.blank_icon, false, false, 0);
             status.pack_start(this.frozen_icon, false, false, 0);
             status.pack_start(this.pause_icon, false, false, 0);
+            status.pack_start(this.saved_icon, false, false, 0);
+            status.pack_start(this.loaded_icon, false, false, 0);
 
             this.timer.halign = Gtk.Align.CENTER;
             this.timer.valign = Gtk.Align.END;
@@ -401,6 +416,14 @@ namespace pdfpc.Window {
             return icon;
         }
 
+        public void session_saved() {
+            this.saved_icon.show();
+        }
+
+        public void session_loaded() {
+            this.loaded_icon.show();
+        }
+
         /**
          * Update the slide count view
          */
@@ -450,6 +473,8 @@ namespace pdfpc.Window {
             else
                 this.frozen_icon.hide();
             this.faded_to_black = false;
+ 	    this.saved_icon.hide();
+ 	    this.loaded_icon.hide();
         }
 
         /**


### PR DESCRIPTION
A user can now store the current visited slide in pdfpc file and
resume this state later (e.g. on the next day)