### PR TITLE
Set the "NoView" flag for pdf annotations

### DIFF
--- a/latex/pdfpc/pdfpc.sty
+++ b/latex/pdfpc/pdfpc.sty
@@ -153,6 +153,7 @@ ______</rdf:Description>^^J%
     \pdfannot width 0pt height 0pt depth 0pt {%
        /Subtype /Text%
        /Contents (#1)%
+       /F 6%
     }%
     \relax%
   }%


### PR DESCRIPTION
This sets the "NoView" flag for the annotations created, which makes them invisible even when viewing the PDF file with another viewer than pdfpc. The notes are still embedded and sourced by pdfpc. See the [PDF Reference](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf), p. 493.

I tested this in Okular and the PDF viewer embedded in Google Chrome.