### PR TITLE
The second set of transitions implementation

### DIFF
--- a/latex/pdfpc/pdfpc-doc.dtx
+++ b/latex/pdfpc/pdfpc-doc.dtx
@@ -50,7 +50,7 @@
 
 \title{The \sty{pdfpc} package \\ {\large\url{https://github.com/pdfpc/pdfpc}}}
 \author{Evgeny Stambulchik}
-\date{2020/03/07 (v0.2.1)}
+\date{2020/03/09 (v0.3.0)}
 
 \hypersetup{pdftitle={The pdfpc package}, pdfauthor={Evgeny Stambulchik}}
 
@@ -110,6 +110,7 @@ The following \param{options} may be given as comma-separated list:
 \item \texttt{enduserslide}
 \item \texttt{lastminutes}
 \item \texttt{overridenote}
+\item \texttt{defaulttransition}
 \end{itemize}
 
 The meaning and possible values are documented in \textit{pdfpcrc(5)} man page

--- a/latex/pdfpc/pdfpc.dtx
+++ b/latex/pdfpc/pdfpc.dtx
@@ -55,7 +55,7 @@
 %
 % Identify the package and force \LaTeXe:
 %    \begin{macrocode}
-\ProvidesPackage{pdfpc}[2019/12/03 v0.2.1 PDFPC]
+\ProvidesPackage{pdfpc}[2020/03/09 v0.3.0 PDFPC]
 \NeedsTeXFormat{LaTeX2e}
 %    \end{macrocode}
 %
@@ -79,6 +79,7 @@
 \DeclareStringOption{lastminutes}
 \DeclareBoolOption{overridenote}
 \DeclareStringOption{notesposition}
+\DeclareStringOption{defaulttransition}
 \DeclareDefaultOption{\@unknownoptionerror}
 %
 \ProcessKeyvalOptions*
@@ -158,6 +159,7 @@ ______<rdf:Description xmlns:pdfpc="https://github.com/pdfpc/pdfpc">^^J%
   \hyxmp@add@simple{pdfpc:EndUserSlide}{\PDFPC@enduserslide}%
   \hyxmp@add@simple{pdfpc:LastMinutes}{\PDFPC@lastminutes}%
   \hyxmp@add@simple{pdfpc:NotesPosition}{\PDFPC@notesposition}%
+  \hyxmp@add@simple{pdfpc:DefaultTransition}{\PDFPC@defaulttransition}%
   \hyxmp@add@to@xml{%
 ______</rdf:Description>^^J%
   }%

--- a/latex/pdfpc/pdfpc.pkg
+++ b/latex/pdfpc/pdfpc.pkg
@@ -1,5 +1,5 @@
 \pkg{pdfpc}
-\version{0.2.1}
+\version{0.3.0}
 \update{true}
 \author{Evgeny Stambulchik}
 \email{andreas@bilke.org}

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -70,6 +70,14 @@ developers.
 .BI "\-P, \-\-page"
 Go to a specific page directly after startup. In case of overlays, the first slide will be displayed.
 .TP
+.BI "\-r, \-\-page\-transition"=TRANSITION
+Set default page transition. The TRANSITION specification is of the form
+type:duration:angle:alignment:direction. See the \fBPage transitions\fR section
+for the list of supported types. \fBduration\fR is in seconds. The three last
+settings are optional (and indeed meaningless for some of the transition types).
+The accepted values for \fBangle\fR are 0/90/180/270; \fBalignment\fR can be
+h[orizontal] of v[ertical] and \fBdirection\fR i[nward] or o[utward].
+.TP
 .BI "\-R, \-\-pdfpc\-location"=LOCATION
 Use custom pdfpc file.
 .TP

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -429,7 +429,8 @@ have a better overview of how many slides are left.
 Pdfpc supports almost all standard animated PDF page transitions: blinds, box,
 cover, dissolve, fade, glitter (except the diagonal one), push, split, uncover,
 and wipe, including various alignments, angles, and directions (where
-applicable).
+applicable). The transitions are enabled only for sequential (either forward or
+backward) movement; in the later case, the transition is "inverted".
 
 .SS Movies
 .PP

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -143,6 +143,13 @@ namespace pdfpc.Metadata {
         private string? notes_include = null;
 
         /**
+         * Default page transition
+         */
+        public Poppler.PageTransition default_transition {
+            get; protected set;
+        }
+
+        /**
          * Parse the given pdfpc file
          */
         void parse_pdfpc_file(out string? skip_line) {
@@ -295,6 +302,113 @@ namespace pdfpc.Metadata {
                     this.pdfpc_fname = fname + ".pdfpc";
                 }
             }
+        }
+
+        public void set_default_transition_from_string(string line) {
+            var trans = this.default_transition;
+
+            string[] tokens = line.split(":");
+
+            var trans_type = tokens[0];
+            switch (trans_type) {
+            case "blinds":
+                trans.type = Poppler.PageTransitionType.BLINDS;
+                break;
+            case "box":
+                trans.type = Poppler.PageTransitionType.BOX;
+                break;
+            case "cover":
+                trans.type = Poppler.PageTransitionType.COVER;
+                break;
+            case "dissolve":
+                trans.type = Poppler.PageTransitionType.DISSOLVE;
+                break;
+            case "fade":
+                trans.type = Poppler.PageTransitionType.FADE;
+                break;
+            case "fly":
+                trans.type = Poppler.PageTransitionType.FLY;
+                break;
+            case "glitter":
+                trans.type = Poppler.PageTransitionType.GLITTER;
+                break;
+            case "push":
+                trans.type = Poppler.PageTransitionType.PUSH;
+                break;
+            case "replace":
+                trans.type = Poppler.PageTransitionType.REPLACE;
+                break;
+            case "split":
+                trans.type = Poppler.PageTransitionType.SPLIT;
+                break;
+            case "uncover":
+                trans.type = Poppler.PageTransitionType.UNCOVER;
+                break;
+            case "wipe":
+                trans.type = Poppler.PageTransitionType.WIPE;
+                break;
+            default:
+                GLib.printerr("Unknown trans type %s\n", trans_type);
+                return;
+            }
+
+            if (tokens.length > 1) {
+                var trans_duration = double.parse(tokens[1]);
+                if (trans_duration > 0) {
+                    trans.duration_real = trans_duration;
+                } else {
+                    GLib.printerr("Transition duration must be positive\n");
+                    return;
+                }
+            }
+
+            if (tokens.length > 2) {
+                trans.angle = int.parse(tokens[2]);
+            }
+
+            if (tokens.length > 3) {
+                var alignment = tokens[3];
+                switch (alignment) {
+                case "h":
+                case "horizontal":
+                    trans.alignment =
+                        Poppler.PageTransitionAlignment.HORIZONTAL;
+                    break;
+                case "v":
+                case "vertical":
+                    trans.alignment =
+                        Poppler.PageTransitionAlignment.VERTICAL;
+                    break;
+                case "":
+                    break;
+                default:
+                    GLib.printerr("Invalid transition alignment %s\n",
+                        alignment);
+                    return;
+                }
+            }
+
+            if (tokens.length > 4) {
+                var direction = tokens[4];
+                switch (direction) {
+                case "i":
+                case "inward":
+                    trans.direction = Poppler.PageTransitionDirection.INWARD;
+                    break;
+                case "o":
+                case "outward":
+                    trans.direction = Poppler.PageTransitionDirection.OUTWARD;
+                    break;
+                case "":
+                    break;
+                default:
+                    GLib.printerr("Invalid transition direction %s\n",
+                        direction);
+                    return;
+                }
+            }
+
+            this.default_transition = trans;
         }
 
         /**
@@ -526,6 +640,8 @@ namespace pdfpc.Metadata {
                 this.load(pdfFilename);
             }
             this.renderer = new Renderer.Pdf(this);
+            this.default_transition = new Poppler.PageTransition();
+            this.default_transition.duration_real = 1.0;
         }
 
         /**

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -622,6 +622,9 @@ namespace pdfpc.Metadata {
                             this.notes_position =
                                 NotesPosition.from_string(entry.value);
                             break;
+                        case "DefaultTransition":
+                            this.set_default_transition_from_string(entry.value);
+                            break;
                         default:
                             GLib.printerr("unknown XMP entry %s\n", entry.key);
                             break;
@@ -636,12 +639,12 @@ namespace pdfpc.Metadata {
          * Base constructor taking the file url to the pdf file
          */
         public Pdf(string? pdfFilename) {
+            this.default_transition = new Poppler.PageTransition();
+            this.default_transition.duration_real = 1.0;
             if (pdfFilename != null) {
                 this.load(pdfFilename);
             }
             this.renderer = new Renderer.Pdf(this);
-            this.default_transition = new Poppler.PageTransition();
-            this.default_transition.duration_real = 1.0;
         }
 
         /**

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -278,6 +278,11 @@ namespace pdfpc {
         public static uint transition_fps = 25;
 
         /**
+         * Default page transition
+         */
+        public static string? default_transition = null;
+
+        /**
          * Show the final slide of each overlay in "next slide" view
          * instead of the next slide.
          */

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -289,6 +289,21 @@ namespace pdfpc {
             }
 
             if (this.current_slide_number != slide_number || force) {
+                bool trans_inverse = false;
+                bool sequential_move = false;
+                if (slide_number == this.current_slide_number + 1) {
+                    sequential_move = true;
+                } else if (slide_number + 1 == this.current_slide_number) {
+                    sequential_move = true;
+                    trans_inverse = true;
+                }
+                int trans_slide_number;
+                if (trans_inverse) {
+                    trans_slide_number = this.current_slide_number;
+                } else {
+                    trans_slide_number = slide_number;
+                }
+
                 var previous_slide = this.current_slide;
 
                 // Notify all listeners
@@ -305,9 +320,11 @@ namespace pdfpc {
                     this.transition_tid = 0;
                 }
 
-                if (!this.disabled && this.transitions_enabled) {
+                if (!this.disabled && this.transitions_enabled &&
+                    sequential_move) {
                     var metadata = this.get_metadata();
-                    this.transman.init(metadata, slide_number, previous_slide);
+                    this.transman.init(metadata,
+                        trans_slide_number, previous_slide, trans_inverse);
                 } else {
                     this.transman.disable();
                 }

--- a/src/classes/view/transition_manager.vala
+++ b/src/classes/view/transition_manager.vala
@@ -62,7 +62,7 @@ namespace pdfpc {
          * Initialization. At this time, the next slide is not ready.
          */
         public void init(Metadata.Pdf metadata, int slide_number,
-            Cairo.ImageSurface? prev) {
+            Cairo.ImageSurface? prev, bool inverse) {
 
             this.iframe = 0;
             this.prev = prev;
@@ -104,6 +104,31 @@ namespace pdfpc {
                 default:
                     this.transition = trans;
                     break;
+                }
+
+                // For inverse transitions, "fix" the properties and/or type
+                if (inverse && this.transition != null) {
+                    switch (this.transition.type) {
+                    case Poppler.PageTransitionType.COVER:
+                        this.transition.type = Poppler.PageTransitionType.UNCOVER;
+                        break;
+                    case Poppler.PageTransitionType.UNCOVER:
+                        this.transition.type = Poppler.PageTransitionType.COVER;
+                        break;
+                    }
+
+                    this.transition.angle = (180 + this.transition.angle)%360;
+
+                    switch (this.transition.direction) {
+                    case Poppler.PageTransitionDirection.INWARD:
+                        this.transition.direction =
+                            Poppler.PageTransitionDirection.OUTWARD;
+                        break;
+                    case Poppler.PageTransitionDirection.OUTWARD:
+                        this.transition.direction =
+                            Poppler.PageTransitionDirection.INWARD;
+                        break;
+                    }
                 }
             }
 

--- a/src/classes/view/transition_manager.vala
+++ b/src/classes/view/transition_manager.vala
@@ -79,6 +79,12 @@ namespace pdfpc {
                 var page = metadata.get_document().get_page(slide_number);
 
                 var trans = page.get_transition();
+                // If it is the simple replace transition, assume the
+                // user-defined one
+                if (trans.type == Poppler.PageTransitionType.REPLACE) {
+                    trans = metadata.default_transition;
+                }
+
                 trans.angle %= 360;
                 if (trans.angle % 90 != 0) {
                     GLib.printerr("Diagonal transitions are unsupported.\n");

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -78,6 +78,9 @@ namespace pdfpc {
             {"page", 'P', 0, OptionArg.INT,
                 ref Options.page,
                 "Go to page number N directly after startup", "N"},
+            {"page-transition", 'r', 0, OptionArg.STRING,
+                ref Options.default_transition,
+                "Set default page transition", "TYPE"},
             {"pdfpc-location", 'R', 0, OptionArg.STRING,
                 ref Options.pdfpc_location,
                 "Full path location to a pdfpc file", "PATH"},
@@ -442,6 +445,10 @@ namespace pdfpc {
                 GLib.printerr("Argument --page/-P must be between 1 and %d\n",
                     metadata.get_end_user_slide());
                 Process.exit(1);
+            }
+
+            if (Options.default_transition != null) {
+                metadata.set_default_transition_from_string(Options.default_transition);
             }
 
             // Handle monitor added/removed events.


### PR DESCRIPTION
- Allow setting default page transition - either from command line or via XMP.
- Only enable transitions for sequential (+/-1) slide movement, but not for "jumps".
- When moving backward, "invert" the transitions.