### PR TITLE
Update docs related to video support

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -15,12 +15,16 @@ flag. See issue #312 and #214 for more information.
 Embedded video playback is not working.
 =======================================
 
-You likely have a ``gstreamer`` codec issue. Try loading the video file you
-want to play with the following command: ``gst-launch-1.0 filesrc
-location=<your video> ! decodebin !  autovideosink``  If the video plays, go
-ahead and `submit an issue <https://github.com/pdfpc/pdfpc/issues>`_.
-Otherwise, the command will likely output some good hints for why gstreamer
-cannot decode the video.
+You likely have a ``gstreamer`` codec issue. In particular,
+pdfpc uses the "gtksink" ``gstreamer`` plugin. On modern Debian-based systems,
+it is part of the ``gstreamer1.0-gtk3`` package; install it with::
+    sudo apt-get install gstreamer1.0-gtk3
+
+Try loading the video file you want to play with the following command:
+``gst-launch-1.0 filesrc location=<your video> ! decodebin !  autovideosink`` 
+If the video plays, go ahead and `submit an issue
+<https://github.com/pdfpc/pdfpc/issues>`_. Otherwise, the command will likely
+output some good hints for why gstreamer cannot decode the video.
 
 Windows do not appear on the correct screen.
 ============================================

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ requirements need to be met:
 - gstreamer 1.0
 - pangocairo
 
-On Ubuntu systems, you can install these dependencies with::
+On Ubuntu 18.04 onwards, you can install these dependencies with::
 
     sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev gstreamer1.0-gtk3
 

--- a/README.rst
+++ b/README.rst
@@ -88,24 +88,24 @@ requirements need to be met:
 
 On Ubuntu systems, you can install these dependencies with::
 
-    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-bad1.0-dev
+    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev gstreamer1.0-gtk3
 
-and you should consider installing all the available gstreamer codecs::
-
-    sudo apt-get install gstreamer1.0-*
+(the latter is a run-time dependence). You should also consider installing all
+plugins to support required video formats; chances are they are already present
+through dependencies of ``ubuntu-desktop``.
 
 Compiling from source tarballs
 ------------------------------
 
 You can download the latest stable release of pdfpc in the release section of
 github (https://github.com/pdfpc/pdfpc/releases). Uncompress the tarball (we
-use v4.0.2 as an example here)::
+use v4.2.1 as an example here)::
 
-    tar xvf pdfpc-4.0.2.tar.gz
+    tar xvf pdfpc-4.2.1.tar.gz
 
 Change to the extracted directory::
 
-    cd pdfpc-4.0.2
+    cd pdfpc-4.2.1
 
 Compile and install::
 


### PR DESCRIPTION
libgstreamer-plugins-bad1.0-dev is no longer part of the current Ubuntu
LTS, and the previous one isn't supported by us anyway (through the gtk >=
3.20 requirement).