### PR TITLE
Add a line break between slide notes in .pdfpc file

### DIFF
--- a/src/classes/metadata/slides_notes.vala
+++ b/src/classes/metadata/slides_notes.vala
@@ -122,6 +122,10 @@ namespace pdfpc {
                         var note_text = notes[i].note_text;
                         var escaped_text = escape_regex.replace(note_text, note_text.length, 0, "\\\\\\0");
                         builder.append(escaped_text);
+                        // ensure there is a line break before the next comment start mark
+                        if (!escaped_text.has_suffix("\n")) {
+                            builder.append("\n");
+                        }
                     }
                 }
             } catch (RegexError e) {


### PR DESCRIPTION
The start mark of a note will now always be in its own line in the .pdfpc file, rather than on the last line of the previous note.
It makes the .pdfpc file easier to read and to edit manually.