### PR TITLE
Implement spotlight mode

### DIFF
--- a/demo/pdfpc-demo.tex
+++ b/demo/pdfpc-demo.tex
@@ -214,17 +214,31 @@
 \end{frame}
 
 \begin{frame}
-  \frametitle{Annotation modes}
+  \frametitle{Pointer and spotlight}
   \begin{itemize}
-    \item \pdfpc has a built-in ``laser'' pointer. To switch the pointer
-      mode on, press \keys{2}
+    \item \pdfpc has a built-in ``laser'' pointer
       \begin{itemize}
+        \item To switch the pointer mode on, press \keys{2}
         \item The pointer size can be adjusted with the \keys{{+}} and \keys{-}
           keys
         \item A rectangular area can be highlighted by using the drag mouse
           motion
         \item Press \keys{Z} to zoom in the highlighted area; \keys{esc} to exit
       \end{itemize}
+    \item The spotlight mode is similar to the pointer mode, but instead of
+      highlighting the spot by a different color, it shades the background
+      \begin{itemize}
+        \item To switch this mode on, press \keys{5}
+        \item The spot size can be adjusted with the \keys{{+}} and \keys{-}
+          keys, too
+      \end{itemize}
+    \item Press \keys{1} to return to the normal presentation mode
+  \end{itemize}
+\end{frame}
+
+\begin{frame}
+  \frametitle{Drawings}
+  \begin{itemize}
     \item Press \keys{3} to enter the drawing mode with the pen tool selected
       \singleitem{Again, use \keys{{+}} and \keys{-} to alter the size of the
         drawing tool}

--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -13,6 +13,7 @@ install(FILES
     move.svg
     settings.svg
     linewidth.svg
+    spotlight.svg
 DESTINATION
     share/pixmaps/pdfpc
 )

--- a/icons/README.icons
+++ b/icons/README.icons
@@ -10,3 +10,5 @@ https://github.com/KDE/breeze-icons
 
 move.svg is mono-move.svg, linewidth.svg is mono-linewidth.svg, and
 settings.svg is settings-button from https://openclipart.org
+
+spotlight.svg is derived from https://openclipart.org/detail/271879/spotlight

