### PR TITLE
Automatically generated lists of action descriptions and bindings

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -29,6 +29,9 @@ monitors).
 
 .SH OPTIONS
 .TP
+.BI "\-B, \-\-list\-bindings"
+List action bindings defined
+.TP
 .BI "\-c, \-\-disable\-cache"
 Disable caching and pre-rendering of slides to save memory at the cost of speed.
 .TP
@@ -53,7 +56,7 @@ Show this help
 Time in minutes, from which on the timer changes its color. (Default: 5 minutes)
 .TP
 .BI "\-L, \-\-list\-actions"
-List actions supported in the config file(s)
+List actions supported
 .TP
 .BI "\-M, \-\-list\-monitors"
 List monitors known to the operating system

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -185,11 +185,7 @@ the size of pen or eraser
 Clear the drawing on the current page
 .TP
 .B d
-Toggle visibility the drawings; if in the drawing mode (pen/eraser), exit it
-.TP
-.B Shift + 1 / KP_1 ... Shift + 8 / KP_8
-Switch the drawing color to red/orange/yellow/green/blue/violet/black/white,
-respectively.
+Toggle visibility of the drawings; if in the drawing mode (pen/eraser), exit it
 .TP
 .B f
 Freeze the current presentation display (the presenter display is still

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -38,8 +38,9 @@ Unbind a mouse button
 Clear all the mouse bindings
 
 .PP
-A list of all possible actions can be obtained
-via the \-L command line option of \fBpdfpc\fR(1).
+A list of all possible actions can be obtained via the \fB\-L\fR command line
+option of \fBpdfpc\fR(1). Use the \fB\-B\fR command line option to list the
+action bindings defined.
 
 .SS Options
 .PP

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -38,6 +38,17 @@ Unbind a mouse button
 Clear all the mouse bindings
 
 .PP
+Key names can be obtained with the help of the \fBxev\fR(1) utility. Note that
+names are case sensitive. Key combinations with modifiers can be specified in
+the form <mod>+<key>, where <mod> is one of S (for shift), C (for control) and
+A/M (for Alt/Meta).
+
+.PP
+A shorthand for specifying key combinations constituting shift and an
+alphabetic character is to simply give the uppercase version of the
+alphabetic character. For example, S+r and R are equivalent.
+
+.PP
 A list of all possible actions can be obtained via the \fB\-L\fR command line
 option of \fBpdfpc\fR(1). Use the \fB\-B\fR command line option to list the
 action bindings defined.
@@ -133,23 +144,14 @@ Set the initial toolbox state minimized (bool, Default is false).
 .SH EXAMPLES
 
 .PP
-Key names can be obtained with the help of the xev utility. Note that
-names are case sensitive. Modifiers can be specified in the form
-<mod>+<key> where <mod> is one of S (for shift), C (for control) and
-A/M (for Alt/Meta). E.g.
+To change the drawing pen color using the numerical pad keys:
 
 .RS
-bind S+Next    next10
-.RE
-
-.PP
-A shorthand for specifying key combinations constituting shift and an
-alphabetic character is to simply give the uppercase version of the
-alphabetic character. For example, to bind <shift>+r to the 'reset'
-action, use
-
-.RS
-bind R reset
+bind S+KP_1    setPenColor  red
+.br
+bind S+KP_2    setPenColor  green
+.br
+bind S+KP_3    setPenColor  blue
 .RE
 
 .PP

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -18,8 +18,9 @@ user-specific one if it exists.
 .PP
 The following commands are accepted:
 .TP
-.B bind <key> <func> [<arg>]
-Bind a key to a function, passing a specified argument for functions which require one
+.B bind <key> <action> [<arg>]
+Bind a key to an action, passing a specified argument for actions that require
+one
 .TP
 .B unbind <key>
 Unbind the given key
@@ -27,8 +28,8 @@ Unbind the given key
 .B unbind_all
 Clear all the key bindings
 .TP
-.B mouse <button> <func>
-Bind a mouse button to a function
+.B mouse <button> <action>
+Bind a mouse button to an action
 .TP
 .B unmouse <button>
 Unbind a mouse button
@@ -37,7 +38,7 @@ Unbind a mouse button
 Clear all the mouse bindings
 
 .PP
-A list of all possible functions can be obtained
+A list of all possible actions can be obtained
 via the \-L command line option of \fBpdfpc\fR(1).
 
 .SS Options
@@ -144,7 +145,7 @@ bind S+Next    next10
 A shorthand for specifying key combinations constituting shift and an
 alphabetic character is to simply give the uppercase version of the
 alphabetic character. For example, to bind <shift>+r to the 'reset'
-function, use
+action, use
 
 .RS
 bind R reset

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -165,6 +165,11 @@ namespace pdfpc {
         public static bool list_actions = false;
 
         /**
+         * Show the defined action bindings
+         */
+        public static bool list_bindings = false;
+
+        /**
          * Show the available monitors(s)
          */
         public static bool list_monitors = false;

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1033,29 +1033,50 @@ namespace pdfpc {
         }
 
         /**
-         * Bind the (user-defined) keys
+         * Bind the (user-defined) key or mouse button
          */
-        public void bind(uint keycode, uint modMask, string action_name, GLib.Variant? parameter) {
+        private void bindKeyOrMouse(bool is_mouse, uint keycode, uint modMask,
+            string action_name, GLib.Variant? parameter) {
             Action? action = this.action_group.lookup_action(action_name);
             if (action != null) {
                 GLib.VariantType expected_type = action.get_parameter_type();
                 if (expected_type == null) {
                     if (parameter != null) {
-                        GLib.printerr("Parameter provided to action %s that does not expect one\n", action_name);
+                        GLib.printerr("Action %s does not expect a parameter\n",
+                            action_name);
                     }
                 } else if (parameter == null) {
-                    GLib.printerr("Parameter expected for action %s but not provided\n", action_name);
+                    GLib.printerr("Action %s expects a parameter\n",
+                        action_name);
                 } else {
                     assert(
                         parameter.get_type().equal(GLib.VariantType.STRING) &&
                         expected_type.equal(GLib.VariantType.STRING)
                     );
                 }
-                this.keyBindings.set(new KeyDef(keycode, modMask),
+                Gee.HashMap<KeyDef, ActionAndParameter> bindings;
+                if (is_mouse) {
+                    bindings = this.mouseBindings;
+                } else {
+                    bindings = this.keyBindings;
+                }
+                bindings.set(new KeyDef(keycode, modMask),
                     new ActionAndParameter(action, parameter));
             } else {
                 GLib.printerr("Unknown action %s\n", action_name);
             }
+        }
+
+        private void bind(uint keycode, uint modMask,
+            string action_name, GLib.Variant? parameter) {
+            this.bindKeyOrMouse(false, keycode, modMask,
+                action_name, parameter);
+        }
+
+        private void bindMouse(uint keycode, uint modMask,
+            string action_name, GLib.Variant? parameter) {
+            this.bindKeyOrMouse(true, keycode, modMask,
+                action_name, parameter);
         }
 
         /**
@@ -1070,32 +1091,6 @@ namespace pdfpc {
          */
         public void unbindAll() {
             this.keyBindings.clear();
-        }
-
-        /**
-         * Bind the (user-defined) keys
-         */
-        public void bindMouse(uint button, uint modMask, string action_name, Variant? parameter) {
-            Action? action = this.action_group.lookup_action(action_name);
-            if (action != null) {
-                GLib.VariantType expected_type = action.get_parameter_type();
-                if (expected_type == null) {
-                    if (parameter != null) {
-                        GLib.printerr("Parameter provided to action %s that does not expect one\n", action_name);
-                    }
-                } else if (parameter == null) {
-                    GLib.printerr("Parameter expected for action %s but not provided\n", action_name);
-                } else {
-                    assert(
-                        parameter.get_type().equal(GLib.VariantType.STRING) &&
-                        expected_type.equal(GLib.VariantType.STRING)
-                    );
-                }
-                this.mouseBindings.set(new KeyDef(button, modMask),
-                    new ActionAndParameter(action, parameter));
-            } else {
-                GLib.printerr("Unknown action %s\n", action_name);
-            }
         }
 
         /**

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -66,6 +66,9 @@ namespace pdfpc {
             {"list-actions", 'L', 0, 0,
                 ref Options.list_actions,
                 "List actions supported in the config file(s)", null},
+            {"list-bindings", 'B', 0, 0,
+                ref Options.list_bindings,
+                "List action bindings defined", null},
             {"list-monitors", 'M', 0, 0,
                 ref Options.list_monitors,
                 "List available monitors", null},
@@ -303,6 +306,21 @@ namespace pdfpc {
                         tabAlignment += "\t";
                     }
                     GLib.print("    %s%s=> %s\n",
+                        actions[i], tabAlignment, actions[i+1]);
+                }
+
+                return;
+            }
+
+            if (Options.list_bindings) {
+                GLib.print("Action bindings defined:\n");
+                var actions = this.controller.get_action_bindings();
+                for (int i = 0; i < actions.length; i += 2) {
+                    string tabAlignment = "\t";
+                    if (actions[i].length < 12) {
+                        tabAlignment += "\t";
+                    }
+                    GLib.print("    %s%s<= %s\n",
                         actions[i], tabAlignment, actions[i+1]);
                 }
 

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -272,26 +272,6 @@ namespace pdfpc {
 #if MOVIES
             Gst.init(ref args);
 #endif
-            if (Options.list_actions) {
-                GLib.print("Config file commands accepted by pdfpc:\n");
-                string[] actions = PresentationController.getActionDescriptions();
-                for (int i = 0; i < actions.length; i+=2) {
-                    string tabAlignment = "\t";
-                    if (actions[i].length < 12)
-                        tabAlignment += "\t";
-                    GLib.print("    %s%s=> %s\n", actions[i], tabAlignment, actions[i+1]);
-                }
-
-                return;
-            }
-            if (pdfFilename == null) {
-                GLib.printerr("No pdf file given\n");
-                Process.exit(1);
-            } else if (!GLib.FileUtils.test(pdfFilename, (GLib.FileTest.IS_REGULAR))) {
-                GLib.printerr("Pdf file \"%s\" not found\n", pdfFilename);
-                Process.exit(1);
-            }
-
             // parse size option
             // should be in the width:height format
 
@@ -311,11 +291,34 @@ namespace pdfpc {
                 Options.windowed = true;
             }
 
-            var metadata = new Metadata.Pdf(pdfFilename);
-
-            // Initialize global controller to manage
-            // crosscutting concerns between the different windows.
+            // Initialize the master controller
             this.controller = new PresentationController();
+
+            if (Options.list_actions) {
+                GLib.print("Actions supported by pdfpc:\n");
+                var actions = this.controller.get_action_descriptions();
+                for (int i = 0; i < actions.length; i += 2) {
+                    string tabAlignment = "\t";
+                    if (actions[i].length < 12) {
+                        tabAlignment += "\t";
+                    }
+                    GLib.print("    %s%s=> %s\n",
+                        actions[i], tabAlignment, actions[i+1]);
+                }
+
+                return;
+            }
+
+            if (pdfFilename == null) {
+                GLib.printerr("No pdf file given\n");
+                Process.exit(1);
+            } else if (!GLib.FileUtils.test(pdfFilename,
+                (GLib.FileTest.IS_REGULAR))) {
+                GLib.printerr("Pdf file \"%s\" not found\n", pdfFilename);
+                Process.exit(1);
+            }
+
+            var metadata = new Metadata.Pdf(pdfFilename);
             this.controller.metadata = metadata;
 
             set_styling();


### PR DESCRIPTION
This changeset guarantees that the "-L" output will always be in sync with the available actions by generating it automatically instead of the hand-written array. Also, adds a similar "-B" list of bindings. The latter will also be used to implement #326, of course.