### PR TITLE
Implement file reload functionality

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -221,6 +221,9 @@ below)
 .B Ctrl + e
 Define end slide
 .TP
+.B Ctrl + r
+Reload the presentation (e.g., if the PDF file has been updated)
+.TP
 .B Ctrl + q
 Exit pdfpc
 .P

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -48,6 +48,9 @@ bind t                  toggleToolbox
 # Exit
 bind C+q                quit
 
+# Exit
+bind C+r                reload
+
 # Presentation state
 bind b                  blank
 bind f                  freeze

--- a/src/classes/cache_status.vala
+++ b/src/classes/cache_status.vala
@@ -72,5 +72,13 @@ namespace pdfpc {
                 this.update();
             });
         }
+
+        /**
+         * Reset the stats
+         */
+        public void reset() {
+            this.max_value = 0;
+            this.current_value = 0;
+        }
     }
 }

--- a/src/classes/drawings/drawing.vala
+++ b/src/classes/drawings/drawing.vala
@@ -153,6 +153,13 @@ namespace pdfpc.Drawings {
                 this.current_slide = slide_number;
             }
         }
+
+        /*
+         * Clear the storage.
+         */
+        public void clear_storage() {
+            this.storage.clear();
+        }
     }
 
     public Drawing create(Metadata.Pdf metadata, int width, int height) {

--- a/src/classes/drawings/storage.vala
+++ b/src/classes/drawings/storage.vala
@@ -50,6 +50,11 @@ namespace pdfpc.Drawings.Storage {
          * The returned reference can be modified without modifying the storage.
          */
         public abstract Cairo.ImageSurface? retrieve(uint index);
+
+        /**
+         * Clear the storage
+         */
+        public abstract void clear();
     }
 
     public class MemoryUncompressed : Drawings.Storage.Base {
@@ -77,6 +82,10 @@ namespace pdfpc.Drawings.Storage {
             Cairo.ImageSurface? result = storage[index];
             storage[index] = null;
             return result;
+        }
+
+        public override void clear() {
+            storage = new Cairo.ImageSurface[this.metadata.get_slide_count()];
         }
     }
 

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -114,6 +114,11 @@ namespace pdfpc.Metadata {
         private int _font_size = -1;
         public int font_size { get { return _font_size; } set { _font_size = value; } }
 
+        public bool is_ready {
+            get {
+                return (this.document != null);
+            }
+        }
 
         /**
          * A file to read additional notes from
@@ -292,7 +297,9 @@ namespace pdfpc.Metadata {
          * Called on quit
          */
         public void quit() {
-            this.save_to_disk();
+            if (this.is_ready) {
+                this.save_to_disk();
+            }
             foreach (var mapping in this.action_mapping) {
                 mapping.deactivate();
             }
@@ -768,6 +775,17 @@ namespace pdfpc.Metadata {
          */
         public Poppler.Document get_document() {
             return this.document;
+        }
+
+        /**
+         * Return the PDF title
+         */
+        public string get_title() {
+            if (this.document != null) {
+                return this.document.get_title();
+            } else {
+                return "";
+            }
         }
 
         /**

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -876,7 +876,6 @@ namespace pdfpc.Metadata {
         public unowned Gee.List<ActionMapping> get_action_mapping(int page_num) {
             if (page_num != this.mapping_page_num) {
                 this.deactivate_mappings();
-                this.action_mapping.clear();
 
                 GLib.List<Poppler.LinkMapping> link_mappings;
                 link_mappings = this.get_document().get_page(page_num).get_link_mapping();

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -465,7 +465,16 @@ namespace pdfpc.Metadata {
         /**
          * Base constructor taking the file url to the pdf file
          */
-        public Pdf(string pdfFilename) {
+        public Pdf(string? pdfFilename) {
+            if (pdfFilename != null) {
+                this.load(pdfFilename);
+            }
+        }
+
+        /**
+         * Actual file loading, initialization, etc
+         */
+        public void load(string pdfFilename) {
             var fname = pdfFilename;
             string cwd = GLib.Environment.get_current_dir();
             if (!GLib.Path.is_absolute(fname)) {
@@ -498,6 +507,7 @@ namespace pdfpc.Metadata {
             if (GLib.FileUtils.test(this.pdfpc_fname, (GLib.FileTest.IS_REGULAR))) {
                 parse_pdfpc_file(out skip_line);
             }
+            this.user_view_indexes = new int [0];
             this.document = this.open_pdf_document(this.pdf_fname);
 
             // Get maximal page dimensions

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -294,15 +294,23 @@ namespace pdfpc.Metadata {
         }
 
         /**
+         * Deactivate all active mappings
+         */
+        private void deactivate_mappings() {
+            foreach (var mapping in this.action_mapping) {
+                mapping.deactivate();
+            }
+            this.action_mapping.clear();
+        }
+
+        /**
          * Called on quit
          */
         public void quit() {
             if (this.is_ready) {
                 this.save_to_disk();
             }
-            foreach (var mapping in this.action_mapping) {
-                mapping.deactivate();
-            }
+            this.deactivate_mappings();
         }
 
         /**
@@ -493,7 +501,11 @@ namespace pdfpc.Metadata {
 
             this.url = File.new_for_commandline_arg(fname).get_uri();
 
-            this.action_mapping = new Gee.ArrayList<ActionMapping>();
+            if (this.action_mapping != null) {
+                this.deactivate_mappings();
+            } else {
+                this.action_mapping = new Gee.ArrayList<ActionMapping>();
+            }
 
             this.notes_position = NotesPosition.from_string(Options.notes_position);
 
@@ -863,9 +875,7 @@ namespace pdfpc.Metadata {
          */
         public unowned Gee.List<ActionMapping> get_action_mapping(int page_num) {
             if (page_num != this.mapping_page_num) {
-                foreach (var mapping in this.action_mapping) {
-                    mapping.deactivate();
-                }
+                this.deactivate_mappings();
                 this.action_mapping.clear();
 
                 GLib.List<Poppler.LinkMapping> link_mappings;

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -458,7 +458,23 @@ namespace pdfpc.Metadata {
         /**
          * Base constructor taking the file url to the pdf file
          */
-        public Pdf(string fname, string? fpcname = null) {
+        public Pdf(string pdfFilename) {
+            var fname = pdfFilename;
+            string cwd = GLib.Environment.get_current_dir();
+            if (!GLib.Path.is_absolute(fname)) {
+                fname = GLib.Path.build_filename(cwd, fname);
+            }
+
+            var fpcname = Options.pdfpc_location;
+            if (fpcname != null && !GLib.Path.is_absolute(fpcname)) {
+                fpcname = GLib.Path.build_filename(cwd, fpcname);
+            }
+            if (fpcname != null &&
+                !GLib.FileUtils.test(fpcname, (GLib.FileTest.IS_REGULAR))) {
+                GLib.printerr("Can't find custom pdfpc file at %s\n", fpcname);
+                Process.exit(1);
+            }
+
             this.url = File.new_for_commandline_arg(fname).get_uri();
 
             this.action_mapping = new Gee.ArrayList<ActionMapping>();

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -668,13 +668,13 @@ namespace pdfpc.Metadata {
          * The user slide corresponding to a real slide.
          *
          * If number is larger than the number of real slides return the
-         * number of user slides.
+         * last user slide.
          */
         public int real_slide_to_user_slide(int number) {
 
             // is this not a valid page?
             if (number > this.page_count) {
-                return (int)this.get_user_slide_count();
+                return (int)this.get_user_slide_count() - 1;
             }
 
             // is number a real page of the last user page?

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -759,11 +759,6 @@ namespace pdfpc {
                 | Gdk.EventMask.BUTTON_RELEASE_MASK
                 | Gdk.EventMask.POINTER_MOTION_MASK
             );
-
-            var w = presenter_pointer_surface.get_window();
-            if (w != null) {
-                w.set_cursor(new Gdk.Cursor.from_name(Gdk.Display.get_default(), "none"));
-            }
         }
 
         protected void init_presentation_pointer() {
@@ -785,24 +780,20 @@ namespace pdfpc {
             }
         }
 
-        public void move_pointer(double percent_x, double percent_y) {
-            pointer_y = percent_y;
-            pointer_x = percent_x;
+        /**
+         * Handle mouse scrolling events on the window and, if neccessary send
+         * them to the presentation controller
+         */
+        protected bool on_move_pointer(Gtk.Widget source, Gdk.EventMotion move) {
+            pointer_x = move.x/presenter_allocation.width;
+            pointer_y = move.y/presenter_allocation.height;
             if (presenter != null) {
                 presenter_pointer_surface.queue_draw();
             }
             if (presentation != null) {
                 presentation_pointer_surface.queue_draw();
             }
-        }
-
-        /**
-         * Handle mouse scrolling events on the window and, if neccessary send
-         * them to the presentation controller
-         */
-        protected bool on_move_pointer(Gtk.Widget source, Gdk.EventMotion move) {
-            move_pointer(move.x / (double) presenter_allocation.width, move.y / (double) presenter_allocation.height);
-            update_highlight(move.x/presenter_allocation.width, move.y/presenter_allocation.height);
+            update_highlight(pointer_x, pointer_y);
             return true;
         }
 

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1803,11 +1803,20 @@ namespace pdfpc {
                     this.controllables_hide_overview();
                 }
 
+                var position_saved = this.current_slide_number;
                 this.metadata.load(fname);
+                if (this.n_slides == 0) {
+                    return;
+                }
 
-                this.current_user_slide_number =
-                    this.metadata.real_slide_to_user_slide(
-                        this.current_slide_number);
+                // Make sure the current position remains valid
+                if (position_saved >= this.n_slides) {
+                    this.current_slide_number = (int) this.n_slides - 1;
+                    this.current_user_slide_number =
+                        this.metadata.real_slide_to_user_slide(
+                            this.current_slide_number);
+                }
+
                 this.overview.set_n_slides(this.user_n_slides);
                 this.cache_status.reset();
                 this.reload_request();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -80,6 +80,13 @@ namespace pdfpc {
         }
 
         /**
+         * CacheStatus object, which coordinates all the information about
+         * cached slides to provide a visual feedback to the user about the
+         * rendering state
+         */
+        public CacheStatus cache_status { get; protected set; }
+
+        /**
          * Presenter window showing the current and the next slide as well as
          * different other meta information useful for the person giving the
          * presentation.
@@ -132,6 +139,11 @@ namespace pdfpc {
          */
         public bool ignore_keyboard_events { get; protected set; default = false; }
         public bool ignore_mouse_events { get; protected set; default = false; }
+
+        /**
+         * Signal: Fired on document reload
+         */
+        public signal void reload_request();
 
         /**
          * Signal: Update the display
@@ -315,6 +327,8 @@ namespace pdfpc {
          */
         public PresentationController() {
             this.controllables = new Gee.ArrayList<Controllable>();
+
+            this.cache_status = new CacheStatus();
 
             this.history = new Gee.ArrayQueue<int>();
 
@@ -1783,6 +1797,8 @@ namespace pdfpc {
             if (fname != null) {
                 this.metadata.load(fname);
                 this.overview.set_n_slides(this.user_n_slides);
+                this.cache_status.reset();
+                this.reload_request();
                 this.controllables_update();
             }
         }

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1795,7 +1795,15 @@ namespace pdfpc {
         protected void reload() {
             var fname = this.metadata.pdf_fname;
             if (fname != null) {
+                if (this.overview_shown) {
+                    this.controllables_hide_overview();
+                }
+
                 this.metadata.load(fname);
+
+                this.current_user_slide_number =
+                    this.metadata.real_slide_to_user_slide(
+                        this.current_slide_number);
                 this.overview.set_n_slides(this.user_n_slides);
                 this.cache_status.reset();
                 this.reload_request();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -189,11 +189,6 @@ namespace pdfpc {
                     this.user_slide_progress =
                         new int[metadata.get_user_slide_count()];
 
-                    // If end_time is set, reset duration to 0
-                    if (Options.end_time != null) {
-                        Options.duration = 0;
-                        this.metadata.set_duration(0);
-                    }
                     this.timer = getTimerLabel(this,
                         (int) this.metadata.get_duration() * 60);
                     this.timer.reset();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1817,6 +1817,10 @@ namespace pdfpc {
                             this.current_slide_number);
                 }
 
+                // Reset the drawing storage & clear the current drawings
+                this.pen_drawing.clear_storage();
+                this.clear_pen_drawing();
+
                 this.overview.set_n_slides(this.user_n_slides);
                 this.cache_status.reset();
                 this.reload_request();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -169,13 +169,6 @@ namespace pdfpc {
         public signal void decrease_font_size_request();
 
         /**
-         * A flag signaling if we allow for a black slide at the end. Tis is
-         * useful for the next view and (for some presenters) also for the main
-         * view.
-         */
-        protected bool black_on_end;
-
-        /**
          * Controllables which are registered with this presentation controller.
          */
         protected Gee.List<Controllable> controllables;
@@ -297,10 +290,9 @@ namespace pdfpc {
         /**
          * Instantiate a new controller
          */
-        public PresentationController(Metadata.Pdf metadata, bool allow_black_on_end) {
+        public PresentationController(Metadata.Pdf metadata) {
             this.metadata = metadata;
             this.metadata.controller = this;
-            this.black_on_end = allow_black_on_end;
 
             this.controllables = new Gee.ArrayList<Controllable>();
 
@@ -1303,7 +1295,7 @@ namespace pdfpc {
                 }
 
                 this.controllables_update();
-            } else if (this.black_on_end && !this.faded_to_black) {
+            } else if (Options.black_on_end && !this.faded_to_black) {
                 this.fade_to_black();
             }
             if(this.current_slide_number > this.user_slide_progress[this.current_user_slide_number]) {
@@ -1326,7 +1318,7 @@ namespace pdfpc {
             } else {
                 // we are at the last slide
                 if (this.current_slide_number == this.n_slides - 1) {
-                    if (this.black_on_end && !this.faded_to_black) {
+                    if (Options.black_on_end && !this.faded_to_black) {
                         this.fade_to_black();
                     }
                 } else {

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1610,19 +1610,19 @@ namespace pdfpc {
         }
 
         /**
-         * Goto a slide in user page numbers. page_number is 1 indexed.
+         * Goto a slide in user page numbers
          */
         public void goto_user_page(int page_number, bool useLast = true) {
             this.timer.start();
 
-            if (this.current_user_slide_number != page_number - 1) {
+            if (this.current_user_slide_number != page_number) {
                 this.push_history();
             }
 
             this.controllables_hide_overview();
-            int destination = page_number - 1;
+            int destination = page_number;
             int n_user_slides = this.metadata.get_user_slide_count();
-            if (page_number < 1) {
+            if (page_number < 0) {
                 destination = 0;
             } else if (page_number >= n_user_slides) {
                 destination = n_user_slides - 1;

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -68,7 +68,11 @@ namespace pdfpc {
         /**
          * The number of slides in the presentation
          */
-        public int n_slides { get; protected set; }
+        public uint n_slides {
+            get {
+                return this.metadata.get_slide_count();
+            }
+        }
 
         /**
          * The number of user slides
@@ -204,8 +208,6 @@ namespace pdfpc {
                     this.timer = getTimerLabel(this,
                         (int) this.metadata.get_duration() * 60);
                     this.timer.reset();
-
-                    this.n_slides = (int) this.metadata.get_slide_count();
 
                     this.current_slide_number = 0;
                     this.current_user_slide_number = 0;
@@ -1341,13 +1343,15 @@ namespace pdfpc {
                 needs_update = true;
             } else {
                 // we are at the last slide
-                if (this.current_slide_number == this.n_slides - 1) {
+                if (this.current_slide_number + 1 == this.n_slides) {
                     if (Options.black_on_end && !this.faded_to_black) {
                         this.fade_to_black();
                     }
                 } else {
                     // move to the last slide, we are already at the last user slide
-                    this.current_slide_number = this.n_slides - 1;
+                    if (this.n_slides > 0) {
+                        this.current_slide_number = (int) this.n_slides - 1;
+                    }
                 }
             }
 
@@ -1374,7 +1378,7 @@ namespace pdfpc {
                 this.faded_to_black = false;
             }
 
-            if(this.current_slide_number == this.n_slides - 1) {
+            if(this.current_slide_number + 1 == this.n_slides) {
                 return;
             }
 

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -924,6 +924,7 @@ namespace pdfpc {
             add_action("toggleToolbox", this.toggle_toolbox);
 
             add_action("exitState", this.exit_state);
+            add_action("reload", this.reload);
             add_action("quit", this.quit);
         }
 
@@ -982,6 +983,7 @@ namespace pdfpc {
                 "toggleDrawings", "Toggle all drawings on all slides",
                 "toggleToolbox", "Toggle the toolbox",
                 "exitState", "Exit \"special\" state (pause, freeze, blank)",
+                "reload", "Reload the presentation",
                 "quit", "Exit pdfpc",
             };
         }
@@ -1286,6 +1288,9 @@ namespace pdfpc {
          * Go to the next slide
          */
         public void next_page() {
+            if (!this.metadata.is_ready) {
+                return;
+            }
             if (overview_shown)
                 return;
 
@@ -1650,6 +1655,9 @@ namespace pdfpc {
         }
 
         protected void toggle_overview() {
+            if (!this.metadata.is_ready) {
+                return;
+            }
             if (this.overview_shown) {
                 this.controllables_hide_overview();
             } else {
@@ -1765,6 +1773,18 @@ namespace pdfpc {
          */
         protected void reset_timer() {
             this.timer.reset();
+        }
+
+        /**
+         * Reload the presentation
+         */
+        protected void reload() {
+            var fname = this.metadata.pdf_fname;
+            if (fname != null) {
+                this.metadata.load(fname);
+                this.overview.set_n_slides(this.user_n_slides);
+                this.controllables_update();
+            }
         }
 
         protected void increase_font_size() {

--- a/src/classes/renderer/cache/base.vala
+++ b/src/classes/renderer/cache/base.vala
@@ -64,6 +64,11 @@ namespace pdfpc.Renderer.Cache {
          * If no item with the given index is available null is returned
          */
         public abstract Cairo.ImageSurface? retrieve(uint index);
+
+        /**
+         * Invalidate the whole cache (if the document is reloaded/changed)
+         */
+        public abstract void invalidate();
     }
 
     /**

--- a/src/classes/renderer/cache/png/engine.vala
+++ b/src/classes/renderer/cache/png/engine.vala
@@ -100,6 +100,14 @@ namespace pdfpc.Renderer.Cache {
 
             return surface;
         }
+
+        /**
+         * Invalidate the cache
+         */
+        public override void invalidate() {
+            uint size = this.metadata.get_slide_count();
+            this.storage = new PNG.Item[size];
+        }
     }
 }
 

--- a/src/classes/renderer/cache/simple/engine.vala
+++ b/src/classes/renderer/cache/simple/engine.vala
@@ -55,5 +55,13 @@ namespace pdfpc.Renderer.Cache {
         public override Cairo.ImageSurface? retrieve( uint index ) {
             return this.storage[index];
         }
+
+        /**
+         * Invalidate the cache
+         */
+        public override void invalidate() {
+            uint size = this.metadata.get_slide_count();
+            this.storage = new Cairo.ImageSurface[size];
+        }
     }
 }

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -147,7 +147,7 @@ namespace pdfpc {
         }
 
         /**
-         * Create a new Pdf view directly from a file
+         * Create a new Pdf view from a Fullscreen window instance
          *
          * This is a convenience constructor which automatically create a full
          * metadata and rendering chain to be used with the pdf view. The given
@@ -155,18 +155,21 @@ namespace pdfpc {
          * aspect ration. The scale rectangle is provided in the scale_rect
          * argument.
          */
-        public Pdf.from_metadata(Metadata.Pdf metadata, int width, int height,
-                                 Metadata.Area area, bool allow_black_on_end, bool clickable_links,
-                                 PresentationController presentation_controller, int gdk_scale_factor, out Gdk.Rectangle scale_rect = null) {
+        public Pdf.from_fullscreen(Window.Fullscreen window,
+            int width, int height, Metadata.Area area,
+            bool allow_black_on_end, bool clickable_links,
+            out Gdk.Rectangle scale_rect = null) {
+            var presentation_controller = window.presentation_controller;
+            var metadata = presentation_controller.metadata;
             var scaler = new Scaler(metadata.get_page_width(), metadata.get_page_height());
             scale_rect = scaler.scale_to(width, height);
 
-            scale_rect.width *= gdk_scale_factor;
-            scale_rect.height *= gdk_scale_factor;
+            scale_rect.width *= window.gdk_scale;
+            scale_rect.height *= window.gdk_scale;
 
             var renderer = new Renderer.Pdf(metadata, scale_rect.width, scale_rect.height, area);
 
-            this(renderer, allow_black_on_end, clickable_links, presentation_controller, gdk_scale_factor);
+            this(renderer, allow_black_on_end, clickable_links, presentation_controller, window.gdk_scale);
         }
 
         /**

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -111,7 +111,7 @@ namespace pdfpc {
          * Default constructor restricted to Pdf renderers as input parameter
          */
         public Pdf(Renderer.Pdf renderer, bool clickable_links,
-            PresentationController presentation_controller, int gdk_scale_factor) {
+            PresentationController controller, int gdk_scale_factor) {
             this.renderer = renderer;
             this.gdk_scale = gdk_scale_factor;
 
@@ -120,7 +120,7 @@ namespace pdfpc {
 
             this.current_slide_number = 0;
 
-            presentation_controller.reload_request.connect(this.rebuild_cache);
+            controller.reload_request.connect(this.rebuild_cache);
 
             // Render the initial page on first realization.
             this.add_events(Gdk.EventMask.STRUCTURE_MASK);
@@ -163,8 +163,8 @@ namespace pdfpc {
             int width, int height, Metadata.Area area,
             bool clickable_links,
             out Gdk.Rectangle scale_rect = null) {
-            var presentation_controller = window.presentation_controller;
-            var metadata = presentation_controller.metadata;
+            var controller = window.controller;
+            var metadata = controller.metadata;
             var scaler = new Scaler(metadata.get_page_width(), metadata.get_page_height());
             scale_rect = scaler.scale_to(width, height);
 
@@ -173,7 +173,7 @@ namespace pdfpc {
 
             var renderer = new Renderer.Pdf(metadata, scale_rect.width, scale_rect.height, area);
 
-            this(renderer, clickable_links, presentation_controller, window.gdk_scale);
+            this(renderer, clickable_links, controller, window.gdk_scale);
         }
 
         /**

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -120,6 +120,8 @@ namespace pdfpc {
 
             this.current_slide_number = 0;
 
+            presentation_controller.reload_request.connect(this.rebuild_cache);
+
             // Render the initial page on first realization.
             this.add_events(Gdk.EventMask.STRUCTURE_MASK);
             this.realize.connect(() => {
@@ -359,6 +361,18 @@ namespace pdfpc {
             // We are the only ones drawing on this context skip everything
             // else.
             return true;
+        }
+
+        /**
+         * Clear the current cache and begin building it anew
+         */
+        protected void rebuild_cache() {
+            if (this.renderer.cache != null) {
+                this.renderer.cache.invalidate();
+                if (renderer.cache.allows_prerendering()) {
+                    this.register_prerendering();
+                }
+            }
         }
     }
 }

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -106,7 +106,7 @@ namespace pdfpc {
         /**
          * Default constructor restricted to Pdf renderers as input parameter
          */
-        public Pdf(Renderer.Pdf renderer, bool allow_black_on_end, bool clickable_links,
+        public Pdf(Renderer.Pdf renderer, bool clickable_links,
             PresentationController presentation_controller, int gdk_scale_factor) {
             this.renderer = renderer;
             this.gdk_scale = gdk_scale_factor;
@@ -157,7 +157,7 @@ namespace pdfpc {
          */
         public Pdf.from_fullscreen(Window.Fullscreen window,
             int width, int height, Metadata.Area area,
-            bool allow_black_on_end, bool clickable_links,
+            bool clickable_links,
             out Gdk.Rectangle scale_rect = null) {
             var presentation_controller = window.presentation_controller;
             var metadata = presentation_controller.metadata;
@@ -169,7 +169,7 @@ namespace pdfpc {
 
             var renderer = new Renderer.Pdf(metadata, scale_rect.width, scale_rect.height, area);
 
-            this(renderer, allow_black_on_end, clickable_links, presentation_controller, window.gdk_scale);
+            this(renderer, clickable_links, presentation_controller, window.gdk_scale);
         }
 
         /**

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -34,6 +34,22 @@ namespace pdfpc.Window {
      */
     public class Fullscreen : Gtk.Window {
         /**
+         * The registered PresentationController
+         */
+        public PresentationController presentation_controller {
+            get; protected set;
+        }
+
+        /**
+         * Metadata of the slides
+         */
+        protected Metadata.Pdf metadata {
+            get {
+                return this.presentation_controller.metadata;
+            }
+        }
+
+        /**
          * The geometry data of the screen this window is on
          */
         protected Gdk.Rectangle screen_geometry;

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -36,7 +36,7 @@ namespace pdfpc.Window {
         /**
          * The registered PresentationController
          */
-        public PresentationController presentation_controller {
+        public PresentationController controller {
             get; protected set;
         }
 
@@ -45,7 +45,7 @@ namespace pdfpc.Window {
          */
         protected Metadata.Pdf metadata {
             get {
-                return this.presentation_controller.metadata;
+                return this.controller.metadata;
             }
         }
 

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -94,7 +94,9 @@ namespace pdfpc.Window {
         /**
          * The GDK scale factor. Used for better slide rendering
          */
-        protected int gdk_scale = 1;
+        public int gdk_scale {
+            get; protected set;
+        }
 
         /**
          * The screen we want this window to be shown
@@ -107,6 +109,7 @@ namespace pdfpc.Window {
         protected int monitor_num_to_use;
 
         public Fullscreen(int monitor_num, int width = -1, int height = -1) {
+            this.gdk_scale = 1;
             var display = Gdk.Display.get_default();
             Gdk.Monitor monitor;
             if (monitor_num >= 0) {

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -39,10 +39,13 @@ namespace pdfpc.Window {
         protected Gtk.IconView slides_view;
 
         /**
-         * We will need the metadata mainly for converting from user slides to
-         * real slides.
+         * Metadata of the slides
          */
-        protected Metadata.Pdf metadata;
+        protected Metadata.Pdf metadata {
+            get {
+                return this.presentation_controller.metadata;
+            }
+        }
 
         /**
          * How many (user) slides we have.
@@ -77,10 +80,13 @@ namespace pdfpc.Window {
         protected PresentationController presentation_controller;
 
         /**
-         * The presenter. We have a reference here to update the current slide
-         * display.
+         * The presenter
          */
-        protected Presenter presenter;
+        protected Presenter presenter {
+            get {
+                return this.presentation_controller.presenter;
+            }
+        }
 
         /**
          * The maximal size of the slides_view.
@@ -127,7 +133,9 @@ namespace pdfpc.Window {
         /**
          * Constructor
          */
-        public Overview( Metadata.Pdf metadata, PresentationController presentation_controller, Presenter presenter ) {
+        public Overview(PresentationController presentation_controller) {
+            this.presentation_controller = presentation_controller;
+
             this.get_style_context().add_class("overviewWindow");
 
             this.slides = new Gtk.ListStore(1, typeof(int));
@@ -147,17 +155,12 @@ namespace pdfpc.Window {
             this.slides_view.show();
             this.add(this.slides_view);
 
-            this.metadata = metadata;
-            this.presentation_controller = presentation_controller;
-            this.presenter = presenter;
-
             this.slides_view.motion_notify_event.connect(this.presenter.on_mouse_move);
             this.slides_view.motion_notify_event.connect(this.on_mouse_move);
             this.slides_view.button_release_event.connect(this.on_mouse_release);
             this.slides_view.key_press_event.connect(this.on_key_press);
             this.slides_view.selection_changed.connect(this.on_selection_changed);
             this.key_press_event.connect((event) => this.slides_view.key_press_event(event));
-
         }
 
         public void set_available_space(int width, int height) {

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -155,7 +155,6 @@ namespace pdfpc.Window {
             this.slides_view.show();
             this.add(this.slides_view);
 
-            this.slides_view.motion_notify_event.connect(this.presenter.on_mouse_move);
             this.slides_view.motion_notify_event.connect(this.on_mouse_move);
             this.slides_view.button_release_event.connect(this.on_mouse_release);
             this.slides_view.key_press_event.connect(this.on_key_press);

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -43,7 +43,7 @@ namespace pdfpc.Window {
          */
         protected Metadata.Pdf metadata {
             get {
-                return this.presentation_controller.metadata;
+                return this.controller.metadata;
             }
         }
 
@@ -77,14 +77,14 @@ namespace pdfpc.Window {
         /**
          * The presentation controller
          */
-        protected PresentationController presentation_controller;
+        protected PresentationController controller;
 
         /**
          * The presenter
          */
         protected Presenter presenter {
             get {
-                return this.presentation_controller.presenter;
+                return this.controller.presenter;
             }
         }
 
@@ -133,8 +133,8 @@ namespace pdfpc.Window {
         /**
          * Constructor
          */
-        public Overview(PresentationController presentation_controller) {
-            this.presentation_controller = presentation_controller;
+        public Overview(PresentationController controller) {
+            this.controller = controller;
 
             this.get_style_context().add_class("overviewWindow");
 
@@ -339,7 +339,7 @@ namespace pdfpc.Window {
                     break;
                 case 0xff0d: /* Return */
                     bool gotoFirst = (key.state & Gdk.ModifierType.SHIFT_MASK) != 0;
-                    this.presentation_controller.goto_user_page(this.current_slide + 1, !gotoFirst);
+                    this.controller.goto_user_page(this.current_slide + 1, !gotoFirst);
                     handled = true;
                     break;
             }
@@ -367,7 +367,7 @@ namespace pdfpc.Window {
         public bool on_mouse_release(Gdk.EventButton event) {
             if (event.button == 1) {
                 bool gotoFirst = (event.state & Gdk.ModifierType.SHIFT_MASK) != 0;
-                this.presentation_controller.goto_user_page(this.current_slide + 1, !gotoFirst);
+                this.controller.goto_user_page(this.current_slide + 1, !gotoFirst);
             }
             return false;
         }

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -339,7 +339,7 @@ namespace pdfpc.Window {
                     break;
                 case 0xff0d: /* Return */
                     bool gotoFirst = (key.state & Gdk.ModifierType.SHIFT_MASK) != 0;
-                    this.controller.goto_user_page(this.current_slide + 1, !gotoFirst);
+                    this.controller.goto_user_page(this.current_slide, !gotoFirst);
                     handled = true;
                     break;
             }
@@ -367,7 +367,7 @@ namespace pdfpc.Window {
         public bool on_mouse_release(Gdk.EventButton event) {
             if (event.button == 1) {
                 bool gotoFirst = (event.state & Gdk.ModifierType.SHIFT_MASK) != 0;
-                this.controller.goto_user_page(this.current_slide + 1, !gotoFirst);
+                this.controller.goto_user_page(this.current_slide, !gotoFirst);
             }
             return false;
         }

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -194,6 +194,9 @@ namespace pdfpc.Window {
          * for all the slides.
          */
         protected void prepare_layout() {
+            if (!this.metadata.is_ready) {
+                return;
+            }
             if (this.max_width == -1) {
                 return;
             }

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -53,7 +53,7 @@ namespace pdfpc.Window {
             this.presentation_controller = presentation_controller;
 
             this.role = "presentation";
-            this.title = "pdfpc - presentation (%s)".printf(metadata.get_document().get_title());
+            this.title = "pdfpc - presentation (%s)".printf(metadata.get_title());
 
             this.destroy.connect((source) => presentation_controller.quit());
 

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -31,11 +31,6 @@ namespace pdfpc.Window {
      */
     public class Presentation : Fullscreen, Controllable {
         /**
-         * The registered PresentationController
-         */
-        public PresentationController presentation_controller { get; protected set; }
-
-        /**
          * The only view is the main view.
          */
         public View.Pdf main_view {
@@ -56,8 +51,6 @@ namespace pdfpc.Window {
             int screen_num, int width = -1, int height = -1) {
             base(screen_num, width, height);
             this.presentation_controller = presentation_controller;
-
-            var metadata = presentation_controller.metadata;
 
             this.role = "presentation";
             this.title = "pdfpc - presentation (%s)".printf(metadata.get_document().get_title());

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -63,7 +63,7 @@ namespace pdfpc.Window {
             this.view = new View.Pdf.from_fullscreen(this,
                 this.screen_geometry.width, this.screen_geometry.height,
                 Metadata.Area.CONTENT,
-                Options.black_on_end, true, out scale_rect);
+                true, out scale_rect);
 
             if (!Options.disable_caching) {
                 this.view.get_renderer().cache = Renderer.Cache.create(metadata);

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -60,10 +60,10 @@ namespace pdfpc.Window {
             this.presentation_controller.update_request.connect(this.update);
 
             Gdk.Rectangle scale_rect;
-            this.view = new View.Pdf.from_metadata(
-                metadata, this.screen_geometry.width, this.screen_geometry.height, Metadata.Area.CONTENT,
-                Options.black_on_end, true, this.presentation_controller, this.gdk_scale, out scale_rect
-            );
+            this.view = new View.Pdf.from_fullscreen(this,
+                this.screen_geometry.width, this.screen_geometry.height,
+                Metadata.Area.CONTENT,
+                Options.black_on_end, true, out scale_rect);
 
             if (!Options.disable_caching) {
                 this.view.get_renderer().cache = Renderer.Cache.create(metadata);

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -52,15 +52,18 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presentation window
          */
-        public Presentation(Metadata.Pdf metadata, int screen_num,
-            PresentationController presentation_controller, int width = -1, int height = -1) {
+        public Presentation(PresentationController presentation_controller,
+            int screen_num, int width = -1, int height = -1) {
             base(screen_num, width, height);
+            this.presentation_controller = presentation_controller;
+
+            var metadata = presentation_controller.metadata;
+
             this.role = "presentation";
             this.title = "pdfpc - presentation (%s)".printf(metadata.get_document().get_title());
 
             this.destroy.connect((source) => presentation_controller.quit());
 
-            this.presentation_controller = presentation_controller;
             this.presentation_controller.update_request.connect(this.update);
 
             Gdk.Rectangle scale_rect;

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -83,6 +83,8 @@ namespace pdfpc.Window {
             this.scroll_event.connect(this.presentation_controller.scroll);
 
             this.presentation_controller.register_controllable(this);
+
+            this.set_cache_observer(this.presentation_controller.cache_status);
         }
 
         /**

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -47,17 +47,17 @@ namespace pdfpc.Window {
         /**
          * Base constructor instantiating a new presentation window
          */
-        public Presentation(PresentationController presentation_controller,
+        public Presentation(PresentationController controller,
             int screen_num, int width = -1, int height = -1) {
             base(screen_num, width, height);
-            this.presentation_controller = presentation_controller;
+            this.controller = controller;
 
             this.role = "presentation";
             this.title = "pdfpc - presentation (%s)".printf(metadata.get_title());
 
-            this.destroy.connect((source) => presentation_controller.quit());
+            this.destroy.connect((source) => controller.quit());
 
-            this.presentation_controller.update_request.connect(this.update);
+            this.controller.update_request.connect(this.update);
 
             Gdk.Rectangle scale_rect;
             this.view = new View.Pdf.from_fullscreen(this,
@@ -78,13 +78,13 @@ namespace pdfpc.Window {
 
             this.add(overlay_layout);
 
-            this.key_press_event.connect(this.presentation_controller.key_press);
-            this.button_press_event.connect(this.presentation_controller.button_press);
-            this.scroll_event.connect(this.presentation_controller.scroll);
+            this.key_press_event.connect(this.controller.key_press);
+            this.button_press_event.connect(this.controller.button_press);
+            this.scroll_event.connect(this.controller.scroll);
 
-            this.presentation_controller.register_controllable(this);
+            this.controller.register_controllable(this);
 
-            this.set_cache_observer(this.presentation_controller.cache_status);
+            this.set_cache_observer(this.controller.cache_status);
         }
 
         /**
@@ -92,27 +92,27 @@ namespace pdfpc.Window {
          * other observed events
          */
         public void set_controller(PresentationController controller) {
-            this.presentation_controller = controller;
+            this.controller = controller;
         }
 
         /**
          * Update the display
          */
         public void update() {
-            this.visible = !this.presentation_controller.hidden;
+            this.visible = !this.controller.hidden;
 
-            if (this.presentation_controller.faded_to_black) {
+            if (this.controller.faded_to_black) {
                 this.view.fade_to_black();
                 return;
             }
-            if (this.presentation_controller.frozen)
+            if (this.controller.frozen)
                 return;
 
             try {
-                this.view.display(this.presentation_controller.current_slide_number, true);
+                this.view.display(this.controller.current_slide_number, true);
             } catch (Renderer.RenderError e) {
                 GLib.printerr("The pdf page %d could not be rendered: %s\n",
-                    this.presentation_controller.current_slide_number, e.message );
+                    this.controller.current_slide_number, e.message );
                 Process.exit(1);
             }
         }

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -752,7 +752,9 @@ namespace pdfpc.Window {
          * Update the slide count view
          */
         protected void update_slide_count() {
-            this.custom_slide_count(this.metadata.real_slide_to_user_slide(this.presentation_controller.current_slide_number) + 1);
+            int current_user_slide_number =
+                this.presentation_controller.current_user_slide_number;
+            this.custom_slide_count(current_user_slide_number + 1);
         }
 
         public void custom_slide_count(int current) {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -256,10 +256,10 @@ namespace pdfpc.Window {
             // is active
             var popup = button.get_popup();
             popup.show.connect(() => {
-                this.presentation_controller.set_ignore_input_events(true);
+                this.controller.set_ignore_input_events(true);
             });
             popup.hide.connect(() => {
-                this.presentation_controller.set_ignore_input_events(false);
+                this.controller.set_ignore_input_events(false);
             });
 
             return button;
@@ -268,25 +268,25 @@ namespace pdfpc.Window {
        /**
          * Base constructor instantiating a new presenter window
          */
-        public Presenter(PresentationController presentation_controller,
+        public Presenter(PresentationController controller,
             int screen_num) {
             base(screen_num);
 
-            this.presentation_controller = presentation_controller;
+            this.controller = controller;
 
             this.role = "presenter";
             this.title = "pdfpc - presenter (%s)".printf(metadata.get_title());
 
-            this.destroy.connect((source) => presentation_controller.quit());
+            this.destroy.connect((source) => controller.quit());
 
-            this.presentation_controller.reload_request.connect(this.on_reload);
-            this.presentation_controller.update_request.connect(this.update);
-            this.presentation_controller.edit_note_request.connect(this.edit_note);
-            this.presentation_controller.ask_goto_page_request.connect(this.ask_goto_page);
-            this.presentation_controller.show_overview_request.connect(this.show_overview);
-            this.presentation_controller.hide_overview_request.connect(this.hide_overview);
-            this.presentation_controller.increase_font_size_request.connect(this.increase_font_size);
-            this.presentation_controller.decrease_font_size_request.connect(this.decrease_font_size);
+            this.controller.reload_request.connect(this.on_reload);
+            this.controller.update_request.connect(this.update);
+            this.controller.edit_note_request.connect(this.edit_note);
+            this.controller.ask_goto_page_request.connect(this.ask_goto_page);
+            this.controller.show_overview_request.connect(this.show_overview);
+            this.controller.hide_overview_request.connect(this.hide_overview);
+            this.controller.increase_font_size_request.connect(this.increase_font_size);
+            this.controller.decrease_font_size_request.connect(this.decrease_font_size);
 
             // We need the value of 90% height a lot of times. Therefore store it
             // in advance
@@ -371,7 +371,7 @@ namespace pdfpc.Window {
             }
 
             // The countdown timer is centered in the 90% bottom part of the screen
-            this.timer = this.presentation_controller.getTimer();
+            this.timer = this.controller.getTimer();
             this.timer.name = "timer";
             this.timer.get_style_context().add_class("bottomText");
             this.timer.set_justify(Gtk.Justification.CENTER);
@@ -424,9 +424,9 @@ namespace pdfpc.Window {
             this.add_events(Gdk.EventMask.BUTTON_PRESS_MASK);
             this.add_events(Gdk.EventMask.SCROLL_MASK);
 
-            this.key_press_event.connect(this.presentation_controller.key_press);
-            this.button_press_event.connect(this.presentation_controller.button_press);
-            this.scroll_event.connect(this.presentation_controller.scroll);
+            this.key_press_event.connect(this.controller.key_press);
+            this.button_press_event.connect(this.controller.button_press);
+            this.scroll_event.connect(this.controller.scroll);
 
             // resize the bottom text based on the window height
             // (see http://stackoverflow.com/a/35237445/730138)
@@ -444,12 +444,12 @@ namespace pdfpc.Window {
                 GLib.printerr("Warning: failed to set CSS for auto-sized bottom controls.\n");
             }
 
-            this.overview = new Overview(this.presentation_controller);
+            this.overview = new Overview(this.controller);
             this.overview.vexpand = true;
             this.overview.hexpand = true;
-            this.overview.set_n_slides(this.presentation_controller.user_n_slides);
-            this.presentation_controller.set_overview(this.overview);
-            this.presentation_controller.register_controllable(this);
+            this.overview.set_n_slides(this.controller.user_n_slides);
+            this.controller.set_overview(this.overview);
+            this.controller.register_controllable(this);
 
             // Enable the render caching if it hasn't been forcefully disabled.
             if (!Options.disable_caching) {
@@ -617,50 +617,50 @@ namespace pdfpc.Window {
 
             tb = add_toolbox_button(button_panel, tbox_inverse, "empty.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.set_normal_mode();
+		    this.controller.set_normal_mode();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "highlight.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.set_pointer_mode();
+		    this.controller.set_pointer_mode();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "pen.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.set_pen_mode();
+		    this.controller.set_pen_mode();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "eraser.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.set_eraser_mode();
+		    this.controller.set_eraser_mode();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "snow.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.toggle_freeze();
+		    this.controller.toggle_freeze();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "blank.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.fade_to_black();
+		    this.controller.fade_to_black();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "hidden.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.hide_presentation();
+		    this.controller.hide_presentation();
 		});
             tb = add_toolbox_button(button_panel, tbox_inverse, "pause.svg");
             tb.clicked.connect(() => {
-		    this.presentation_controller.toggle_pause();
+		    this.controller.toggle_pause();
 		});
 
             scale_button = add_toolbox_sbutton(button_panel, tbox_inverse,
                 "linewidth.svg");
             scale_button.set_child_visible(false);
             scale_button.value_changed.connect((val) => {
-                this.presentation_controller.set_pen_size(val);
+                this.controller.set_pen_size(val);
             });
 
             color_button = add_toolbox_cbutton(button_panel, tbox_inverse);
             color_button.set_child_visible(false);
             color_button.color_set.connect(() => {
                     var rgba = color_button.rgba;
-                    this.presentation_controller.pen_drawing.pen.set_rgba(rgba);
-                    this.presentation_controller.queue_pen_surface_draws();
+                    this.controller.pen_drawing.pen.set_rgba(rgba);
+                    this.controller.queue_pen_surface_draws();
 		});
 
             this.toolbox_container = new Gtk.Fixed();
@@ -671,7 +671,7 @@ namespace pdfpc.Window {
 
             this.add(full_overlay);
 
-            this.set_cache_observer(this.presentation_controller.cache_status);
+            this.set_cache_observer(this.controller.cache_status);
         }
 
         public override void show() {
@@ -753,7 +753,7 @@ namespace pdfpc.Window {
          */
         protected void update_slide_count() {
             int current_user_slide_number =
-                this.presentation_controller.current_user_slide_number;
+                this.controller.current_user_slide_number;
             this.custom_slide_count(current_user_slide_number + 1);
         }
 
@@ -765,7 +765,7 @@ namespace pdfpc.Window {
         protected void update_toolbox() {
             toolbox.set_child_visible(Options.toolbox_shown);
 
-            var controller = this.presentation_controller;
+            var controller = this.controller;
 
             var rgba = controller.pen_drawing.pen.get_rgba();
             color_button.set_rgba(rgba);
@@ -792,18 +792,18 @@ namespace pdfpc.Window {
             if (!metadata.is_ready) {
                 return;
             }
-            int current_slide_number = this.presentation_controller.current_slide_number;
-            int current_user_slide_number = this.presentation_controller.current_user_slide_number;
+            int current_slide_number = this.controller.current_slide_number;
+            int current_user_slide_number = this.controller.current_user_slide_number;
             try {
                 this.current_view.display(current_slide_number, true);
                 this.next_view.display(this.metadata.user_slide_to_real_slide(
                     current_user_slide_number + 1), true);
-                if (this.presentation_controller.skip_next()) {
+                if (this.controller.skip_next()) {
                     this.strict_next_view.display(current_slide_number + 1, true);
                 } else {
                     this.strict_next_view.fade_to_black();
                 }
-                if (this.presentation_controller.skip_previous()) {
+                if (this.controller.skip_previous()) {
                     this.strict_prev_view.display(current_slide_number - 1, true);
                 } else {
                     this.strict_prev_view.fade_to_black();
@@ -820,34 +820,34 @@ namespace pdfpc.Window {
             } else {
                 this.pause_icon.hide();
             }
-            if (this.presentation_controller.faded_to_black) {
+            if (this.controller.faded_to_black) {
                 this.blank_icon.show();
             } else {
                 this.blank_icon.hide();
             }
-            if (this.presentation_controller.hidden) {
+            if (this.controller.hidden) {
                 this.hidden_icon.show();
                 // Ensure the presenter window remains focused
                 this.present();
             } else {
                 this.hidden_icon.hide();
             }
-            if (this.presentation_controller.frozen) {
+            if (this.controller.frozen) {
                 this.frozen_icon.show();
             } else {
                 this.frozen_icon.hide();
             }
-            if (this.presentation_controller.is_pointer_active()) {
+            if (this.controller.is_pointer_active()) {
                 this.highlight_icon.show();
             } else {
                 this.highlight_icon.hide();
             }
-            if (this.presentation_controller.is_eraser_active()) {
+            if (this.controller.is_eraser_active()) {
                 this.eraser_icon.show();
             } else {
                 this.eraser_icon.hide();
             }
-            if (this.presentation_controller.is_pen_active()) {
+            if (this.controller.is_pen_active()) {
                 this.pen_icon.show();
             } else {
                 this.pen_icon.hide();
@@ -886,11 +886,11 @@ namespace pdfpc.Window {
                 return;
             }
 
-            this.slide_progress.set_text("/%u".printf(this.presentation_controller.user_n_slides));
+            this.slide_progress.set_text("/%u".printf(this.controller.user_n_slides));
             this.slide_progress.sensitive = true;
             this.slide_progress.grab_focus();
             this.slide_progress.set_position(0);
-            this.presentation_controller.set_ignore_input_events(true);
+            this.controller.set_ignore_input_events(true);
         }
 
         /**
@@ -902,9 +902,9 @@ namespace pdfpc.Window {
                 string input_text = this.slide_progress.text;
                 int destination = int.parse(input_text.substring(0, input_text.index_of("/")));
                 this.slide_progress.sensitive = false;
-                this.presentation_controller.set_ignore_input_events(false);
+                this.controller.set_ignore_input_events(false);
                 if (destination != 0)
-                    this.presentation_controller.goto_user_page(destination);
+                    this.controller.goto_user_page(destination);
                 else
                     this.update_slide_count(); // Reset the display we had before
                 return true;
@@ -931,7 +931,7 @@ namespace pdfpc.Window {
             }
 
             // Disallow editing notes imported from PDF annotations
-            int number = this.presentation_controller.current_user_slide_number;
+            int number = this.controller.current_user_slide_number;
             if (this.metadata.get_notes().is_note_read_only(number)) {
                 blink_lock_icon();
                 return;
@@ -940,7 +940,7 @@ namespace pdfpc.Window {
             this.notes_view.editable = true;
             this.notes_view.cursor_visible = true;
             this.notes_view.grab_focus();
-            this.presentation_controller.set_ignore_input_events(true);
+            this.controller.set_ignore_input_events(true);
         }
 
         /**
@@ -951,8 +951,8 @@ namespace pdfpc.Window {
                 this.notes_view.editable = false;
                 this.notes_view.cursor_visible = false;
                 this.metadata.get_notes().set_note(this.notes_view.buffer.text,
-                    this.presentation_controller.current_user_slide_number);
-                this.presentation_controller.set_ignore_input_events(false);
+                    this.controller.current_user_slide_number);
+                this.controller.set_ignore_input_events(false);
                 return true;
             } else {
                 return false;
@@ -964,7 +964,7 @@ namespace pdfpc.Window {
          */
         protected void update_note() {
             string this_note = this.metadata.get_notes().get_note_for_slide(
-                this.presentation_controller.current_user_slide_number);
+                this.controller.current_user_slide_number);
             this.notes_view.buffer.text = this_note;
         }
 
@@ -974,7 +974,7 @@ namespace pdfpc.Window {
                 return;
             }
 
-            this.overview.current_slide = this.presentation_controller.current_user_slide_number;
+            this.overview.current_slide = this.controller.current_user_slide_number;
             this.slide_stack.set_visible_child_name("overview");
             this.overview.ensure_focus();
         }

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -778,9 +778,9 @@ namespace pdfpc.Window {
             int current_slide_number = this.presentation_controller.current_slide_number;
             int current_user_slide_number = this.presentation_controller.current_user_slide_number;
             try {
-                this.current_view.display(current_slide_number);
+                this.current_view.display(current_slide_number, true);
                 this.next_view.display(this.metadata.user_slide_to_real_slide(
-                    current_user_slide_number + 1));
+                    current_user_slide_number + 1), true);
                 if (this.presentation_controller.skip_next()) {
                     this.strict_next_view.display(current_slide_number + 1, true);
                 } else {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -904,7 +904,7 @@ namespace pdfpc.Window {
                 this.slide_progress.sensitive = false;
                 this.controller.set_ignore_input_events(false);
                 if (destination != 0)
-                    this.controller.goto_user_page(destination);
+                    this.controller.goto_user_page(destination - 1);
                 else
                     this.update_slide_count(); // Reset the display we had before
                 return true;

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -300,15 +300,13 @@ namespace pdfpc.Window {
             Gdk.Rectangle current_slide_rect;
             int current_allocated_width = (int) Math.floor(
                 this.screen_geometry.width * Options.current_size / (double) 100);
-            this.current_view = new View.Pdf.from_metadata(
-                metadata,
+            this.current_view = new View.Pdf.from_fullscreen(
+                this,
                 current_allocated_width,
                 (int) Math.floor(Options.current_height * bottom_position / (double) 100),
                 Metadata.Area.NOTES,
                 Options.black_on_end,
                 true,
-                this.presentation_controller,
-                this.gdk_scale,
                 out current_slide_rect
             );
 
@@ -321,40 +319,34 @@ namespace pdfpc.Window {
             this.next_allocated_width = next_allocated_width;
             // We leave a bit of margin between the two views
             Gdk.Rectangle next_slide_rect;
-            this.next_view = new View.Pdf.from_metadata(
-                metadata,
+            this.next_view = new View.Pdf.from_fullscreen(
+                this,
                 next_allocated_width,
                 (int) Math.floor(Options.next_height * bottom_position / (double)100 ),
                 Metadata.Area.CONTENT,
                 true,
                 false,
-                this.presentation_controller,
-                this.gdk_scale,
                 out next_slide_rect
             );
 
             Gdk.Rectangle strict_next_slide_rect;
-            this.strict_next_view = new View.Pdf.from_metadata(
-                metadata,
+            this.strict_next_view = new View.Pdf.from_fullscreen(
+                this,
                 (int) Math.floor(0.5 * current_allocated_width),
                 (int) (Options.disable_auto_grouping ? 1 : (Math.floor(0.19 * bottom_position) - 2)),
                 Metadata.Area.CONTENT,
                 true,
                 false,
-                this.presentation_controller,
-                this.gdk_scale,
                 out strict_next_slide_rect
             );
             Gdk.Rectangle strict_prev_slide_rect;
-            this.strict_prev_view = new View.Pdf.from_metadata(
-                metadata,
+            this.strict_prev_view = new View.Pdf.from_fullscreen(
+                this,
                 (int) Math.floor(0.5 * current_allocated_width),
                 (int) (Options.disable_auto_grouping ? 1 : (Math.floor(0.19 * bottom_position) - 2)),
                 Metadata.Area.CONTENT,
                 true,
                 false,
-                this.presentation_controller,
-                this.gdk_scale,
                 out strict_prev_slide_rect
             );
 

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -305,7 +305,6 @@ namespace pdfpc.Window {
                 current_allocated_width,
                 (int) Math.floor(Options.current_height * bottom_position / (double) 100),
                 Metadata.Area.NOTES,
-                Options.black_on_end,
                 true,
                 out current_slide_rect
             );
@@ -324,7 +323,6 @@ namespace pdfpc.Window {
                 next_allocated_width,
                 (int) Math.floor(Options.next_height * bottom_position / (double)100 ),
                 Metadata.Area.CONTENT,
-                true,
                 false,
                 out next_slide_rect
             );
@@ -335,7 +333,6 @@ namespace pdfpc.Window {
                 (int) Math.floor(0.5 * current_allocated_width),
                 (int) (Options.disable_auto_grouping ? 1 : (Math.floor(0.19 * bottom_position) - 2)),
                 Metadata.Area.CONTENT,
-                true,
                 false,
                 out strict_next_slide_rect
             );
@@ -345,7 +342,6 @@ namespace pdfpc.Window {
                 (int) Math.floor(0.5 * current_allocated_width),
                 (int) (Options.disable_auto_grouping ? 1 : (Math.floor(0.19 * bottom_position) - 2)),
                 Metadata.Area.CONTENT,
-                true,
                 false,
                 out strict_prev_slide_rect
             );

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -279,6 +279,7 @@ namespace pdfpc.Window {
 
             this.destroy.connect((source) => presentation_controller.quit());
 
+            this.presentation_controller.reload_request.connect(this.on_reload);
             this.presentation_controller.update_request.connect(this.update);
             this.presentation_controller.edit_note_request.connect(this.edit_note);
             this.presentation_controller.ask_goto_page_request.connect(this.ask_goto_page);
@@ -669,6 +670,8 @@ namespace pdfpc.Window {
             full_overlay.set_overlay_pass_through(this.toolbox_container, true);
 
             this.add(full_overlay);
+
+            this.set_cache_observer(this.presentation_controller.cache_status);
         }
 
         public override void show() {
@@ -769,6 +772,18 @@ namespace pdfpc.Window {
             scale_button.set_value(controller.get_pen_size());
             scale_button.set_child_visible(controller.is_pen_active() ||
                 controller.is_eraser_active());
+        }
+
+        /**
+         * Called on document reload. Currently, only re-enables the cache
+         * progress indicator, but in principle the document geometry may
+         * change; TODO
+         */
+        public void on_reload() {
+            if (!Options.disable_caching) {
+                this.prerender_progress.set_fraction(0);
+                this.prerender_progress.opacity = 1;
+            }
         }
 
         public void update() {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -469,7 +469,7 @@ namespace pdfpc.Window {
                 GLib.printerr("Warning: failed to set CSS for auto-sized bottom controls.\n");
             }
 
-            this.overview = new Overview(this.metadata, this.presentation_controller, this);
+            this.overview = new Overview(this.presentation_controller);
             this.overview.vexpand = true;
             this.overview.hexpand = true;
             this.overview.set_n_slides(this.presentation_controller.user_n_slides);

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -37,11 +37,6 @@ namespace pdfpc.Window {
      */
     public class Presenter : Fullscreen, Controllable {
         /**
-         * The registered PresentationController
-         */
-        public PresentationController presentation_controller { get; protected set; }
-
-        /**
          * Only handle links and annotations on the current_view
          */
         public View.Pdf main_view {
@@ -178,15 +173,6 @@ namespace pdfpc.Window {
          * Size of the toolbox button icons
          **/
         private int toolbox_icon_height;
-
-        /**
-         * Metadata of the slides
-         */
-        protected Metadata.Pdf metadata {
-            get {
-                return this.presentation_controller.metadata;
-            }
-        }
 
         /**
          * Width of next/notes area

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -275,7 +275,7 @@ namespace pdfpc.Window {
             this.presentation_controller = presentation_controller;
 
             this.role = "presenter";
-            this.title = "pdfpc - presenter (%s)".printf(metadata.get_document().get_title());
+            this.title = "pdfpc - presenter (%s)".printf(metadata.get_title());
 
             this.destroy.connect((source) => presentation_controller.quit());
 
@@ -772,6 +772,9 @@ namespace pdfpc.Window {
         }
 
         public void update() {
+            if (!metadata.is_ready) {
+                return;
+            }
             int current_slide_number = this.presentation_controller.current_slide_number;
             int current_user_slide_number = this.presentation_controller.current_user_slide_number;
             try {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -182,7 +182,11 @@ namespace pdfpc.Window {
         /**
          * Metadata of the slides
          */
-        protected Metadata.Pdf metadata;
+        protected Metadata.Pdf metadata {
+            get {
+                return this.presentation_controller.metadata;
+            }
+        }
 
         /**
          * Width of next/notes area
@@ -278,15 +282,17 @@ namespace pdfpc.Window {
        /**
          * Base constructor instantiating a new presenter window
          */
-        public Presenter(Metadata.Pdf metadata, int screen_num,
-            PresentationController presentation_controller) {
+        public Presenter(PresentationController presentation_controller,
+            int screen_num) {
             base(screen_num);
+
+            this.presentation_controller = presentation_controller;
+
             this.role = "presenter";
             this.title = "pdfpc - presenter (%s)".printf(metadata.get_document().get_title());
 
             this.destroy.connect((source) => presentation_controller.quit());
 
-            this.presentation_controller = presentation_controller;
             this.presentation_controller.update_request.connect(this.update);
             this.presentation_controller.edit_note_request.connect(this.edit_note);
             this.presentation_controller.ask_goto_page_request.connect(this.ask_goto_page);
@@ -294,8 +300,6 @@ namespace pdfpc.Window {
             this.presentation_controller.hide_overview_request.connect(this.hide_overview);
             this.presentation_controller.increase_font_size_request.connect(this.increase_font_size);
             this.presentation_controller.decrease_font_size_request.connect(this.decrease_font_size);
-
-            this.metadata = metadata;
 
             // We need the value of 90% height a lot of times. Therefore store it
             // in advance

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -775,7 +775,7 @@ namespace pdfpc.Window {
         }
 
         public void custom_slide_count(int current) {
-            int total = this.presentation_controller.get_end_user_slide();
+            int total = this.metadata.get_end_user_slide();
             this.slide_progress.set_text("%d/%u".printf(current, total));
         }
 

--- a/src/interfaces/controllable.vala
+++ b/src/interfaces/controllable.vala
@@ -32,7 +32,7 @@ namespace pdfpc {
         /**
          * The registered PresentationController
          */
-        public abstract PresentationController presentation_controller { get; protected set; }
+        public abstract PresentationController controller { get; protected set; }
 
         /**
          * The view on which links and annotations should be handled.

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -335,21 +335,7 @@ namespace pdfpc {
                 Options.windowed = true;
             }
 
-            string cwd = GLib.Environment.get_current_dir();
-            if (!GLib.Path.is_absolute(pdfFilename)) {
-                pdfFilename = GLib.Path.build_filename(cwd, pdfFilename);
-            }
-            var pdfpc_location = Options.pdfpc_location;
-            if (pdfpc_location != null && !GLib.Path.is_absolute(pdfpc_location)) {
-                pdfpc_location = GLib.Path.build_filename(cwd, pdfpc_location);
-            }
-
-            if (pdfpc_location != null && !GLib.FileUtils.test(pdfpc_location, (GLib.FileTest.IS_REGULAR))) {
-                GLib.printerr("Can't find custom pdfpc file at %s\n", pdfpc_location);
-                Process.exit(1);
-            }
-
-            var metadata = new Metadata.Pdf(pdfFilename, pdfpc_location);
+            var metadata = new Metadata.Pdf(pdfFilename);
 
             // Initialize global controller and CacheStatus, to manage
             // crosscutting concerns between the different windows.

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -339,7 +339,8 @@ namespace pdfpc {
 
             // Initialize global controller and CacheStatus, to manage
             // crosscutting concerns between the different windows.
-            this.controller = new PresentationController(metadata);
+            this.controller = new PresentationController();
+            this.controller.metadata = metadata;
             this.cache_status = new CacheStatus();
 
             set_styling();

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -269,6 +269,11 @@ namespace pdfpc {
                 GLib.printerr("--notes option detected. Disable auto grouping.\n");
             }
 
+            // If end_time is set, reset duration to 0
+            if (Options.end_time != null) {
+                Options.duration = 0;
+            }
+
             // if pdfpc runs at a tablet we force the toolbox to be shown
             var seat = display.get_default_seat();
             var touchSeats = seat.get_slaves(Gdk.SeatCapabilities.TOUCH);

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -210,7 +210,7 @@ namespace pdfpc {
          * while displaying the given file
          */
         private Window.Presenter create_presenter(Metadata.Pdf metadata, int monitor) {
-            var presenter = new Window.Presenter(metadata, monitor, this.controller);
+            var presenter = new Window.Presenter(this.controller, monitor);
             presenter.set_cache_observer(this.cache_status);
 
             return presenter;
@@ -220,8 +220,10 @@ namespace pdfpc {
          * Create and return a PresentationWindow using the specified monitor
          * while displaying the given file
          */
-        private Window.Presentation create_presentation(Metadata.Pdf metadata, int monitor, int width = -1, int height = -1) {
-            var presentation = new Window.Presentation(metadata, monitor, this.controller, width, height);
+        private Window.Presentation create_presentation(Metadata.Pdf metadata,
+            int monitor, int width = -1, int height = -1) {
+            var presentation = new Window.Presentation(this.controller, monitor,
+                width, height);
             presentation.set_cache_observer(this.cache_status);
 
             return presentation;

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -339,7 +339,7 @@ namespace pdfpc {
 
             // Initialize global controller and CacheStatus, to manage
             // crosscutting concerns between the different windows.
-            this.controller = new PresentationController( metadata, Options.black_on_end );
+            this.controller = new PresentationController(metadata);
             this.cache_status = new CacheStatus();
 
             set_styling();

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -42,13 +42,6 @@ namespace pdfpc {
         private PresentationController controller;
 
         /**
-         * CacheStatus widget, which coordinates all the information about
-         * cached slides to provide a visual feedback to the user about the
-         * rendering state
-         */
-        private CacheStatus cache_status;
-
-        /**
          * Commandline option parser entry definitions
          */
         const OptionEntry[] options = {
@@ -206,30 +199,6 @@ namespace pdfpc {
         }
 
         /**
-         * Create and return a PresenterWindow using the specified monitor
-         * while displaying the given file
-         */
-        private Window.Presenter create_presenter(int monitor) {
-            var presenter = new Window.Presenter(this.controller, monitor);
-            presenter.set_cache_observer(this.cache_status);
-
-            return presenter;
-        }
-
-        /**
-         * Create and return a PresentationWindow using the specified monitor
-         * while displaying the given file
-         */
-        private Window.Presentation create_presentation(int monitor,
-            int width = -1, int height = -1) {
-            var presentation = new Window.Presentation(this.controller, monitor,
-                width, height);
-            presentation.set_cache_observer(this.cache_status);
-
-            return presentation;
-        }
-
-        /**
          * Main application function, which instantiates the windows and
          * initializes the Gtk system.
          */
@@ -344,11 +313,10 @@ namespace pdfpc {
 
             var metadata = new Metadata.Pdf(pdfFilename);
 
-            // Initialize global controller and CacheStatus, to manage
+            // Initialize global controller to manage
             // crosscutting concerns between the different windows.
             this.controller = new PresentationController();
             this.controller.metadata = metadata;
-            this.cache_status = new CacheStatus();
 
             set_styling();
 
@@ -376,12 +344,13 @@ namespace pdfpc {
 
             if (!Options.single_screen || !Options.display_switch) {
                 this.controller.presenter =
-                    this.create_presenter(presenter_monitor);
+                    new Window.Presenter(this.controller, presenter_monitor);
+
             }
             if (!Options.single_screen || Options.display_switch) {
                 this.controller.presentation =
-                    this.create_presentation(presentation_monitor,
-                        width, height);
+                    new Window.Presentation(this.controller,
+                        presentation_monitor, width, height);
             }
 
             // The windows are always displayed at last to be sure all caches

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -209,7 +209,7 @@ namespace pdfpc {
          * Create and return a PresenterWindow using the specified monitor
          * while displaying the given file
          */
-        private Window.Presenter create_presenter(Metadata.Pdf metadata, int monitor) {
+        private Window.Presenter create_presenter(int monitor) {
             var presenter = new Window.Presenter(this.controller, monitor);
             presenter.set_cache_observer(this.cache_status);
 
@@ -220,8 +220,8 @@ namespace pdfpc {
          * Create and return a PresentationWindow using the specified monitor
          * while displaying the given file
          */
-        private Window.Presentation create_presentation(Metadata.Pdf metadata,
-            int monitor, int width = -1, int height = -1) {
+        private Window.Presentation create_presentation(int monitor,
+            int width = -1, int height = -1) {
             var presentation = new Window.Presentation(this.controller, monitor,
                 width, height);
             presentation.set_cache_observer(this.cache_status);
@@ -375,12 +375,13 @@ namespace pdfpc {
             }
 
             if (!Options.single_screen || !Options.display_switch) {
-                this.controller.presenter = this.create_presenter(metadata,
-                    presenter_monitor);
+                this.controller.presenter =
+                    this.create_presenter(presenter_monitor);
             }
             if (!Options.single_screen || Options.display_switch) {
-                this.controller.presentation = this.create_presentation(metadata,
-                    presentation_monitor, width, height);
+                this.controller.presentation =
+                    this.create_presentation(presentation_monitor,
+                        width, height);
             }
 
             // The windows are always displayed at last to be sure all caches


### PR DESCRIPTION
This is quite an invasive changeset, touching almost every source file. When I started implementing the reload stuff I didn't expect it would be _that_ large... The assumption of the document properties set once and forever was literally everywhere.

I kept each change small so it is easy to see what is going on. If desired, everything can be squashed into a single commit.

One thing that wouldn't work correctly still is the document page size changes between reloads. But it is really exotic. A proper implementation would require rearranging the whole GUI, and so better be postponed to #408.