### PR TITLE
specify screens by output name

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -67,6 +67,12 @@ Go to a specific page directly after startup. In case of overlays, the first sli
 .BI "\-R, \-\-pdfpc\-location"=LOCATION
 Use custom pdfpc file.
 .TP
+.BI "\-1, \-\-presenter\-screen"=OUTPUT
+Screen to be used for the presenter (output name, see e.g. "xrandr --listmonitors").
+.TP
+.BI "\-2, \-\-presentation\-screen"=OUTPUT
+Screen to be used for the presentation (output name).
+.TP
 .BI "\-s, \-\-switch\-screens"
 Switch the presentation and the presenter screen.
 .TP

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -95,6 +95,12 @@ Set the pointer opacity in percent (int, default is 50).
 .B pointer-size
 Set the initial pointer size, in pixels (int, default is 10).
 .TP
+.B presentation-screen
+Screen to be used for the presentation (output name, see e.g. "xrandr --listmonitors").
+.TP
+.B presenter-screen
+Screen to be used for the presenter (output name).
+.TP
 .B switch-screens
 Switch the presentation and the presenter screen (bool, Default is false).
 .TP

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -275,6 +275,12 @@ namespace pdfpc {
                 case "pointer-size":
                     Options.pointer_size = int.parse(fields[2]);
                     break;
+                case "presentation-screen":
+                    Options.presentation_screen = fields[2];
+                    break;
+                case "presenter-screen":
+                    Options.presenter_screen = fields[2];
+                    break;
                 case "switch-screens":
                     bool switch_screens = bool.parse(fields[2]);
                     if (switch_screens) {

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -170,6 +170,16 @@ namespace pdfpc {
         public static string? notes_position = null;
 
         /**
+         * Screen to be used for the presentation (output name)
+         */
+        public static string? presentation_screen = null;
+
+        /**
+         * Screen to be used for the presenter (output name)
+         */
+        public static string? presenter_screen = null;
+
+        /**
          * Size of the presenter window
          */
         public static string? size = null;

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -63,6 +63,8 @@ namespace pdfpc {
             { "persist-cache", 'p', 0, 0, ref Options.persist_cache, "Persist the PNG cache on disk for faster startup.", null },
             { "page", 'P', 0, OptionArg.INT, ref Options.page, "Goto a specific page directly after startup", "PAGE" },
             { "pdfpc-location", 'R', 0, OptionArg.STRING, ref Options.pdfpc_location, "Full path location to a pdfpc file (e.g. ./build/withnotes.pdfpc).", "LOCATION"},
+            { "presentation-screen", '2', 0, OptionArg.STRING, ref Options.presentation_screen, "Screen to be used for the presentation (output name)", "OUTPUT"},
+            { "presenter-screen", '1', 0, OptionArg.STRING, ref Options.presenter_screen, "Screen to be used for the presenter (output name)", "OUTPUT"},
             { "switch-screens", 's', 0, 0, ref Options.display_switch, "Switch the presentation and the presenter screen.", null },
             { "single-screen", 'S', 0, 0, ref Options.single_screen, "Force to use only one screen", null },
             { "start-time", 't', 0, OptionArg.STRING, ref Options.start_time, "Start time of the presentation to be used as a countdown. (Format: HH:MM (24h))", "T" },
@@ -285,12 +287,14 @@ namespace pdfpc {
             int primary_monitor_num = 0, secondary_monitor_num = 0;
             int presenter_monitor = -1, presentation_monitor = -1;
             int n_monitors = display.get_n_monitors();
+            bool by_output = (Options.presentation_screen != null) || (Options.presenter_screen != null);
             for (int i = 0; i < n_monitors; i++) {
                 // Not obvious what's right to do if n_monitors > 2...
                 // But let's be realistic :)
-                if (display.get_monitor(i).is_primary()) {
+                if ((by_output && Options.presenter_screen == display.get_monitor(i).get_model())
+                    || display.get_monitor(i).is_primary()) {
                     primary_monitor_num = i;
-                } else {
+                } else if (!by_output || Options.presentation_screen == display.get_monitor(i).get_model()) {
                     secondary_monitor_num = i;
                 }
             }


### PR DESCRIPTION
Currently, the used outputs depend on the enumeration: the primary
screen for the presenter, the last one for the presentation (or the last
but one, if the primary is last).

Allow to specify both screens by giving the name of the output such as
"HDMI-1".

Note:
There is also a (not so) hidden agenda, which is to make use of more outputs: the laptop screen and two different outputs. Then it will be necessary to specify three displays (presenter, presentation and review/tertiary).

But even now, being able to specify the outputs independent of the enumeration can be helpful.