### PR TITLE
PDF annotations as notes

### DIFF
--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -4,6 +4,7 @@ install(FILES
     pause.svg
     saved.svg
     loaded.svg
+    locked.svg
     highlight.svg
     pen.svg
     eraser.svg

--- a/icons/README.icons
+++ b/icons/README.icons
@@ -4,3 +4,6 @@ pen.svg, highlight.svg, eraser.svg icons by Charles Reiss
 
 snow.svg based on icon by bocian
 (http://openclipart.org/detail/30829/snowflake-by-bocian)
+
+locked.svg based on document-encrypted.svg from
+https://github.com/KDE/breeze-icons

--- a/icons/locked.svg
+++ b/icons/locked.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <defs id="defs3051">
+    <style type="text/css" id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#f0f0f0;
+      }
+      </style>
+  </defs>
+ <path style="fill:currentColor;fill-opacity:1;stroke:none" 
+     d="M 8,2 C 6.3431375,2 5,3.3431372 5,5 l 0,3 -2,0 0,6 10,0 0,-6 -2,0 0,-3 C 11,3.3431372 9.6568625,2 8,2 Z m 0,1 c 1.1045695,0 2,0.8954305 2,2 L 10,8 6,8 6,5 C 6,3.8954305 6.8954305,3 8,3 Z"
+     class="ColorScheme-Text"
+     />
+</svg>

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -318,7 +318,9 @@ i.e. you are not able to change slides. These notes are stored in the .pdfpc
 file in a plain text format, easy to edit also from outside the program; see
 the section about the pdfpc format below.  These notes take precedence over the
 native PDF annotations, i.e., if a user-proveded note exists for a given slide,
-any PDF annotations on that page will be silently ignored.  Although mixing the
+any PDF annotations on that page will be silently ignored.
+.PP
+Although mixing the
 two types of notes is possible, for a given presentation one will likely want to
 have either only the "native" notes (produced by the same PDF authoring software
 used for making the slides), or only the "pdfpc" ones.

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -305,14 +305,23 @@ many minutes you are overtime.
 .SS Notes
 
 .PP
-Textual notes can be displayed for each slide.  While in the presentation mode,
-pressing \[aq]n\[aq] will allow you to take notes for the screen.  To go out of
-the editing mode, press the Escape key.  Note that while editing a note the
-keybindings stop working, i.e.  you are not able to change slides.
-
+Textual notes can be displayed for each slide.  A few types of PDF annotations
+are understood by pdfpc and will be automatically imported and displayed (only
+their textual content, no formatting attributes are preserved).  The PDF
+annotations can be made using many PDF editors and even viewers.  These "native"
+PDF notes cannot be edited in pdfpc.
 .PP
-The notes are stored in the given file in a plain text format, easy to edit
-also from outside the program.  See the section about the pdfpc format below.
+In addition, while in the presentation mode, pressing \[aq]n\[aq] will allow you
+to take notes for the current user slide.  To exit the note editing mode, press
+the Escape key.  Note that while editing a note, the keybindings stop working,
+i.e. you are not able to change slides. These notes are stored in the .pdfpc
+file in a plain text format, easy to edit also from outside the program; see
+the section about the pdfpc format below.  These notes take precedence over the
+native PDF annotations, i.e., if a user-proveded note exists for a given slide,
+any PDF annotations on that page will be silently ignored.  Although mixing the
+two types of notes is possible, for a given presentation one will likely want to
+have either only the "native" notes (produced by the same PDF authoring software
+used for making the slides), or only the "pdfpc" ones.
 
 .SS Overview mode
 

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -373,6 +373,7 @@ namespace pdfpc.Metadata {
                     continue;
                 }
 
+                string note_text = "";
                 List<Poppler.AnnotMapping> anns = page.get_annot_mapping();
                 foreach(unowned Poppler.AnnotMapping am in anns) {
                     var a = am.annot;
@@ -382,11 +383,14 @@ namespace pdfpc.Metadata {
                         case Poppler.AnnotType.HIGHLIGHT:
                         case Poppler.AnnotType.UNDERLINE:
                         case Poppler.AnnotType.SQUIGGLY:
-                            this.notes.set_note(a.get_contents(),
-                                user_slide, true);
+                            if (note_text.length > 0) {
+                                note_text += "\n";
+                            }
+                            note_text += a.get_contents();
                             break;
                     }
                 }
+                this.notes.set_note(note_text, user_slide, true);
             }
         }
 

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -365,15 +365,14 @@ namespace pdfpc.Metadata {
         private void notes_from_document() {
             for (int i = 0; i < this.page_count; i++) {
                 var page = this.document.get_page(i);
-                var user_slide = real_slide_to_user_slide(i);
-                var page_note = this.notes.get_note_for_slide(user_slide);
+                int user_slide = real_slide_to_user_slide(i);
+                string note_text = this.notes.get_note_for_slide(user_slide);
 
                 // We never overwrite existing notes
-                if (page_note != "") {
+                if (note_text != "") {
                     continue;
                 }
 
-                string note_text = "";
                 List<Poppler.AnnotMapping> anns = page.get_annot_mapping();
                 foreach(unowned Poppler.AnnotMapping am in anns) {
                     var a = am.annot;
@@ -390,7 +389,9 @@ namespace pdfpc.Metadata {
                             break;
                     }
                 }
-                this.notes.set_note(note_text, user_slide, true);
+                if (note_text != "") {
+                    this.notes.set_note(note_text, user_slide, true);
+                }
             }
         }
 

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -363,18 +363,27 @@ namespace pdfpc.Metadata {
          * Fill the slide notes from pdf text annotations.
          */
         private void notes_from_document() {
-            for(int i = 0; i < this.page_count; i++) {
+            for (int i = 0; i < this.page_count; i++) {
                 var page = this.document.get_page(i);
+                var user_slide = real_slide_to_user_slide(i);
+                var page_note = this.notes.get_note_for_slide(user_slide);
+
+                // We never overwrite existing notes
+                if (page_note != "") {
+                    continue;
+                }
+
                 List<Poppler.AnnotMapping> anns = page.get_annot_mapping();
                 foreach(unowned Poppler.AnnotMapping am in anns) {
                     var a = am.annot;
-                    switch(a.get_annot_type()) {
+                    switch (a.get_annot_type()) {
                         case Poppler.AnnotType.TEXT:
                         case Poppler.AnnotType.FREE_TEXT:
                         case Poppler.AnnotType.HIGHLIGHT:
                         case Poppler.AnnotType.UNDERLINE:
                         case Poppler.AnnotType.SQUIGGLY:
-                            this.notes.set_note(a.get_contents(), real_slide_to_user_slide(i));
+                            this.notes.set_note(a.get_contents(),
+                                user_slide, true);
                             break;
                     }
                 }

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -370,6 +370,10 @@ namespace pdfpc.Metadata {
                     var a = am.annot;
                     switch(a.get_annot_type()) {
                         case Poppler.AnnotType.TEXT:
+                        case Poppler.AnnotType.FREE_TEXT:
+                        case Poppler.AnnotType.HIGHLIGHT:
+                        case Poppler.AnnotType.UNDERLINE:
+                        case Poppler.AnnotType.SQUIGGLY:
                             this.notes.set_note(a.get_contents(), real_slide_to_user_slide(i));
                             break;
                     }

--- a/src/classes/metadata/slides_notes.vala
+++ b/src/classes/metadata/slides_notes.vala
@@ -49,6 +49,8 @@ namespace pdfpc {
             if (slide_number != -1) {
                 if (notes.length <= slide_number) {
                     notes.resize(slide_number+1);
+                }
+                if (notes[slide_number] == null) {
                     notes[slide_number] = new slide_note();
                 }
                 notes[slide_number].note_text = note_text;
@@ -64,6 +66,14 @@ namespace pdfpc {
                 return "";
             } else {
                 return notes[number].note_text;
+            }
+        }
+
+        public bool is_note_native(int number) {
+            if (number >= notes.length || number < 0 || notes[number] == null) {
+                return false;
+            } else {
+                return notes[number].is_native;
             }
         }
 

--- a/src/classes/metadata/slides_notes.vala
+++ b/src/classes/metadata/slides_notes.vala
@@ -23,6 +23,15 @@
  */
 
 namespace pdfpc {
+    protected class slide_note: Object {
+        public string note_text = null;
+
+        /**
+         * Native PDF annotation flag
+         */
+        public bool is_native = false;
+    }
+
     /**
      * Class for providing storage for the notes associate with a presentation
      */
@@ -30,17 +39,20 @@ namespace pdfpc {
         /**
          * The array where we will store the text of the notes
          */
-        protected string?[] notes = null;
+        protected slide_note?[] notes = null;
 
         /**
          * Set a note for a given slide
          */
-        public void set_note(string note, int slide_number) {
+        public void set_note(string note_text, int slide_number,
+            bool is_native = false) {
             if (slide_number != -1) {
                 if (notes.length <= slide_number) {
                     notes.resize(slide_number+1);
+                    notes[slide_number] = new slide_note();
                 }
-                notes[slide_number] = note;
+                notes[slide_number].note_text = note_text;
+                notes[slide_number].is_native = is_native;
             }
         }
 
@@ -51,15 +63,23 @@ namespace pdfpc {
             if (number >= notes.length || notes[number] == null) {
                 return "";
             } else {
-                return notes[number];
+                return notes[number].note_text;
             }
         }
 
         /**
-         * Does the user want notes?
+         * Are there user-defined notes?
          */
         public bool has_notes() {
-            return notes != null;
+            if (notes != null) {
+                for (int i = 0; i < notes.length; ++i) {
+                    if (notes[i] != null && notes[i].is_native == false) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /**
@@ -71,11 +91,12 @@ namespace pdfpc {
                 // match for ether [, ] or #
                 var escape_regex = new Regex("[\\[\\]#]");
                 for (int i = 0; i < notes.length; ++i) {
-                    if (notes[i] != null) {
+                    if (notes[i] != null && notes[i].is_native == false) {
                         builder.append(@"### $(i+1)\n");
                         // match [,],# and replace it with \[ etc. \0 is the whole match (respectively just [,],#)
                         // escaping escape characters is fun!
-                        var escaped_text = escape_regex.replace(notes[i], notes[i].length, 0, "\\\\\\0");
+                        var note_text = notes[i].note_text;
+                        var escaped_text = escape_regex.replace(note_text, note_text.length, 0, "\\\\\\0");
                         builder.append(escaped_text);
                     }
                 }
@@ -83,7 +104,7 @@ namespace pdfpc {
                 // we failed in formatting the notes for disk storage. put a
                 // raw dump to stderr.
                 for (int i = 0; i < notes.length; ++i) {
-                    GLib.print("### %d\n%s\n", i, notes[i]);
+                    GLib.print("### %d\n%s\n", i, notes[i].note_text);
                 }
 
                 GLib.printerr("Formatting notes for pdfpc file failed.\n");

--- a/src/classes/renderer/pdf.vala
+++ b/src/classes/renderer/pdf.vala
@@ -120,7 +120,8 @@ namespace pdfpc {
             cr.scale(this.scaling_factor, this.scaling_factor);
             cr.translate(-metadata.get_horizontal_offset(this.area),
                 -metadata.get_vertical_offset(this.area));
-            page.render(cr);
+            page.render_for_printing_with_options(cr,
+                Poppler.PrintFlags.DOCUMENT);
 
             // If the cache is enabled store the newly rendered pixmap
             if (this.cache != null) {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -579,10 +579,25 @@ namespace pdfpc.Window {
             }
         }
 
+        private void blink_lock_icon() {
+            this.blank_icon.show();
+            GLib.Timeout.add(1000, () => {
+                    this.blank_icon.hide();
+                    return false;
+                });
+        }
+
         /**
          * Edit a note. Basically give focus to notes_view
          */
         public void edit_note() {
+            // Disallow editing notes imported from PDF annotations
+            int number = this.presentation_controller.current_user_slide_number;
+            if (this.metadata.get_notes().is_note_native(number)) {
+                blink_lock_icon();
+                return;
+            }
+
             this.notes_view.editable = true;
             this.notes_view.cursor_visible = true;
             this.notes_view.grab_focus();

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -103,6 +103,11 @@ namespace pdfpc.Window {
         protected Gtk.Image loaded_icon;
 
         /**
+         * Indication that the notes are read-only (coming from PDF annotations)
+         */
+        protected Gtk.Image locked_icon;
+
+        /**
          * Text box for displaying notes for the slides
          */
         protected Gtk.TextView notes_view;
@@ -298,6 +303,7 @@ namespace pdfpc.Window {
             this.pause_icon = this.load_icon("pause.svg", icon_height);
             this.saved_icon = this.load_icon("saved.svg", icon_height);
             this.loaded_icon = this.load_icon("loaded.svg", icon_height);
+            this.locked_icon = this.load_icon("locked.svg", icon_height);
 
             this.highlight_icon = this.load_icon("highlight.svg", icon_height);
             this.pen_icon = this.load_icon("pen.svg", icon_height);
@@ -394,6 +400,7 @@ namespace pdfpc.Window {
             status.pack_start(this.pause_icon, false, false, 0);
             status.pack_start(this.saved_icon, false, false, 0);
             status.pack_start(this.loaded_icon, false, false, 0);
+            status.pack_start(this.locked_icon, false, false, 0);
             status.pack_start(this.highlight_icon, false, false, 0);
             status.pack_start(this.pen_icon, false, false, 0);
             status.pack_start(this.eraser_icon, false, false, 0);
@@ -529,6 +536,7 @@ namespace pdfpc.Window {
             this.faded_to_black = false;
             this.saved_icon.hide();
             this.loaded_icon.hide();
+            this.locked_icon.hide();
         }
 
         /**
@@ -580,9 +588,9 @@ namespace pdfpc.Window {
         }
 
         private void blink_lock_icon() {
-            this.blank_icon.show();
+            this.locked_icon.show();
             GLib.Timeout.add(1000, () => {
-                    this.blank_icon.hide();
+                    this.locked_icon.hide();
                     return false;
                 });
         }


### PR DESCRIPTION
PR for issue #291. In addition:

1. pdfpc now recognizes more types of PDF annotations;
2. If there are few per page, they will be concatenated;
3. Editing PDF-imported notes is disabled which is indicated by a flashing "lock" icon if 'n' is pressed.