### PR TITLE
Config file option to disable scrolling events

### DIFF
--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -9,18 +9,15 @@
 .SH NAME
 pdfpcrc \- pdfpc configuration file
 
-.SH SYNOPSIS
-.B @SYSCONFDIR@/pdfpcrc / $XDG_CONFIG_DIR/pdfpc/pdfpcrc
-
 .SH DESCRIPTION
 .PP
-pdfpc(1) reads its configuration file from @SYSCONFDIR@/pdfpcrc. It also reads,
-if present, the file $XDG_CONFIG_DIR/pdfpc/pdfpcrc. If $XDG_CONFIG_DIR is not
-set, it uses $HOME/.config .
+pdfpc(1) reads its configuration from @SYSCONFDIR@/pdfpcrc.  It also reads
+$XDG_CONFIG_DIR/pdfpc/pdfpcrc if this file exists (if $XDG_CONFIG_DIR is not
+set, $HOME/.config will be used).
 
 .SS Keybindings
 .PP
-Following commands are aceepted:
+The following commands are accepted:
 .TP
 .B bind <key> <func> [<arg>]
 Bind a key to a function, passing a specified argument for functions which require one
@@ -85,7 +82,6 @@ Switch the presentation and the presenter screen. (bool, Default false)
 .TP
 .B time-of-day
 see
-
 .B pdfpc(1)
 .TP
 .B timer-pace-color
@@ -115,7 +111,6 @@ function, use
 .RS
 bind R reset
 .RE
-
 
 .PP
 To always activate the black-on-end option, one could add the following to the

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -71,6 +71,9 @@ see
 see
 .B pdfpc(1)
 .TP
+.BI disable-scrolling
+Disable scrolling events on the presenter window (bool, Default false)
+.TP
 .B next-height
 Percentage of the height of the presenter screen to be used for the next slide. (int, Default 70)
 .TP

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -251,6 +251,9 @@ namespace pdfpc {
                         Options.disable_cache_compression = true;
                     }
                     break;
+                case "disable-scrolling":
+                    Options.disable_scrolling = bool.parse(fields[2]);
+                    break;
                 case "next-height":
                     Options.next_height = int.parse(fields[2]);
                     break;

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -65,6 +65,10 @@ namespace pdfpc {
         public static bool disable_cache_compression = false;
 
         /**
+         * Config option to disable scrolling events on the presenter window.
+         */
+        public static bool disable_scrolling = false;
+        /**
          * Commandline option to persist the PNG cache to disk.
          */
         public static bool persist_cache = false;

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1004,7 +1004,7 @@ namespace pdfpc {
          * Notify each of the controllables of mouse scrolling
          */
         public bool scroll(Gdk.EventScroll scroll) {
-            if (!this.ignore_mouse_events) {
+            if (!this.ignore_mouse_events && !Options.disable_scrolling) {
                 switch (scroll.direction) {
                     case Gdk.ScrollDirection.UP:
                     case Gdk.ScrollDirection.LEFT:


### PR DESCRIPTION
The mouse I use for presentations has a very soft scroll wheel, so it is too easy to page up/down several slides inadvertently. I first tried to "unmouse 4/5", but it turned out the scrolling events are routed differently from the standard 3 mouse buttons.

(In fact, I don't understand why one would ever use the scrolling, given there is a much more convenient and precise "Overview" mode...)

I also fixed a few minor spelling/style issues in the pdfpcrc man page.