### PR TITLE
[DO NOT MERGE YET] Auxiliary screen for review slides

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -73,6 +73,9 @@ Screen to be used for the presenter (output name, see e.g. "xrandr --listmonitor
 .BI "\-2, \-\-presentation\-screen"=OUTPUT
 Screen to be used for the presentation (output name).
 .TP
+.BI "\-3, \-\-auxiliary\-screen"=OUTPUT
+Screen to be used as auxiliary (output name).
+.TP
 .BI "\-s, \-\-switch\-screens"
 Switch the presentation and the presenter screen.
 .TP

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -50,6 +50,9 @@ Some permanent changes can be configured via the config file. The syntax is:
 The following option_name's are recognized:
 
 .TP
+.B auxiliary-screen
+Screen to be used for the auxiliary (output name).
+.TP
 .B black-on-end
 Add an additional black slide at the end of the presentation (bool, Default is false).
 .TP

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -226,6 +226,9 @@ namespace pdfpc {
             }
 
             switch (fields[1]) {
+                case "auxiliary-screen":
+                    Options.auxiliary_screen = fields[2];
+                    break;
                 case "black-on-end":
                     Options.black_on_end = bool.parse(fields[2]);
                     break;

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -180,6 +180,11 @@ namespace pdfpc {
         public static string? presenter_screen = null;
 
         /**
+         * Screen to be used for the auxiliary (output name)
+         */
+        public static string? auxiliary_screen = null;
+
+        /**
          * Size of the presenter window
          */
         public static string? size = null;

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -116,6 +116,25 @@ namespace pdfpc {
             }
         }
         private Window.Presentation _presentation=null;
+
+        /**
+         * Window which shows an auxiliary slide in fullscreen
+         *
+         * This window is supposed to be shown on the second beamer
+         */
+        public Window.Auxiliary auxiliary {
+            get {
+                return _auxiliary;
+            }
+            set {
+                _auxiliary = value;
+                if (value != null) {
+                    auxiliary.main_view.size_allocate.connect(init_presentation_pointer);
+                }
+            }
+        }
+        private Window.Auxiliary _auxiliary=null;
+
         public Gtk.Image presenter_pointer;
         public Gtk.Image presentation_pointer;
 

--- a/src/classes/window/auxiliary.vala
+++ b/src/classes/window/auxiliary.vala
@@ -1,0 +1,134 @@
+/**
+ * Presentation window
+ *
+ * This file is part of pdfpc.
+ *
+ * Copyright (C) 2010-2011 Jakob Westhoff <jakob@westhoffswelt.de>
+ * Copyright 2011-2012 David Vilar
+ * Copyright 2012, 2015 Robert Schroll
+ * Copyright 2012, 2015, 2017 Andreas Bilke
+ * Copyright 2013 Gabor Adam Toth
+ * Copyright 2014 Andy Barry
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc.Window {
+    /**
+     * Window showing the auxiliary slide to be presented on a second beamer
+     */
+    public class Auxiliary : Fullscreen, Controllable {
+        /**
+         * The registered PresentationController
+         */
+        public PresentationController presentation_controller { get; protected set; }
+
+        /**
+         * The only view is the main view.
+         */
+        public View.Pdf main_view {
+            get {
+                return this.view;
+            }
+        }
+
+        /**
+         * View containing the slide to show
+         */
+        protected View.Pdf view;
+
+        /**
+         * Base constructor instantiating a new presentation window
+         */
+        public Auxiliary(Metadata.Pdf metadata, int screen_num,
+            PresentationController presentation_controller, int width = -1, int height = -1) {
+            base(screen_num, width, height);
+            this.role = "auxiliary";
+            this.title = "pdfpc - auxilary (%s)".printf(metadata.get_document().get_title());
+
+            this.destroy.connect((source) => presentation_controller.quit());
+
+            this.presentation_controller = presentation_controller;
+            this.presentation_controller.update_request.connect(this.update);
+
+            Gdk.Rectangle scale_rect;
+            this.view = new View.Pdf.from_metadata(
+                metadata, this.screen_geometry.width, this.screen_geometry.height, Metadata.Area.CONTENT,
+                Options.black_on_end, true, this.presentation_controller, this.gdk_scale, out scale_rect
+            );
+
+            if (!Options.disable_caching) {
+                this.view.get_renderer().cache = Renderer.Cache.create(metadata);
+            }
+
+            this.overlay_layout.add(this.view);
+
+            this.overlay_layout.set_size_request(
+                this.main_view.get_renderer().width / this.gdk_scale,
+                this.main_view.get_renderer().height / this.gdk_scale
+            );
+
+            this.add(overlay_layout);
+
+            this.key_press_event.connect(this.presentation_controller.key_press);
+            this.button_press_event.connect(this.presentation_controller.button_press);
+            this.scroll_event.connect(this.presentation_controller.scroll);
+
+            this.presentation_controller.register_controllable(this);
+        }
+
+        /**
+         * Set the presentation controller which is notified of keypresses and
+         * other observed events
+         */
+        public void set_controller(PresentationController controller) {
+            this.presentation_controller = controller;
+        }
+
+        /**
+         * Update the display
+         */
+        public void update() {
+            this.visible = !this.presentation_controller.hidden;
+
+            if (this.presentation_controller.faded_to_black) {
+                this.view.fade_to_black();
+                return;
+            }
+            if (this.presentation_controller.frozen)
+                return;
+
+            try {
+                this.view.display(this.presentation_controller.current_slide_number-1, true);
+            } catch (Renderer.RenderError e) {
+                GLib.printerr("The pdf page %d could not be rendered: %s\n",
+                    this.presentation_controller.current_slide_number, e.message );
+                Process.exit(1);
+            }
+        }
+
+        /**
+         * Set the cache observer for the Views on this window
+         *
+         * This method takes care of registering all Prerendering Views used by
+         * this window correctly with the CacheStatus object to provide acurate
+         * cache status measurements.
+         */
+        public void set_cache_observer(CacheStatus observer) {
+            observer.monitor_view(this.view);
+        }
+    }
+}
+

--- a/src/classes/window/auxiliary.vala
+++ b/src/classes/window/auxiliary.vala
@@ -50,6 +50,11 @@ namespace pdfpc.Window {
         protected View.Pdf view;
 
         /**
+         * Metadata of the slides
+         */
+        protected Metadata.Pdf metadata;
+
+        /**
          * Base constructor instantiating a new presentation window
          */
         public Auxiliary(Metadata.Pdf metadata, int screen_num,
@@ -62,6 +67,8 @@ namespace pdfpc.Window {
 
             this.presentation_controller = presentation_controller;
             this.presentation_controller.update_request.connect(this.update);
+
+            this.metadata = metadata;
 
             Gdk.Rectangle scale_rect;
             this.view = new View.Pdf.from_metadata(
@@ -110,8 +117,12 @@ namespace pdfpc.Window {
             if (this.presentation_controller.frozen)
                 return;
 
+            int user_slide = this.presentation_controller.current_user_slide_number;
+            if (user_slide > 0) {
+                user_slide--;
+            }
             try {
-                this.view.display(this.presentation_controller.current_slide_number-1, true);
+                this.view.display(this.metadata.user_slide_to_real_slide(user_slide), true);
             } catch (Renderer.RenderError e) {
                 GLib.printerr("The pdf page %d could not be rendered: %s\n",
                     this.presentation_controller.current_slide_number, e.message );

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -176,6 +176,17 @@ namespace pdfpc {
         }
 
         /**
+         * Create and return an AuxiliaryWindow using the specified monitor
+         * while displaying the given file
+         */
+        private Window.Auxiliary create_auxiliary(Metadata.Pdf metadata, int monitor, int width = -1, int height = -1) {
+            var auxiliary = new Window.Auxiliary(metadata, monitor, this.controller, width, height);
+            auxiliary.set_cache_observer(this.cache_status);
+
+            return auxiliary;
+        }
+
+        /**
          * Main application function, which instantiates the windows and
          * initializes the Gtk system.
          */
@@ -289,6 +300,9 @@ namespace pdfpc {
             int presenter_monitor = -1, presentation_monitor = -1, auxiliary_monitor = -1;
             int n_monitors = display.get_n_monitors();
             bool by_output = (Options.presentation_screen != null) || (Options.presenter_screen != null) || (Options.auxiliary_screen != null);
+            if (Options.auxiliary_screen != null) {
+                auxiliary_monitor = 0;
+            }
             for (int i = 0; i < n_monitors; i++) {
                 // Not obvious what's right to do if n_monitors > 2...
                 // But let's be realistic :)
@@ -317,6 +331,10 @@ namespace pdfpc {
                 this.controller.presentation = this.create_presentation(metadata,
                     presentation_monitor, width, height);
             }
+            if(auxiliary_monitor != -1) {
+                this.controller.auxiliary = this.create_auxiliary(metadata,
+                    auxiliary_monitor);
+            }
 
             // The windows are always displayed at last to be sure all caches
             // have been created at this point.
@@ -328,6 +346,11 @@ namespace pdfpc {
             if (this.controller.presenter != null) {
                 this.controller.presenter.show_all();
                 this.controller.presenter.update();
+            }
+
+            if (this.controller.auxiliary != null) {
+                this.controller.auxiliary.show_all();
+                this.controller.auxiliary.update();
             }
 
             if (Options.page >= 1 &&

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -52,6 +52,7 @@ namespace pdfpc {
          * Commandline option parser entry definitions
          */
         const OptionEntry[] options = {
+            { "auxiliary-screen", '3', 0, OptionArg.STRING, ref Options.auxiliary_screen, "Screen to be used as auxiliary (output name)", "OUTPUT"},
             { "disable-cache", 'c', 0, 0, ref Options.disable_caching, "Disable caching and pre-rendering of slides to save memory at the cost of speed.", null },
             { "time-of-day", 'C', 0, 0, ref Options.use_time_of_day, "Use the current time of the day for the timer", null},
             { "duration", 'd', 0, OptionArg.INT, ref Options.duration, "Duration in minutes of the presentation used for timer display.", "N" },
@@ -285,9 +286,9 @@ namespace pdfpc {
             set_styling();
 
             int primary_monitor_num = 0, secondary_monitor_num = 0;
-            int presenter_monitor = -1, presentation_monitor = -1;
+            int presenter_monitor = -1, presentation_monitor = -1, auxiliary_monitor = -1;
             int n_monitors = display.get_n_monitors();
-            bool by_output = (Options.presentation_screen != null) || (Options.presenter_screen != null);
+            bool by_output = (Options.presentation_screen != null) || (Options.presenter_screen != null) || (Options.auxiliary_screen != null);
             for (int i = 0; i < n_monitors; i++) {
                 // Not obvious what's right to do if n_monitors > 2...
                 // But let's be realistic :)
@@ -296,6 +297,8 @@ namespace pdfpc {
                     primary_monitor_num = i;
                 } else if (!by_output || Options.presentation_screen == display.get_monitor(i).get_model()) {
                     secondary_monitor_num = i;
+                } else if (by_output && Options.auxiliary_screen == display.get_monitor(i).get_model()) {
+                    auxiliary_monitor = i;
                 }
             }
             if (!Options.display_switch) {


### PR DESCRIPTION
This little series implements a third screen for pdfpc, nick-named `auxiliary` for now. (`presented` might be an option to keep in line with `presenter` and `presentation`).

I regularly use two beamer screens (with mupdf and xdotool-magic in a script...) to present the "previous page" on the left screen (and sometimes a different one that I am referring to). This increases beamer screen state and greatly helps with all these "can you back one slide" requests. And I want to do this with `pdfpc` in the future, of course.

What is implemented right now:
- options to specify the monitor for the third screen
- automatic display of the previous user slide on the auxiliary screen
- works in windowed mode: turn it on by specifying an auxiliary screen (e.g. the main one), so that you don't need two external outputs to try it out.

What is planned:
- allow to specify the auxiliary page to show for each (real) page in .pdfpc (to support flexible back references)
- allow to specify a different pdf (in .pdfpc) to take the auxiliary pages from (typical use: handout version as produced by the LaTeX beamer class)
- documentation :)

What I'm asking for before a real PR (and before I continue):
- general thumbs up/down
- bike shedding: `auxiliary` vs. `presented` (the third screen may get used for more than just re-view)
- design critique: Is the approach general enough to support e.g. switching the pointer to the auxiliary screen (or switching between aux pages live on keypress)?
- other series to wait for (page number mapping by label or such)
- Should we put a view of the auxiliary screen on the presenter screen (e.g. instead of notes), and where and how...
- Do all screens need their own dimension options (width, height)?