### PR TITLE
Timer pace color

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -266,20 +266,40 @@ If a duration is given (\-d option), the timer will show a countdown with the
 given parameters.  If no duration is specified (or if a value of 0 is given to
 the \-d option), the timer will show how much time has been spent.  The duration
 is stored automatically, so you do not need to repeat it for every invocation.
-
 .PP
 The timer is started if you are navigating away from the first page for the
 first time.  This feature is quite useful as you may want to show the title page
 of your presentation while people are still entering the room and the
 presentation has not really begun yet.  If you want to start over you can
 use the \[aq]r\[aq] key which will make the presenter reset the timer.
-
 .PP
-If a duration is given, at the moment the timer reaches the defined
-last-minutes value it will change color to indicate your talk is nearing its
-end.  As soon as the timer reaches the zero mark (00:00:00) it will turn red
-and count further down showing a negative time, to provide information on how
-many minutes you are overtime.
+If a duration is given, the timer also provides hints aiding the presenter to
+judge whether the talk would end on time.  There are two modes in which pdfpc
+can operate.  In the old (and the only one available up to, and including
+pdfpc-4.0.8) mode, at the moment the timer reaches the defined last-minutes
+value it will change color to indicate your talk is nearing its end, thus
+mimicking a chairman frantically pantomiming in front of you with five (four,
+three, ...) fingers up.  A drawback of this approach is it is often
+too late at that moment to alter the presentation pace without ruining to some
+extent the rest of the talk.  On the other hand, the warning indication provides
+an unnecessary distraction if you have been perfectly conveying the talk and the
+remaining time is adequate.
+.PP
+Contrary to that, in the new (default) mode, pdfpc tracks your progress
+continuously, calculating the expected time as
+(talk_duration)*(current_user_slide_number - 0.5)/(total_number_of_user_slides)
+and comparing it to the actual wall time since beginning of the talk.  If
+these two numbers differ by more than 60 seconds, the timer changes its color to
+either orange (indicating you need to speed up) or a blueish one (need to slow
+down).  Once the optimal progress is recovered, the timer becomes white again.
+In this mode, the last-minutes option (-l) has no effect.  The previous
+behavior can be restored by setting the 'timer-pace-color' option to 'false' in
+the configuration file, see
+.B pdfpcrc(5).
+.PP
+In any case, as soon as the timer reaches the zero mark (00:00:00), it will turn
+red and count further down showing a negative time, to provide information on
+how many minutes you are overtime.
 
 .SS Notes
 

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -83,6 +83,12 @@ Switch the presentation and the presenter screen. (bool, Default false)
 .B time-of-day
 see
 .B pdfpcrc(5)
+.TP
+.B timer-pace-color
+Enable color hints of the timer, continuously indicating whether the
+presentation is progressing according to the expected pace (bool, Default true).
+See the timer operation description in
+.B pdfpc(1).
 
 .SH EXAMPLES
 

--- a/rc/pdfpc.css
+++ b/rc/pdfpc.css
@@ -63,6 +63,14 @@ entry, iconview, textview *, window {
     color: red;
 }
 
