### PR TITLE
Fix support of multiple videos per slide (#537).

### DIFF
--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -389,7 +389,7 @@ namespace pdfpc {
 
             foreach (var sink in this.sinks) {
                 var parent = sink.parent as View.Video;
-                parent.remove_video();
+                parent.remove_video(sink);
             }
         }
 
@@ -732,7 +732,7 @@ namespace pdfpc {
                             this.scalex = (double) this.video_w/rect.width;
                             this.scaley = (double) this.video_h/rect.height;
                         }
-                        video_surface.resize_video(rect);
+                        video_surface.resize_video(video_area, rect);
                     });
                 this.sinks.add(video_area);
 

--- a/src/classes/view/video.vala
+++ b/src/classes/view/video.vala
@@ -27,28 +27,30 @@ namespace pdfpc {
      * video.
      */
     public class View.Video: Gtk.Fixed {
-        private Gtk.Widget video = null;
+        private List<Gtk.Widget> videos = null;
+
+        public Video() {
+            this.videos = new List[Gtk.Widget]();
+        }
 
         public void add_video(Gtk.Widget video, Gdk.Rectangle position) {
-            if (this.video == null) {
+            video.set_size_request(position.width, position.height);
+            this.put(video, position.x, position.y);
+            this.videos.append(video);
+            this.show_all();
+        }
+
+        public void resize_video(Gtk.Widget video, Gdk.Rectangle position) {
+            if (this.videos.find(video) != null) {
                 video.set_size_request(position.width, position.height);
-                this.put(video, position.x, position.y);
-                this.video = video;
-                this.show_all();
+                this.move(video, position.x, position.y);
             }
         }
 
-        public void resize_video(Gdk.Rectangle position) {
-            if (this.video != null) {
-                this.video.set_size_request(position.width, position.height);
-                this.move(this.video, position.x, position.y);
-            }
-        }
-
-        public void remove_video() {
-            if (this.video != null) {
-                this.remove(this.video);
-                this.video = null;
+        public void remove_video(Gtk.Widget video) {
+            if (this.videos.find(video) != null) {
+                this.remove(video);
+                this.videos.remove(video);
             }
         }
     }

--- a/src/classes/view/video.vala
+++ b/src/classes/view/video.vala
@@ -30,7 +30,7 @@ namespace pdfpc {
         private List<Gtk.Widget> videos = null;
 
         public Video() {
-            this.videos = new List[Gtk.Widget]();
+            this.videos = new List<Gtk.Widget>();
         }
 
         public void add_video(Gtk.Widget video, Gdk.Rectangle position) {


### PR DESCRIPTION
Introduce a list of videos in the current view, instead of keep track of a single video at a time (fix #537).