--- a/icons/spotlight.svg
+++ b/icons/spotlight.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="652"
+   height="652"
+   version="1.1"
+   id="svg57"
+   sodipodi:docname="spotlight.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1161"
+     inkscape:window-height="954"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="0.69792802"
+     inkscape:cx="364.57396"
+     inkscape:cy="326"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="imagebot_3" />
+  <defs
+     id="defs29">
+    <linearGradient
+       id="imagebot_46">
+      <stop
+         stop-color="#0e0e0e"
+         offset="0"
+         id="imagebot_53" />
+      <stop
+         stop-color="#c7c7c7"
+         offset="0.7651"
+         id="imagebot_52" />
+      <stop
+         stop-color="#151515"
+         offset="1"
+         id="imagebot_51" />
+    </linearGradient>
+    <linearGradient
+       id="imagebot_45">
+      <stop
+         stop-color="#0e0e0e"
+         offset="0"
+         id="imagebot_50" />
+      <stop
+         stop-color="#8b8b8b"
+         offset="1"
+         id="imagebot_49" />
+    </linearGradient>
+    <linearGradient
+       x1="44.920728"
+       y1="867.1147"
+       x2="218.84553"
+       y2="-169.00827"
+       id="imagebot_40"
+       gradientTransform="matrix(0.85543758,0,0,0.84304196,-39.053494,-38.412)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#171717"
+         offset="0"
+         id="imagebot_48" />
+      <stop
+         stop-color="#a7a7a7"
+         offset="1"
+         id="imagebot_47" />
+    </linearGradient>
+    <linearGradient
+       x1="0"
+       y1="0.50003"
+       x2="1"
+       xlink:href="#imagebot_45"
+       y2="0.50003"
+       id="imagebot_38" />
+    <linearGradient
+       x1="0.3605"
+       y1="0.6631"
+       x2="0.63387"
+       xlink:href="#imagebot_46"
+       y2="0.36159"
+       id="imagebot_34" />
+    <linearGradient
+       x1="-0.01682"
+       y1="0.50002"
+       x2="1.01682"
+       xlink:href="#imagebot_45"
+       y2="0.50002"
+       id="imagebot_32" />
+    <linearGradient
+       x1="-0.01681"
+       y1="0.5"
+       x2="1.01682"
+       xlink:href="#imagebot_46"
+       y2="0.5"
+       id="imagebot_30" />
+    <linearGradient
+       x1="-0.01682"
+       y1="0.50002"
+       x2="1.01682"
+       xlink:href="#imagebot_45"
+       y2="0.50002"
+       id="imagebot_28" />
+    <linearGradient
+       x1="-0.01681"
+       y1="0.5"
+       x2="1.01682"
+       xlink:href="#imagebot_46"
+       y2="0.5"
+       id="imagebot_26" />
+    <linearGradient
+       x1="-0.01682"
+       y1="0.50002"
+       x2="1.01682"
+       xlink:href="#imagebot_45"
+       y2="0.50002"
+       id="imagebot_24" />
+    <linearGradient
+       x1="-0.01681"
+       y1="0.5"
+       x2="1.01682"
+       xlink:href="#imagebot_46"
+       y2="0.5"
+       id="imagebot_22" />
+    <linearGradient
+       x1="0.17033"
+       y1="0.77231"
+       x2="1.18757"
+       xlink:href="#imagebot_45"
+       y2="-0.05949"
+       id="imagebot_19" />
+    <linearGradient
+       x1="0.17041"
+       y1="0.77226"
+       x2="1.18765"
+       xlink:href="#imagebot_45"
+       y2="-0.05954"
+       id="imagebot_17" />
+    <linearGradient
+       x1="0"
+       y1="0.50003"
+       x2="1"
+       xlink:href="#imagebot_45"
+       y2="0.50003"
+       id="imagebot_14" />
+    <linearGradient
+       x1="-0.07987"
+       y1="0.0559"
+       x2="0.92"
+       y2="0.71139"
+       id="imagebot_11">
+      <stop
+         stop-color="#525252"
+         offset="0"
+         id="imagebot_44" />
+      <stop
+         stop-color="#e8e8e8"
+         offset="1"
+         id="imagebot_43" />
+    </linearGradient>
+    <linearGradient
+       x1="32.730267"
+       y1="88.739418"
+       x2="674.65607"
+       y2="702.01453"
+       id="imagebot_7"
+       gradientTransform="matrix(1.0670236,0,0,1.0032449,-128.24637,-131.39558)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#imagebot_40">
+      <stop
+         stop-color="#f0f0f0"
+         stop-opacity="0.54587"
+         offset="0"
+         id="imagebot_42" />
+      <stop
+         stop-color="#f0f0f0"
+         stop-opacity="0"
+         offset="1"
+         id="imagebot_41" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#imagebot_7"
+       id="linearGradient887"
+       x1="5.5161915"
+       y1="329.92355"
+       x2="645.53589"
+       y2="329.92355"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93283897,0,0,1,23.295473,-1.4328125)" />
+  </defs>
+  <g
+     label="Layer 1"
+     id="imagebot_3">
+    <path
+       label="Layer 1"
+       d="m 646.75074,484.77257 c 0,77.27028 -94.00748,139.91022 -209.97459,139.91022 -115.9648,0 -209.97458,-62.63994 -209.97458,-139.91022 0,-77.27027 94.00747,-139.91022 209.97458,-139.91022 115.96481,0 209.97459,62.63995 209.97459,139.91022 z"
+       id="imagebot_8"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke-width:2.36897588" />
+    <path
+       font-size="4"
+       label="Layer 1"
+       d="m 241.29592,521.40759 c 30.23475,60.74402 46.18723,62.57025 94.29723,86.42172 44.56592,22.09875 102.28163,17.14707 147.07568,11.91347 46.27686,-5.41745 103.59335,-39.60126 129.51817,-81.69063 28.95562,-47.01656 7.59331,-118.35031 -35.14761,-146.2955 C 445.27257,294.00979 206.77103,118.79471 78.209028,33.865247 c 0,0 -60.624914,-13.286603 -48.051262,52.774113 26.389213,60.14343 202.086464,409.31116 211.138154,434.76823 z"
+       id="imagebot_6"
+       style="font-size:4px;fill:url(#linearGradient887);fill-opacity:1;fill-rule:evenodd;stroke-width:0.99929518"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc">In the Spotlight</path>
+    <title
+       id="title52">Layer 1</title>
+    <text
+       transform="translate(866.258 190.066) matrix(44.269 0 0 8.38186 -33263.8 -1378.31)"
+       xml:space="preserve"
+       text-anchor="middle"
+       font-family="serif"
+       font-size="24"
+       id="imagebot_55"
+       y="186.35155"
+       x="744.63281"
+       stroke-opacity="null"
+       stroke-linecap="null"
+       stroke-linejoin="null"
+       stroke-dasharray="null"
+       stroke-width="0"
+       stroke="null"
+       fill="#000000" />
+  </g>
+  <metadata
+     id="imagebot_2">image/svg+xmlOpenclipart<rdf:RDF>
+  <cc:Work
+     rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+  </cc:Work>
+</rdf:RDF>
+</metadata>
+</svg>

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -480,15 +480,21 @@ See the bugs section for further information.
 
 .SS Pointer mode
 .PP