+.too-fast {
+    color: steelblue;
+}
+
+.too-slow {
+    color: orange;
+}
+
 .overviewWindow {
     font-size: 4em;
 }

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -273,9 +273,7 @@ namespace pdfpc {
                     break;
                 case "timer-pace-color":
                     bool timer_pace_color = bool.parse(fields[2]);
-                    if (timer_pace_color) {
-                        Options.timer_pace_color = true;
-                    }
+                    Options.timer_pace_color = timer_pace_color;
                     break;
                 default:
                     GLib.printerr("Unknown option %s in pdfpcrc\n", fields[1]);

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -271,6 +271,12 @@ namespace pdfpc {
                         Options.use_time_of_day = true;
                     }
                     break;
+                case "timer-pace-color":
+                    bool timer_pace_color = bool.parse(fields[2]);
+                    if (timer_pace_color) {
+                        Options.timer_pace_color = true;
+                    }
+                    break;
                 default:
                     GLib.printerr("Unknown option %s in pdfpcrc\n", fields[1]);
                     break;

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -123,6 +123,12 @@ namespace pdfpc {
         public static bool use_time_of_day = false;
 
         /**
+         * Use the new coloring mode of the timer according to the actual
+         * progress
+         */
+        public static bool timer_pace_color = false;
+
+        /**
          * Time the talk should end
          */
         public static string? end_time = null;

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -126,7 +126,7 @@ namespace pdfpc {
          * Use the new coloring mode of the timer according to the actual
          * progress
          */
-        public static bool timer_pace_color = false;
+        public static bool timer_pace_color = true;
 
         /**
          * Time the talk should end

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -281,8 +281,10 @@ namespace pdfpc {
                 Options.duration = 0;
                 this.metadata.set_duration(0);
             }
-            this.timer = getTimerLabel((int) this.metadata.get_duration() * 60,
-                end_time, Options.last_minutes, start_time, Options.use_time_of_day);
+            this.timer = getTimerLabel(this,
+                (int) this.metadata.get_duration() * 60,
+                end_time, Options.last_minutes, start_time,
+                Options.use_time_of_day);
             this.timer.reset();
 
             this.n_slides = (int) this.metadata.get_slide_count();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -268,23 +268,13 @@ namespace pdfpc {
             this.history = new Gee.ArrayQueue<int>();
             this.user_slide_progress = new int[metadata.get_user_slide_count()];
 
-            // Calculate the countdown to display until the presentation has to
-            // start
-            time_t start_time = 0;
-            if (Options.start_time != null) {
-                start_time = this.parseTime(Options.start_time);
-            }
-            // The same again for end_time
-            time_t end_time = 0;
+            // If end_time is set, reset duration to 0
             if (Options.end_time != null) {
-                end_time = this.parseTime(Options.end_time);
                 Options.duration = 0;
                 this.metadata.set_duration(0);
             }
             this.timer = getTimerLabel(this,
-                (int) this.metadata.get_duration() * 60,
-                end_time, Options.last_minutes, start_time,
-                Options.use_time_of_day);
+                (int) this.metadata.get_duration() * 60);
             this.timer.reset();
 
             this.n_slides = (int) this.metadata.get_slide_count();
@@ -1686,15 +1676,6 @@ namespace pdfpc {
             if (this.timer.is_paused()) {
                 this.toggle_pause();
             }
-        }
-
-        /**
-         * Parse the given time string to a Time object
-         */
-        private time_t parseTime(string t) {
-            var tm = Time.local(time_t());
-            tm.strptime(t + ":00", "%H:%M:%S");
-            return tm.mktime();
         }
 
 

--- a/src/classes/timer_label.vala
+++ b/src/classes/timer_label.vala
@@ -234,7 +234,6 @@ namespace pdfpc {
                         context.add_class("last-minutes");
                 } else {
                     // Time is over!
-                    context.remove_class("last-minutes");
                     context.add_class("overtime");
                     timeInSecs = this.time - duration;
 

--- a/src/classes/timer_label.vala
+++ b/src/classes/timer_label.vala
@@ -55,7 +55,7 @@ namespace pdfpc {
         if (Options.end_time != null) {
             end_time = parseTime(Options.end_time);
         }
-        
+
         if (Options.use_time_of_day) {
             return new TimeOfDayTimer(controller);
         } else if (end_time > 0) {
@@ -260,21 +260,19 @@ namespace pdfpc {
                     if (Options.timer_pace_color) {
                         // New indication of too slow/fast pace independently
                         // of the time left.
-                        
                         int current_slide_number =
                             this.controller.current_user_slide_number;
                         int slide_count = this.controller.user_n_slides;
-                        
+
                         // Assuming we're in the middle of the current slide
                         double expected_progress =
                             (current_slide_number + 0.5)/slide_count;
-                        
+
                         int expected_time = (int) (duration*expected_progress);
-                        
+
                         if (this.time > expected_time + 60) {
                             context.add_class("too-slow");
-                        } else 
-                        if (this.time < expected_time - 60) {
+                        } else if (this.time < expected_time - 60) {
                             context.add_class("too-fast");
                         } else {
                             context.remove_class("too-fast");
@@ -363,7 +361,7 @@ namespace pdfpc {
         public TimeOfDayTimer(PresentationController controller) {
             base(controller);
         }
-        
+
         /**
          * Just start the timer if is not running
          */

--- a/src/classes/timer_label.vala
+++ b/src/classes/timer_label.vala
@@ -28,17 +28,38 @@
 namespace pdfpc {
 
     /**
+     * Parse the given time string to a Time object
+     */
+    time_t parseTime(string t) {
+        var tm = Time.local(time_t());
+        tm.strptime(t + ":00", "%H:%M:%S");
+        return tm.mktime();
+    }
+
+    /**
       * Factory function for creating TimerLabels, depending if a duration was
       * given.
       */
-    TimerLabel getTimerLabel(PresentationController controller,
-        int duration, time_t end_time, uint last_minutes = 0,
-        time_t start_time = 0, bool clock_time = false) {
+    TimerLabel getTimerLabel(PresentationController controller, int duration) {
+
+        uint last_minutes = Options.last_minutes;
+
+        // Calculate the countdown to display until the presentation has to
+        // start
+        time_t start_time = 0;
+        if (Options.start_time != null) {
+            start_time = parseTime(Options.start_time);
+        }
+        // The same again for end_time
+        time_t end_time = 0;
+        if (Options.end_time != null) {
+            end_time = parseTime(Options.end_time);
+        }
         
-        if (clock_time) {
+        if (Options.use_time_of_day) {
             return new TimeOfDayTimer(controller);
         } else if (end_time > 0) {
-            return new EndTimeTimer(controller, end_time, last_minutes, start_time);
+            return new EndTimeTimer(controller, end_time, -last_minutes, start_time);
         } else if (duration > 0) {
             return new CountdownTimer(controller, duration, last_minutes, start_time);
         } else {


### PR DESCRIPTION
Hello,
I see three problems with the current "last-minutes" timer color warning:

1. If one has too many slides left when only 5 (default) minutes are there to cover, the result is either skipping potentially important material or jumping nervously too fast, or both.
2. If, on the other hand, the pace has been fine and the remaining 5 minutes are completely adequate for the rest of the slides to show, this visual warning is unnecessarily distracting.
3. There is no indication if one "runs" too fast.

What I suggest is to have a continuous indication of "being on time" so one has the chance of fixing it before it is too late. To this end, an alternative timer colorization mode is introduced. If enabled (currently via the "timer-pace-color" boolean config file option), pdfpc compares the actual progress to the expected one (assuming equal time per user page). If the difference is more than one minute (perhaps should be made adjustable), the timer color changes to either orange (one needs to accelerate) or a blueish one (should slow down).

Please let me know if you like this approach. If yes, I will update the man pages. Note that I had to include PresentationController in the TimerLabel class to have access to the current page number.