### PR TITLE
Markdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,14 +98,16 @@ In order to compile and run pdfpc, the following requirements need to be met:
 - poppler with glib bindings
 - pangocairo
 - gstreamer >= 1.0 with gst-plugins-good
+- discount (aka markdown2)
+- webkit2gtk
 
 E.g., on Ubuntu 18.04 onward, you can install these dependencies with::
 
     sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev
     libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
-    gstreamer1.0-gtk3
+    libmarkdown2-dev libwebkit2gtk-4.0-dev gstreamer1.0-gtk3
 
-(the latter is a run-time dependence). You should also consider installing all
+(the last one is a run-time dependence). You should also consider installing all
 plugins to support required video formats; chances are they are already present
 through dependencies of ``ubuntu-desktop``.
 

--- a/latex/pdfpc/pdfpc-doc.tex
+++ b/latex/pdfpc/pdfpc-doc.tex
@@ -104,6 +104,7 @@ The following \param{options} may be given as comma-separated list:
 \item \texttt{lastminutes}
 \item \texttt{hidenotes}
 \item \texttt{overridenote}
+\item \texttt{disablemarkdown}
 \item \texttt{defaulttransition} (needs pdfpc v4.5 or higher)
 \end{itemize}
 
@@ -111,7 +112,10 @@ The meaning and possible values of most of these options are documented in
 \textit{pdfpcrc(5)} man page of the pdfpc program. The rest are explained below.
 
 To add a note to a slide, use \cmd{\pdfpcnote\{Text of a note\}}. A line break
-in the body of the note can be inserted with \cmd{\\}.
+in the body of the note can be inserted with \cmd{\\}. The notes are rendered
+according to the Markdown syntax by default. If you prefer the plain text format
+(which was the case with \texttt{pdfpc}-4.4 and below), use the
+\texttt{disablemarkdown} option.
 
 The pdfpc package can be used standalone or together with beamer. In
 the later case, it may be desirable to continue using the \cmd{\note}

--- a/latex/pdfpc/pdfpc.sty
+++ b/latex/pdfpc/pdfpc.sty
@@ -51,6 +51,7 @@
 \DeclareBoolOption{hidenotes}
 \DeclareBoolOption{overridenote}
 \DeclareStringOption{notesposition}
+\DeclareBoolOption[false]{disablemarkdown}
 \DeclareStringOption{defaulttransition}
 \DeclareDefaultOption{\@unknownoptionerror}
 %
@@ -128,6 +129,11 @@ ______<rdf:Description xmlns:pdfpc="https://github.com/pdfpc/pdfpc">^^J%
   \hyxmp@add@simple{pdfpc:EndUserSlide}{\PDFPC@enduserslide}%
   \hyxmp@add@simple{pdfpc:LastMinutes}{\PDFPC@lastminutes}%
   \hyxmp@add@simple{pdfpc:NotesPosition}{\PDFPC@notesposition}%
+  \ifPDFPC@disablemarkdown%
+    \hyxmp@add@simple{pdfpc:EnableMarkdown}{false}%
+  \else%
+    \hyxmp@add@simple{pdfpc:EnableMarkdown}{true}%
+  \fi
   \hyxmp@add@simple{pdfpc:DefaultTransition}{\PDFPC@defaulttransition}%
   \hyxmp@add@to@xml{%
 ______</rdf:Description>^^J%

--- a/rc/CMakeLists.txt
+++ b/rc/CMakeLists.txt
@@ -5,7 +5,7 @@ DESTINATION
 )
 
 install(FILES
-    pdfpc.css
+    pdfpc.css notes.css
 DESTINATION
     ${CMAKE_INSTALL_PREFIX}/share/pixmaps/pdfpc/
 )

