### PR TITLE
Changed slide_number to user_slide_number for drawing.

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -510,7 +510,7 @@ namespace pdfpc {
         }
 
         protected void update_pen_drawing() {
-            pen_drawing.switch_to_slide(this.current_slide_number);
+            pen_drawing.switch_to_slide(this.current_user_slide_number);
             this.queue_pen_surface_draws();
         }
 


### PR DESCRIPTION
The man pages indicate that drawings are stored by user slide number. Up until now that was not the case. This small change should fix the behavior.