### PR TITLE
Make key bindings less keyboard-dependent

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -146,32 +146,37 @@ Increase font size of notes
 .B Minus / KP_Subtract / Bracket Right
 Decrease font size of notes
 .TP
-.B 8
+.B 8 / KP_8
 Toggle pointer mode
 .TP
-.B 7
+.B 7 / KP_7
 Decrease pointer size
 .TP
-.B 9
+.B 9 / KP_9
 Increase pointer size
 .TP
-.B 5
+.B 5 / KP_5
 Toggle drawing mode
 .TP
-.B 6
+.B 6 / KP_6
 Clear the current drawing
 .TP
-.B 4
+.B 4 / KP_4
 Temporarily hide the current drawing and exit drawing mode
 .TP
-.B 1
+.B 1 / KP_1
 Decrease the pen or eraser size for drawing
 .TP
-.B 3
+.B 3 / KP_3
 Increase the pen or eraser size for drawing
 .TP
-.B 2
+.B 2 / KP_2
 Toggle between the pen and eraser tool for drawing
+.TP
+.B Shift-1 / Shift-KP_2 ... Shift-8 / Shift-KP_8
+Switch the drawing color to red/orange/yellow/green/blue/violet/black/white,
+respectively. (Depending on your keyboard layout, not all options will work
+in the main section of the keyboard.)
 .TP
 .B Escape / q
 Exit pdfpc

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -63,18 +63,27 @@ bind KP_Subtract decreaseFontSize
 bind bracketright decreaseFontSize
 
 # Pointer
-bind 8 togglePointer
-bind 7 decreasePointer
-bind 9 increasePointer
+bind 8         togglePointer
+bind KP_8      togglePointer
+bind 7         decreasePointer
+bind KP_7      decreasePointer
+bind 9         increasePointer
+bind KP_9      increasePointer
 
 # Drawing
-bind 5 toggleDrawing
-bind 6 clearDrawing
-bind 4 hideDrawing
+bind 5         toggleDrawing
+bind KP_5      toggleDrawing
+bind 6         clearDrawing
+bind KP_6      clearDrawing
+bind 4         hideDrawing
+bind KP_4      hideDrawing
 
-bind 1 decreasePen
-bind 2 toggleEraser
-bind 3 increasePen
+bind 1         decreasePen
+bind KP_1      decreasePen
+bind 2         toggleEraser
+bind KP_2      toggleEraser
+bind 3         increasePen
+bind KP_3      increasePen
 
 #### Mouse bindings
 mouse 1        next
@@ -94,11 +103,19 @@ bind S+dead_circumflex setPenColor violet
 bind S+ampersand  setPenColor black
 bind S+asterisk   setPenColor white
 
-bind S+1 setPenColor red
-bind S+2 setPenColor orange
-bind S+3 setPenColor yellow
-bind S+4 setPenColor green
-bind S+5 setPenColor blue
-bind S+6 setPenColor violet
-bind S+7 setPenColor black
-bind S+8 setPenColor white
+bind S+1          setPenColor red
+bind S+KP_1       setPenColor red
+bind S+2          setPenColor orange
+bind S+KP_2       setPenColor orange
+bind S+3          setPenColor yellow
+bind S+KP_3       setPenColor yellow
+bind S+4          setPenColor green
+bind S+KP_4       setPenColor green
+bind S+5          setPenColor blue
+bind S+KP_5       setPenColor blue
+bind S+6          setPenColor violet
+bind S+KP_6       setPenColor violet
+bind S+7          setPenColor black
+bind S+KP_7       setPenColor black
+bind S+8          setPenColor white
+bind S+KP_8       setPenColor white

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -90,6 +90,7 @@ bind S+numbersign setPenColor yellow
 bind S+dollar     setPenColor green
 bind S+percent    setPenColor blue
 bind S+asciicircum setPenColor violet
+bind S+dead_circumflex setPenColor violet
 bind S+ampersand  setPenColor black
 bind S+asterisk   setPenColor white
 

--- a/rc/rcfile-logitech
+++ b/rc/rcfile-logitech
@@ -1,4 +1,4 @@
-# Config file for Logitech Wireless Presetners
+# Config file for Logitech Wireless Presenters
 
 bind Escape exitState
 bind period blank


### PR DESCRIPTION
- Alias dead_circumflex for asciicircum
- Allow numpad, S+numpad as alternatives to numbers on main section (less keyboard-dependent and nicely structured, as if made for the numpad)