--- a/rc/notes.css
+++ b/rc/notes.css
@@ -1,0 +1,35 @@
+body {
+    font-family: Verdana, Helvetica, Arial, sans-serif;
+    background-color: black;
+    color: white;
+}
+
+a {
+    color: #4682b4;
+    text-decoration: none;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+table thead th {
+    background-color: #444;
+    text-align: center;
+}
+
+table tr {
+    border-top: 1px solid #ccc;
+}
+
+table tr:nth-child(2n) {
+    background-color: #444;
+}
+
+table tr th, table tr td {
+    border: 1px solid #ccc;
+}
+
+img {
+    max-width: 100%;
+}

--- a/rc/notes.css
+++ b/rc/notes.css
@@ -1,5 +1,6 @@
 body {
     font-family: Verdana, Helvetica, Arial, sans-serif;
+    font-size: 20pt;
     background-color: black;
     color: white;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,8 @@ pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(GEE REQUIRED gee-0.8)
 pkg_check_modules(POPPLER REQUIRED poppler-glib>=0.22)
 pkg_check_modules(GTK REQUIRED gtk+-3.0>=3.22)
+pkg_check_modules(WEBKIT REQUIRED webkit2gtk-4.0)
+pkg_check_modules(MARKDOWN REQUIRED libmarkdown)
 list (FIND GTK_STATIC_LIBRARIES "X11" _index)
 if (${_index} GREATER -1)
     set(WITH_X11 1)
@@ -42,6 +44,8 @@ include_directories(
     ${GSTREAMER_INCLUDE_DIRS}
     ${GSTINTERFACES_INCLUDE_DIRS}
     ${GSTVIDEO_INCLUDE_DIRS}
+    ${WEBKIT_INCLUDE_DIRS}
+    ${MARKDOWN_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -56,6 +60,8 @@ link_directories(
     ${GSTREAMER_LIBRARY_DIRS}
     ${GSTINTERFACES_LIBRARY_DIRS}
     ${GSTVIDEO_LIBRARY_DIRS}
+    ${WEBKIT_LIBRARY_DIRS}
+    ${MARKDOWN_LIBRARY_DIRS}
 )
 
 if(${WITH_X11})
@@ -99,6 +105,7 @@ endif()
 vala_precompile(VALA_C
     ${VALA_SRC}
 PACKAGES
+    webkit2gtk-4.0
     gio-2.0
     gee-0.8
     poppler-glib
@@ -113,6 +120,7 @@ OPTIONS
 CUSTOM_VAPIS
     ${CMAKE_CURRENT_BINARY_DIR}/paths.vala
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_binding.vapi
+    ${CMAKE_CURRENT_SOURCE_DIR}/libmarkdown.vapi
 )
 
 add_executable(pdfpc
@@ -127,6 +135,8 @@ target_link_libraries(pdfpc
     ${GIO_LIBRARIES}
     ${GEE_LIBRARIES}
     ${POPPLER_LIBRARIES}
+    ${MARKDOWN_LIBRARIES}
+    ${WEBKIT_LIBRARIES}
     ${GTK_LIBRARIES}
     ${GTHREAD_LIBRARIES}
     ${PANGOCAIRO_LIBRARIES}

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -78,6 +78,12 @@ namespace pdfpc.Metadata {
         protected NotesPosition notes_position = NotesPosition.NONE;
 
         /**
+         * Assume notes are formatted in Markdown. False by default for backward
+         * compatibility.
+         */
+        public bool enable_markdown = false;
+
+        /**
          * Number of pages in the pdf document
          */
         protected uint page_count;
@@ -624,6 +630,9 @@ namespace pdfpc.Metadata {
                             break;
                         case "DefaultTransition":
                             this.set_default_transition_from_string(entry.value);
+                            break;
+                        case "EnableMarkdown":
+                            this.enable_markdown = bool.parse(entry.value);
                             break;
                         default:
                             GLib.printerr("unknown XMP entry %s\n", entry.key);

--- a/src/classes/metadata/slides_notes.vala
+++ b/src/classes/metadata/slides_notes.vala
@@ -58,9 +58,6 @@ namespace pdfpc {
                 }
                 if (notes[slide_number] == null) {
                     notes[slide_number] = new slide_note();
-                } else {
-                    GLib.printerr("Found conflicting notes for slide %d\n", slide_number + 1);
-                    GLib.printerr("Using '%s' instead of '%s'\n", note_text.strip(), notes[slide_number].note_text.strip());
                 }
                 notes[slide_number].note_text = note_text;
                 notes[slide_number].is_native = is_native;

--- a/src/classes/view/markdown.vala
+++ b/src/classes/view/markdown.vala
@@ -60,14 +60,20 @@ namespace pdfpc.View {
             return true;
         }
 
-        public void render(string? text = "") {
+        public void render(string? text = "", bool plain_text = false) {
             Markdown.DocumentFlags flags = Markdown.DocumentFlags.NO_EXT;
 
-            var md = new Markdown.Document.from_string(text.data, flags);
-            md.compile(flags);
-
             string html;
-            md.document(out html);
+            if (text != "" && plain_text) {
+                html = "<pre>%s</pre>".printf(text.replace("&", "&amp;")
+                                                  .replace("<", "&lt;")
+                                                  .replace(">", "&gt;"));
+            } else {
+                var md = new Markdown.Document.from_string(text.data, flags);
+                md.compile(flags);
+
+                md.document(out html);
+            }
 
             // Form a minimal compliant Unicode HTML document
             const string tmpl =

--- a/src/classes/view/markdown.vala
+++ b/src/classes/view/markdown.vala
@@ -1,0 +1,91 @@
+/**
+ * Markdown View, based on WebKit
+ *
+ * This file is part of pdfpc.
+ *
+ * Copyright 2020 Evgeny Stambulchik
+ * Inspired by Showdown <https://github.com/showdownjs/showdown>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc.View {
+    public class MarkdownView : WebKit.WebView {
+        WebKit.UserContentManager ucm;
+        
+        public MarkdownView() {
+            this.ucm = this.get_user_content_manager();
+
+            string css_path;
+            if (Options.no_install) {
+                css_path = Path.build_filename(Paths.SOURCE_PATH, "rc/notes.css");
+            } else {
+                css_path = Path.build_filename(Paths.ICON_PATH, "notes.css");
+            }
+
+            try {
+                File css_file = File.new_for_path(css_path);
+                uint8[] css_contents;
+                css_file.load_contents(null, out css_contents, null);
+
+                var ss = new WebKit.UserStyleSheet((string) css_contents,
+                    WebKit.UserContentInjectedFrames.ALL_FRAMES,
+                    WebKit.UserStyleLevel.USER, null, null);
+                this.ucm.add_style_sheet(ss);
+            } catch (Error e) {
+                GLib.printerr("Warning: Could not load CSS %s (%s)\n",
+                    css_path, e.message);
+            }
+
+            var mdsettings = this.get_settings();
+            mdsettings.enable_plugins = false;
+            mdsettings.enable_javascript = false;
+        }
+
+        // Disable the context menu
+        protected override bool context_menu(WebKit.ContextMenu m,
+            Gdk.Event e, WebKit.HitTestResult r) {
+            return true;
+        }
+
+        public void render(string? text = "") {
+            Markdown.DocumentFlags flags = Markdown.DocumentFlags.NO_EXT;
+
+            var md = new Markdown.Document.from_string(text.data, flags);
+            md.compile(flags);
+
+            string html;
+            md.document(out html);
+
+            // Form a minimal compliant Unicode HTML document
+            const string tmpl =
+                "<!doctype html>\n<html>\n"              +
+                "<head><meta charset='utf-8'></head>\n" +
+                "<body>\n%s\n</body>\n</html>\n";
+            var doc = tmpl.printf(html);
+
+            // Actually render it
+            this.load_html(doc, null);
+        }
+
+        public void apply_zoom(double level) {
+            string css_contents = "body {zoom: %d%%;}".printf((int) (100*level));
+            var ss = new WebKit.UserStyleSheet((string) css_contents,
+                WebKit.UserContentInjectedFrames.ALL_FRAMES,
+                WebKit.UserStyleLevel.USER, null, null);
+            this.ucm.add_style_sheet(ss);
+        }
+    }
+}

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -1074,7 +1074,7 @@ namespace pdfpc.Window {
                 this.metadata.get_notes().set_note(this_note,
                     this.controller.current_user_slide_number);
                 this.controller.set_ignore_input_events(false);
-                this.mdview.render(this_note);
+                this.mdview.render(this_note, !this.metadata.enable_markdown);
                 this.notes_stack.set_visible_child_name("mdview");
                 return true;
             } else {
@@ -1091,7 +1091,7 @@ namespace pdfpc.Window {
             this.notes_editor.buffer.text = this_note;
 
             // render the note
-            this.mdview.render(this_note);
+            this.mdview.render(this_note, !this.metadata.enable_markdown);
         }
 
         public void show_overview() {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -71,11 +71,6 @@ namespace pdfpc.Window {
         protected View.MarkdownView mdview;
 
         /**
-         * Zoom level of the MD notes view
-         */
-        protected double mdview_zoom = 1.0;
-
-        /**
          * Timer for the presenation
          */
         protected TimerLabel? timer;
@@ -517,15 +512,6 @@ namespace pdfpc.Window {
             this.notes_editor.wrap_mode = Gtk.WrapMode.WORD;
             this.notes_editor.buffer.text = "";
             this.notes_editor.key_press_event.connect(this.on_key_press_notes_editor);
-            if (this.metadata.font_size >= 0) {
-                // LEGACY font size detection
-                // Before, we had the font size in absolute (device) units.
-                // These were typically larger than 1000
-                if (this.metadata.font_size >= 1000) {
-                    this.metadata.font_size /= Pango.SCALE;
-                }
-                this.set_font_size(this.metadata.font_size);
-            }
             var notes_sw = new Gtk.ScrolledWindow(null, null);
             notes_sw.add(this.notes_editor);
             notes_sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC);
@@ -544,6 +530,16 @@ namespace pdfpc.Window {
             this.notes_stack.add_named(frame, "view");
             this.notes_stack.add_named(this.mdview, "mdview");
             this.notes_stack.homogeneous = true;
+
+            if (this.metadata.font_size >= 0) {
+                // LEGACY font size detection
+                // Before, we had the font size in absolute (device) units.
+                // These were typically larger than 1000
+                if (this.metadata.font_size >= 1000) {
+                    this.metadata.font_size /= Pango.SCALE;
+                }
+                this.set_font_size(this.metadata.font_size);
+            }
 
             // The countdown timer is centered in the 90% bottom part of the screen
             this.timer = this.controller.getTimer();
@@ -1125,9 +1121,6 @@ namespace pdfpc.Window {
             font_size += 2;
             this.metadata.font_size = font_size;
             set_font_size(font_size);
-
-            this.mdview_zoom *= Math.pow(2, 0.25);
-            this.mdview.apply_zoom(this.mdview_zoom);
         }
 
         /**
@@ -1141,9 +1134,6 @@ namespace pdfpc.Window {
             }
             this.metadata.font_size = font_size;
             set_font_size(font_size);
-
-            this.mdview_zoom /= Math.pow(2, 0.25);
-            this.mdview.apply_zoom(this.mdview_zoom);
         }
 
         private int get_font_size() {
@@ -1163,6 +1153,10 @@ namespace pdfpc.Window {
             } catch (Error e) {
                 GLib.printerr("Warning: failed to set CSS for notes.\n");
             }
+
+            // 20pt is set in notes.css
+            var mdview_zoom = size/20.0;
+            this.mdview.apply_zoom(mdview_zoom);
         }
 
         private void on_zoom(PresentationController.ScaledRectangle? rect) {

--- a/src/libmarkdown.vapi
+++ b/src/libmarkdown.vapi
@@ -1,0 +1,135 @@
+/* libmarkdown Vala Bindings
+ * Copyright 2016 Guillaume Poirier-Morency <guillaumepoiriermorency@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of works must retain the original copyright notice,
+ *     this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the original copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither my name (David L Parsons) nor the names of contributors to
+ *     this code may be used to endorse or promote products derived
+ *     from this work without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[CCode (cheader_filename = "mkdio.h")]
+namespace Markdown
+{
+	[CCode (cname = "mkd_callback_t", has_target = false)]
+	public delegate string Callback<T> (string str, int size, T user_data);
+	[CCode (cname = "mkd_free_t", has_target = false)]
+	public delegate void FreeCallback<T> (string str, int size, T user_data);
+	[CCode (cname = "mkd_sta_t", has_target = false)]
+	public delegate int StringToAnchorCallback<T> (int outchar, T @out);
+
+	public void initialize ();
+	public void with_html5_tags ();
+	public void shlib_destructor ();
+	public char[] markdown_version;
+
+	[Compact]
+	[CCode (cname = "MMIOT", cprefix = "mkd_", free_function = "mkd_cleanup")]
+	public class Document
+	{
+		[CCode (cname = "mkd_in")]
+		public Document.from_in (GLib.FileStream file, DocumentFlags flags);
+		[CCode (cname = "mkd_string")]
+		public Document.from_string (uint8[] doc, DocumentFlags flags);
+
+		[CCode (cname = "gfm_in")]
+		public Document.from_gfm_in (GLib.FileStream file, DocumentFlags flags);
+		[CCode (cname = "gfm_string")]
+		public Document.from_gfm_string (uint8[] doc, DocumentFlags flags);
+
+		public void basename (string @base);
+
+		public bool compile (DocumentFlags flags);
+		public void cleanup ();
+
+		public int dump (GLib.FileStream file, DocumentFlags flags, string title);
+		[CCode (cname = "markdown")]
+		public int markdown (GLib.FileStream file, DocumentFlags flags);
+		public static int line (uint8[] buffer, out string @out, DocumentFlags flags);
+		public static void string_to_anchor<T> (uint8[] buffer, StringToAnchorCallback<T> sta, T @out, DocumentFlags flags);
+		public int xhtmlpage (DocumentFlags flags, GLib.FileStream file);
+
+		public unowned string doc_title ();
+		public unowned string doc_author ();
+		public unowned string doc_date ();
+
+		public int document (out unowned string text);
+		public int toc (out unowned string @out);
+		public int css (out unowned string @out);
+		public static int xml (uint8[] buffer, out string @out);
+
+		public int generatehtml (GLib.FileStream file);
+		public int generatetoc (GLib.FileStream file);
+		public static int generatexml (uint8[] buffer, GLib.FileStream file);
+		public int generatecss (GLib.FileStream file);
+		public static int generateline (uint8[] buffer, GLib.FileStream file, DocumentFlags flags);
+
+		public void e_url (Callback callback);
+		public void e_flags (Callback callback);
+		public void e_free (FreeCallback callback);
+		public void e_data<T> (T user_data);
+
+		public static void mmiot_flags (GLib.FileStream file, Document document, bool htmlplease);
+		public static void flags_are (GLib.FileStream file, DocumentFlags flags, bool htmlplease);
+
+		public void ref_prefix (string prefix);
+	}
+
+	[Flags]
+	[CCode (cname = "mkd_flag_t", cprefix = "MKD_")]
+	public enum DocumentFlags
+	{
+		NOLINKS,
+		NOIMAGE,
+		NOPANTS,
+		NOHTML,
+		STRICT,
+		TAGTEXT,
+		NO_EXT,
+		NOEXT,
+		CDATA,
+		NOSUPERSCRIPT,
+		NORELAXED,
+		NOTABLES,
+		NOSTRIKETHROUGH,
+		TOC,
+		@1_COMPAT,
+		AUTOLINK,
+		SAFELINK,
+		NOHEADER,
+		TABSTOP,
+		NODIVQUOTE,
+		NOALPHALIST,
+		NODLIST,
+		EXTRA_FOOTNOTE,
+		NOSTYLE,
+		NODLDISCOUNT,
+                DLEXTRA,
+                FENCEDCODE,
+                GITHUBTAGS,
+                HTML5ANCHOR,
+                LATEX,
+                EXPLICITLIST,
+                ENBED
+	}
+}


### PR DESCRIPTION
This is just an initial commit.

Issues to discuss related to the `.pdfpc` notes format:

* Do we continue supporting the plain text format for the notes?
   + In general, plain text renders almost naturally in markdown, but there are some caveats like line breaks. It isn't a big deal to learn, but may confuse/annoy some users.
   + Also, third-level MD headers and `.pdfpc` page number tags (`###`) overlap
* It is possible, e.g., to introduce a tag as the first line of note telling whether the contents should be treated as MD or plain text. Alternatively, it can be a global (per presentation) option and/or pdfpcrc flag. A one-time on-the-fly conversion should be made for backward compatibility.
