### PR TITLE
Fix #351

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -227,8 +227,10 @@ namespace pdfpc {
             }
 
             public uint hash() {
-                var uintHashFunc = Gee.Functions.get_hash_func_for(Type.from_name("uint"));
-                return uintHashFunc(this.keycode | this.modMask); // | is probable the best combinator, but for this small application it should suffice
+                // see gdk/gdkkeysyms.h modMask is usally in the form of
+                // 0xFF??. Keycodes are usally 0x??. We shift modMask by 8 bits
+                // to combine both codes.
+                return (this.modMask << 8) | this.keycode;
             }
 
             public bool equal_to(KeyDef other) {


### PR DESCRIPTION
We had some casting problems when using the
Gee.Functions.get_hash_func_for().

But: the current aproach seems buggy also, since we combine both key
codes with an bitwise OR.

Now we combine both codes without bit overlapping. We also don't need
the get_hash_func_for() approach since we are using uint anyway.