-If needed, it is possible to turn on a pointer which draws a red dot in the
-place pointed by mouse cursor on both - presenter and presentation screens. It
-is also possible to increase and decrease the pointer size. Additionally, when
-the pointer is enabled, it is possible to highlight some area of the current
-slide using the drag mouse motion. The area outside the selected region will be
-dimmed. You can zoom in the selected area by pressing 'z'; press 'Escape' to
-exit the zoom mode. You can highlight another region while zoomed in, but
-there will be no further action on pressing 'z'. Drawing is also disabled in
-this mode.
+If needed, it is possible to turn on a pointer which draws a red (by default)
+dot in the place pointed by mouse cursor on both presenter and presentation
+screens. It is also possible to increase and decrease the pointer size.
+Additionally, when the pointer is enabled, it is possible to highlight some area
+of the current slide using the drag mouse motion. The area outside the selected
+region will be dimmed. You can zoom in the selected area by pressing 'z'; press
+'Escape' to exit the zoom mode. You can highlight another region while zoomed
+in, but there will be no further action on pressing 'z'. Drawing is also
+disabled in this mode.
+
+.SS Spotlight mode
+.PP
+Spotlight mode is similar to the pointer mode: a circular area that moves with
+the mouse and can be adjusted in size, but instead of highlighting the spot by a
+different color, it shades the background.
 
 .SS Drawing mode
 .PP

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -151,6 +151,13 @@ Screen to be used for the presentation (output name, see e.g. "xrandr --listmoni
 .B presenter-screen
 Screen to be used for the presenter (output name).
 .TP
+.B spotlight-opacity
+Set opacity of the area outside of the spotlight, in percent (int, default is
+50).
+.TP
+.B spotlight-size
+Set the initial spotlight size, in pixels (int, default is 100).
+.TP
 .B switch-screens
 Switch the presentation and the presenter screen (bool, Default is false).
 .TP

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -80,6 +80,8 @@ bind 3                  switchMode pen
 bind KP_3               switchMode pen
 bind 4                  switchMode eraser
 bind KP_4               switchMode eraser
+bind 5                  switchMode spotlight
+bind KP_5               switchMode spotlight
 
 # Mode-sensitive size adjustment (notes|pointer|pen|eraser)
 bind plus               increaseSize

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -296,6 +296,12 @@ namespace pdfpc {
                 case "presenter-screen":
                     Options.presenter_screen = fields[2];
                     break;
+                case "spotlight-opacity":
+                    Options.spotlight_opacity = int.parse(fields[2]);
+                    break;
+                case "spotlight-size":
+                    Options.spotlight_size = int.parse(fields[2]);
+                    break;
                 case "switch-screens":
                     bool switch_screens = bool.parse(fields[2]);
                     if (switch_screens) {

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -258,6 +258,16 @@ namespace pdfpc {
         public static uint pointer_size = 10;
 
         /**
+         * Spotlight opacity (i.e., opacity of the outside area) (0 - 100)
+         */
+        public static int spotlight_opacity = 50;
+
+        /**
+         * Spotlight size
+         */
+        public static uint spotlight_size = 100;
+
+        /**
          * Try to automatically load video srt file
          */
         public static bool auto_srt = false;

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -285,7 +285,8 @@ namespace pdfpc.Window {
 
             // Draw the highlighted area, but ignore very short drags
             // made unintentionally by mouse clicks
-            if (c.highlight.width > 0.01 && c.highlight.height > 0.01) {
+            if (!c.current_pointer.is_spotlight &&
+                c.highlight.width > 0.01 && c.highlight.height > 0.01) {
                 context.rectangle(0, 0, a.width, a.height);
                 context.new_sub_path();
                 context.rectangle((int)(c.highlight.x*a.width),
@@ -300,15 +301,22 @@ namespace pdfpc.Window {
                 context.new_path();
             }
             // Draw the pointer when not dragging
-            if (c.drag_x == -1 && !c.pointer_hidden) {
+            if (c.drag_x == -1 &&
+                (!c.pointer_hidden || c.current_pointer.is_spotlight)) {
                 int x = (int)(a.width*c.pointer_x);
                 int y = (int)(a.height*c.pointer_y);
-                int r = (int)(a.height*0.001*c.pointer_size);
+                int r = (int)(a.height*0.001*c.current_pointer.size);
 
-                context.set_source_rgba(c.pointer_color.red,
-                                        c.pointer_color.green,
-                                        c.pointer_color.blue,
-                                        c.pointer_color.alpha);
+                Gdk.RGBA rgba = c.current_pointer.get_rgba();
+                context.set_source_rgba(rgba.red,
+                                        rgba.green,
+                                        rgba.blue,
+                                        rgba.alpha);
+                if (c.current_pointer.is_spotlight) {
+                    context.rectangle(0, 0, a.width, a.height);
+                    context.new_sub_path();
+                    context.set_fill_rule(Cairo.FillRule.EVEN_ODD);
+                }
                 context.arc(x, y, r, 0, 2*Math.PI);
                 context.fill();
             }

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -155,6 +155,11 @@ namespace pdfpc.Window {
         protected Gtk.Image eraser_icon;
 
         /**
+         * Indication that the spotlight tool is selected
+         */
+        protected Gtk.Image spotlight_icon;
+
+        /**
          * The overview of slides
          */
         protected Overview overview = null;
@@ -443,6 +448,7 @@ namespace pdfpc.Window {
             this.highlight_icon = this.load_icon("highlight.svg", icon_height);
             this.pen_icon = this.load_icon("pen.svg", icon_height);
             this.eraser_icon = this.load_icon("eraser.svg", icon_height);
+            this.spotlight_icon = this.load_icon("spotlight.svg", icon_height);
 
             this.status.pack_start(this.blank_icon, false, false);
             this.status.pack_start(this.hidden_icon, false, false);
@@ -454,6 +460,7 @@ namespace pdfpc.Window {
             this.status.pack_start(this.highlight_icon, false, false);
             this.status.pack_start(this.pen_icon, false, false);
             this.status.pack_start(this.eraser_icon, false, false);
+            this.status.pack_start(this.spotlight_icon, false, false);
         }
 
         /**
@@ -494,6 +501,11 @@ namespace pdfpc.Window {
                 this.pen_icon.show();
             } else {
                 this.pen_icon.hide();
+            }
+            if (this.controller.is_spotlight_active()) {
+                this.spotlight_icon.show();
+            } else {
+                this.spotlight_icon.hide();
             }
         }
 
@@ -840,6 +852,11 @@ namespace pdfpc.Window {
                 "Eraser mode");
             tb.clicked.connect(() => {
                     this.controller.set_eraser_mode();
+                });
+            tb = add_toolbox_button(button_panel, tbox_inverse, "spotlight.svg",
+                "Spotlight mode");
+            tb.clicked.connect(() => {
+                    this.controller.set_spotlight_mode();
                 });
             tb = add_toolbox_button(button_panel, tbox_inverse, "snow.svg",
                 "Freeze presentation window");


### PR DESCRIPTION
This implements the spotlight mode as discussed in #484. The mode is activated by default by pressing `5`. The opacity of the shading and the initial size of the spot can be set via pdfpcrc.