### PR TITLE
Add the --external-script command line option.

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -99,6 +99,23 @@ Enable Wayland-specific workaround. This might fix HiDPI scaling problems.
 Run in the given windowed mode (presenter|presentation|both|none). The default
 mode is "none" (both windows are fullscreen).
 .TP
+.BI "\-X, \-\-external-script"=FILENAME
+Specify a script to be executed with the 'X' (Shift+x) key during the
+presentation. The script must be executable but can otherwise be
+written in any language. The script is called with the following
+command line arguments:
+
+\[bu] Name of pdf file
+.br
+\[bu] Total slide count
+.br
+\[bu] Current slide number
+.br
+\[bu] Current user slide number
+
+If the script exits with a non-zero return value, whatever the script
+wrote to stdout is printed in the console. Otherwise nothing is printed.
+.TP
 .BI "\-z, \-\-disable\-compression"
 Disable the compression of slide images to trade memory consumption for speed.
 (Avg.  factor 30)

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -93,7 +93,10 @@ bind d                  toggleDrawings
 
 # Pen colors
 # Can be set by
-# bind S+1                setPenColor red|orange|yellow|green|blue|violet|black|white
+# bind S+1              setPenColor red|orange|yellow|green|blue|violet|black|white
+
+# Script execution
+bind S+x                executeScript
 
 # Short help
 bind question           showHelp

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -37,6 +37,13 @@ namespace pdfpc {
         }
 
         /**
+         * Commandline option enabeling the execution of external
+         * scripts. Only the scripts explicitly given on the
+         * commandline can be executed.
+         */
+        public static string external_script = "none";
+        
+        /**
          * Commandline option specifying if the presenter and presentation screen
          * should be switched.
          */

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -766,12 +766,11 @@ namespace pdfpc {
          */ 
         public void execute_external_script() {
             if (Options.external_script == "none") {
-                GLib.print("Script execution disabled\n");
                 return;
             }
 
             string scriptname = Options.external_script;
-            GLib.print(@"Executing script $scriptname\n");
+            GLib.print("Executing external script\n");
             
             string std_out;
             int exit_status;
@@ -782,7 +781,7 @@ namespace pdfpc {
                     @"$scriptname $pdfname $n_slides $(current_slide_number+1) $(current_user_slide_number+1)",
                     out std_out, null, out exit_status);
                 if (exit_status != 0) {
-                    GLib.print(@"$scriptname returned $exit_status; wrote:\n$std_out");
+                    GLib.print(@"Script returned $exit_status.\n$std_out\n");
                 }
             } catch (SpawnError e) {
                 GLib.print(@"Error: $(e.message)\n");

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -44,7 +44,10 @@ namespace pdfpc {
         /**
          * Commandline option parser entry definitions
          */
-        const OptionEntry[] options = {
+        const OptionEntry[] options = {		 
+            {"external-script", 'X', 0, OptionArg.STRING,
+                ref Options.external_script,
+                "Enable the execution of a particular external script", "filename"},
             {"disable-cache", 'c', 0, 0,
                 ref Options.disable_caching,
                 "Disable caching and pre-rendering of slides", null},


### PR DESCRIPTION
If a script has been specified on the command line, the 'X'
(Shift+x) key executes it. The script is called with the following
commandline arguments:

 - name of pdf file
 - total slide count
 - current slide number
 - current user slide number

If the script exits with a non-zero return value, whatever the script
wrote to stdout is printed in the console.

Related to issue #431