### PR TITLE
A bug in the "pace-color" timer

### DIFF
--- a/src/classes/timer_label.vala
+++ b/src/classes/timer_label.vala
@@ -254,6 +254,8 @@ namespace pdfpc {
                 context.remove_class("pretalk");
                 context.remove_class("last-minutes");
                 context.remove_class("overtime");
+                context.remove_class("too-slow");
+                context.remove_class("too-fast");
                 if (this.time < this.duration) {
                     timeInSecs = duration - this.time;
                     // Still on presentation time


### PR DESCRIPTION
If time runs out in the too-slow/too-fast mode, the overtime mode is not enabled.