### PR TITLE
Update overview on reload only when it exists

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1737,7 +1737,6 @@ namespace pdfpc {
                 this.pen_drawing.clear_storage();
                 this.clear_pen_drawing();
 
-                this.overview.set_n_slides(this.user_n_slides);
                 this.metadata.renderer.invalidate_cache();
                 this.reload_request();
                 this.controllables_update();

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -872,6 +872,7 @@ namespace pdfpc.Window {
             this.next_view.invalidate();
             this.strict_next_view.invalidate();
             this.strict_prev_view.invalidate();
+            this.overview.set_n_slides(this.controller.user_n_slides);
         }
 
         public void update() {


### PR DESCRIPTION
Otherwise, in the single-screen presentation mode (-sS) we get "assertion 'self != NULL' failed".