### PR TITLE
disable event compression using the same Gtk window used to listen for mouse events

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -580,7 +580,7 @@ namespace pdfpc {
 
             if (this.presenter != null) {
                 // Disable event compression for smoother drawing
-                this.presenter.get_window().set_event_compression(!in_drawing_mode());
+                this.presenter.main_view.get_window().set_event_compression(!in_drawing_mode());
             }
 
             this.controllables_update();


### PR DESCRIPTION
At least for me (Ubuntu 18.04, Gtk 3.22), disabling event compression on presenter.get_window() doesn't seem sufficient to get smooth drawings. Using the Gtk window that's used to listen for mouse motion events (presenter.main_view.get_window(), matching how mouse handlers are registered in register_mouse_handlers()) seems to work a lot better.