### PR TITLE
Add command line option to list available monitors

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -55,6 +55,9 @@ Time in minutes, from which on the timer changes its color. (Default: 5 minutes)
 .BI "\-L, \-\-list\-actions"
 List actions supported in the config file(s)
 .TP
+.BI "\-M, \-\-list\-monitors"
+List monitors known to the operating system
+.TP
 .BI "\-n, \-\-notes"=P
 Position of notes on the PDF page. Position can be either left, right, top or bottom. Disable slide auto-grouping (Default: none)
 .TP
@@ -71,12 +74,6 @@ Go to a specific page directly after startup. In case of overlays, the first sli
 .TP
 .BI "\-R, \-\-pdfpc\-location"=LOCATION
 Use custom pdfpc file.
-.TP
-.BI "\-1, \-\-presenter\-screen"=OUTPUT
-Screen to be used for the presenter (output name, see e.g. "xrandr --listmonitors").
-.TP
-.BI "\-2, \-\-presentation\-screen"=OUTPUT
-Screen to be used for the presentation (output name).
 .TP
 .BI "\-s, \-\-switch\-screens"
 Switch the presentation and the presenter screen.
@@ -104,6 +101,12 @@ Disable the compression of slide images to trade memory consumption for speed.
 .TP
 .BI "\-Z, \-\-size"
 Size of the presentation window in width:height format (forces windowed mode)
+.TP
+.BI "\-1, \-\-presenter\-screen"=MONITOR
+Monitor to be used for the presenter screen (see the \-M option).
+.TP
+.BI "\-2, \-\-presentation\-screen"=MONITOR
+Monitor to be used for the presentation screen (see the \-M option).
 
 .SH KEYBINDINGS
 These are the default keybindings for pdfpc:

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -165,6 +165,11 @@ namespace pdfpc {
         public static bool list_actions = false;
 
         /**
+         * Show the available monitors(s)
+         */
+        public static bool list_monitors = false;
+
+        /**
          * Position of notes on slides
          */
         public static string? notes_position = null;

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -49,11 +49,6 @@ namespace pdfpc {
         private CacheStatus cache_status;
 
         /**
-         * Show the available monitors(s)
-         */
-        private static bool list_monitors = false;
-
-        /**
          * Commandline option parser entry definitions
          */
         const OptionEntry[] options = {
@@ -79,7 +74,7 @@ namespace pdfpc {
                 ref Options.list_actions,
                 "List actions supported in the config file(s)", null},
             {"list-monitors", 'M', 0, 0,
-                ref list_monitors,
+                ref Options.list_monitors,
                 "List available monitors", null},
             {"notes", 'n', 0, OptionArg.STRING,
                 ref Options.notes_position,
@@ -251,7 +246,7 @@ namespace pdfpc {
                 Process.exit(0);
             }
 
-            if (list_monitors) {
+            if (Options.list_monitors) {
                 int n_monitors = display.get_n_monitors();
                 GLib.print("Monitors: %d\n", n_monitors);
                 for (int i = 0; i < n_monitors; i++) {

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -49,6 +49,11 @@ namespace pdfpc {
         private CacheStatus cache_status;
 
         /**
+         * Show the available monitors(s)
+         */
+        private static bool list_monitors = false;
+
+        /**
          * Commandline option parser entry definitions
          */
         const OptionEntry[] options = {
@@ -73,6 +78,9 @@ namespace pdfpc {
             {"list-actions", 'L', 0, 0,
                 ref Options.list_actions,
                 "List actions supported in the config file(s)", null},
+            {"list-monitors", 'M', 0, 0,
+                ref list_monitors,
+                "List available monitors", null},
             {"notes", 'n', 0, OptionArg.STRING,
                 ref Options.notes_position,
                 "Position of notes (left|right|top|bottom)", "P"},
@@ -117,10 +125,10 @@ namespace pdfpc {
                 "Size of the presentation window (implies \"-w\")", "W:H"},
             {"presenter-screen", '1', 0, OptionArg.STRING,
                 ref Options.presenter_screen,
-                "Screen to be used for the presenter", "S"},
+                "Monitor to be used for the presenter", "M"},
             {"presentation-screen", '2', 0, OptionArg.STRING,
                 ref Options.presentation_screen,
-                "Screen to be used for the presentation", "S"},
+                "Monitor to be used for the presentation", "M"},
             {null}
         };
 
@@ -240,6 +248,21 @@ namespace pdfpc {
 
             if (Options.version) {
                 print_version();
+                Process.exit(0);
+            }
+
+            if (list_monitors) {
+                int n_monitors = display.get_n_monitors();
+                GLib.print("Monitors: %d\n", n_monitors);
+                for (int i = 0; i < n_monitors; i++) {
+                    var monitor = display.get_monitor(i);
+                    var geo = monitor.get_geometry();
+                    GLib.print(" %d: %c %s [%dx%d@%dHz]\n", i,
+                        monitor.is_primary() ? '*':' ',
+                        monitor.get_model(),
+                        geo.width, geo.height,
+                        (monitor.get_refresh_rate() + 500)/1000);
+                }
                 Process.exit(0);
             }
 


### PR DESCRIPTION
This should work independently of X/Wayland; removed the mention of xrandr.