### PR TITLE
Fix pen hiding

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -959,6 +959,10 @@ namespace pdfpc {
                 set_pen_pressure(pressure);
             }
 
+            // restart the pointer timeout timer
+            this.restart_pointer_timer();
+            this.pointer_hidden = false;
+
             double x, y;
             this.device_to_normalized(event.x, event.y, out x, out y);
             move_pen(x, y);
@@ -975,6 +979,7 @@ namespace pdfpc {
                     this.pointer_timeout_id = 0;
                     this.pointer_hidden = true;
                     this.queue_pointer_surface_draws();
+                    this.queue_pen_surface_draws();
 
                     return false;
                 });

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -351,7 +351,8 @@ namespace pdfpc.Window {
                 context.set_source_surface(drawing_surface, 0, 0);
                 context.paint();
                 context.set_matrix(old_xform);
-                if (this.is_presenter && c.in_drawing_mode()) {
+                if (this.is_presenter && c.in_drawing_mode() &&
+                    !c.pointer_hidden) {
                     double width_adjustment = (double) a.width / base_width;
                     context.set_operator(Cairo.Operator.OVER);
                     context.set_line_width(2.0);


### PR DESCRIPTION
In versions before 872c905 ("Ignore the pointer_hidden flag in the drawing mode", 2020-05-09), it could happen, that a drawing mode tool was hidden and the user did not see where they will draw. The (now reverted) commit 872c905 fixed this problem by never hiding the drawing tool. This resulted in the drawing tool being visible in the slide area even if the cursor was moved out of the slide area.

The second commit in this PR fixes the problem differently. The drawing tool is hidden the same way as the pointer - after two seconds of inactivity or when the cursor is out of slide area. To make this work, it is sufficient to restart the timeout timer in the on_move_pen() callback.