### PR TITLE
Drop pdfcomment package, use \pdfannot directly

### DIFF
--- a/latex/pdfpc/README.md
+++ b/latex/pdfpc/README.md
@@ -9,7 +9,6 @@ console (pdfpc) program.
 `pdfpc` depends on these packages:
 [`kvoptions`](https://ctan.org/pkg/kvoptions),
 [`xstring`](https://ctan.org/pkg/xstring),
-[`pdfcomment`](https://ctan.org/pkg/pdfcomment),
 [`hyperxmp`](https://ctan.org/pkg/hyperxmp)
 
 ## Usage

--- a/latex/pdfpc/pdfpc-doc.tex
+++ b/latex/pdfpc/pdfpc-doc.tex
@@ -43,7 +43,7 @@
 
 \title{The \sty{pdfpc} package \\ {\large\url{https://github.com/pdfpc/pdfpc}}}
 \author{Evgeny Stambulchik}
-\date{2020/06/10 (v0.4.0)}
+\date{2020/06/19 (v0.5.0)}
 
 \hypersetup{pdftitle={The pdfpc package}, pdfauthor={Evgeny Stambulchik}}
 
@@ -66,8 +66,8 @@ GitHub}\footnote{\url{https://pdfpc.github.io/}}.
 
 It depends on the following packages:
 
-\begin{multicols}{4}\sffamily\centering
-kvoptions \\ xstring \\ pdfcomment \\ hyperxmp
+\begin{multicols}{3}\sffamily\centering
+kvoptions \\ xstring \\ hyperxmp
 \end{multicols}
 
 \section*{License}
@@ -110,11 +110,8 @@ The following \param{options} may be given as comma-separated list:
 The meaning and possible values of most of these options are documented in
 \textit{pdfpcrc(5)} man page of the pdfpc program. The rest are explained below.
 
-To add a note to a slide (must not be longer than one paragraph):
-
-{\leftskip2.5em%
-\cmd{\pdfpcnote\{Text of a note\}}
-}\par
+To add a note to a slide, use \cmd{\pdfpcnote\{Text of a note\}}. A line break
+in the body of the note can be inserted with \cmd{\\}.
 
 The pdfpc package can be used standalone or together with beamer. In
 the later case, it may be desirable to continue using the \cmd{\note}

--- a/latex/pdfpc/pdfpc.pkg
+++ b/latex/pdfpc/pdfpc.pkg
@@ -1,5 +1,5 @@
 \pkg{pdfpc}
-\version{0.4.0}
+\version{0.5.0}
 \update{true}
 \author{Evgeny Stambulchik}
 \email{andreas@bilke.org}

--- a/latex/pdfpc/pdfpc.sty
+++ b/latex/pdfpc/pdfpc.sty
@@ -30,13 +30,12 @@
 %
 %  -------------------------------------------------------------------------------------------
 %
-\ProvidesPackage{pdfpc}[2020/06/10 v0.4.0 PDFPC]
+\ProvidesPackage{pdfpc}[2020/06/19 v0.5.0 PDFPC]
 \NeedsTeXFormat{LaTeX2e}
 %
 % Require additional packages needed by \sty{pdfpc}:
 \RequirePackage{kvoptions}
 \RequirePackage{xstring}
-\RequirePackage{pdfcomment}
 \RequirePackage{hyperxmp}
 %
 \SetupKeyvalOptions{
@@ -141,9 +140,16 @@ ______</rdf:Description>^^J%
 %
 % Note command
 \ifPDFPC@hidenotes%
-  \newcommand{\pdfpcnote}[1]{}
+  \newcommand{\pdfpcnote}[1]{}%
 \else%
-  \newcommand{\pdfpcnote}[1]{\pdfmargincomment{#1}}
+  \newcommand{\pdfpcnote}[1]{%
+    \edef\\{\string\n}%
+    \pdfannot width 0pt height 0pt depth 0pt {%
+       /Subtype /Text%
+       /Contents (#1)%
+    }%
+    \relax%
+  }%
 \fi%
 %
 \endinput


### PR DESCRIPTION
Also provided convenience \\ macro for line breaks. Version bumped.