### PR TITLE
Video events

### DIFF
--- a/demo/pdfpc-video-example/video-example.tex
+++ b/demo/pdfpc-video-example/video-example.tex
@@ -198,6 +198,49 @@
   \singleitem{The poster is obtained from the video when the slide is shown.}
 \end{frame}
 
+\begin{frame}[fragile]
+  \frametitle{Hyperlink controls}
+
+  \pdfpc understands a special kind of hyperlinks to control a named video on
+  the {\em same} page.
+
+  \begin{itemize}
+    \item Such hyperlinks can be created using the \opt{hyperlinkmovie}
+          command.
+    \item The possible actions are \opt{play}, \opt{stop}, \opt{pause}, and
+          \opt{resume}.
+  \end{itemize}
+
+  \vspace{10pt}
+
+  E.g.,
+  \begin{lstlisting}
+    \movie[label=mymovie]
+        {\includegraphics{poster.png}}{movie.avi}
+    ...
+    \hyperlinkmovie[play]{mymovie}{Click to play!}
+  \end{lstlisting}
+
+  \vfill
+  See a demo on the next page.
+\end{frame}
+
+\begin{frame}
+  \frametitle{Example 4}
+  \vspace{10pt}
+  \begin{center}
+    \movie[label=apollo]{\includegraphics[width=0.7\textwidth]{apollo17.jpg}}{apollo17.avi}
+
+    \hyperlinkmovie[play]{apollo}{\fbox{\sc Play}}
+    \hyperlinkmovie[pause]{apollo}{\fbox{\sc Pause}}
+    \hyperlinkmovie[resume]{apollo}{\fbox{\sc Resume}}
+    \hyperlinkmovie[stop]{apollo}{\fbox{\sc Stop}}
+  \end{center}
+
+  \vfill
+  \singleitem{You can control the movie using the ``buttons'' below it.}
+\end{frame}
+
 
 \begin{frame}
   \frametitle{Subtitles}
@@ -242,7 +285,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitle{Example 4}
+  \frametitle{Example 5}
 
   An example using the \opt{\textbackslash href\{run:\}} hack. The
   video is set to automatically start playing in the loop a fragment of the

--- a/demo/pdfpc-video-example/video-example.tex
+++ b/demo/pdfpc-video-example/video-example.tex
@@ -5,7 +5,9 @@
 
 \usepackage{multimedia}
 
-\usepackage{hyperref}
+\definecolor{links}{HTML}{302080}
+\hypersetup{colorlinks,linkcolor=links,urlcolor=links}
+
 \usepackage[utf8]{inputenc}
 \usepackage{xspace}
 
@@ -130,17 +132,19 @@
     \item \opt{loop} or \opt{repeat} -- play the video in the loop;
     \item \opt{start=<time>s} -- skip the first \opt{<time>} seconds of the
            video;
-    \item \opt{duration=<time>s} -- let the video play for \opt{<time>} seconds.
+    \item \opt{duration=<time>s} -- let the video play for \opt{<time>} seconds;
+    \item \opt{poster} -- show the first frame of the video as the poster\\
+           (\alert{but there are caveats}, \hyperlink{posterPage}{see below}).
   \end{itemize}
     
-  \vspace{20pt}
+  \vfill
 
   E.g., 
   \begin{lstlisting}
     \movie[loop]{\includegraphics{poster}}{movie.avi}
   \end{lstlisting}
 
-  \vspace{10pt}
+  \vfill
   Switch to the next page to see it in action.
 \end{frame}
 
@@ -153,8 +157,47 @@
   \end{center}
 
   \singleitem{Once started, this video will play back in the loop}
+\end{frame}
+
+\begin{frame}[fragile]
+  \frametitle{The \opt{poster} option}
+  \hypertarget{posterPage}{}
+  There is a partial support for the \opt{poster} option. Note, however, that in
+  this case
+  \begin{itemize}
+    \item you must explicitly specify the \opt{width} and \opt{height}
+          dimensions in the correct aspect ratio of the video;
+    \item the poster will be rendered neither in the ``next slide''
+          preview nor in the ``overview'' mode.
+  \end{itemize}
+
+  \vspace{10pt}
+
+  E.g.,
+  \begin{lstlisting}
+    \movie[width=8cm,height=6cm,poster]{Some text}
+    {movie.avi}
+  \end{lstlisting}
+
+  \vfill
+  The next page is prepared in this manner.
 
 \end{frame}
+
+\begin{frame}
+  \frametitle{Example 3}
+
+  \vspace{10pt}
+  \begin{center}
+    \movie[width=0.68\textwidth,height=0.51\textwidth,poster]
+        {\framebox[0.68\textwidth][c]{A dummy text\rule{0pt}{0.50\textwidth}}}
+        {apollo17.avi}
+  \end{center}
+
+  \vfill
+  \singleitem{The poster is obtained from the video when the slide is shown.}
+\end{frame}
+
 
 \begin{frame}
   \frametitle{Subtitles}
@@ -168,7 +211,7 @@
   appending ``.srt'' to its path (or URL).
   
   \singleitem{There is also a respective \opt{pdfpcrc} option if you want to
-    make this the default behavior}
+    make this the default behavior.}
 \end{frame}
 
 \begin{frame}[fragile]
@@ -199,7 +242,7 @@
 \end{frame}
 
 \begin{frame}
-  \frametitle{Example 3}
+  \frametitle{Example 4}
 
   An example using the \opt{\textbackslash href\{run:\}} hack. The
   video is set to automatically start playing in the loop a fragment of the

--- a/icons/CMakeLists.txt
+++ b/icons/CMakeLists.txt
@@ -14,6 +14,8 @@ install(FILES
     settings.svg
     linewidth.svg
     spotlight.svg
+    play_cur.svg
+    pause_cur.svg
 DESTINATION
     share/pdfpc/icons
 )

--- a/icons/pause_cur.svg
+++ b/icons/pause_cur.svg
@@ -31,7 +31,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="4"
-     inkscape:cx="62.75"
+     inkscape:cx="21"
      inkscape:cy="63.163233"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -40,8 +40,8 @@
      showgrid="true"
      inkscape:window-width="1204"
      inkscape:window-height="827"
-     inkscape:window-x="717"
-     inkscape:window-y="46"
+     inkscape:window-x="1604"
+     inkscape:window-y="43"
      inkscape:window-maximized="0"
      inkscape:snap-bbox="true">
     <inkscape:grid
@@ -73,7 +73,7 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:#333333;fill-opacity:0.7254902;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#ffffff;fill-opacity:1;stroke:#3f3f3f;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 28,24 h 26 v 80 H 28 Z"
        id="path2618"
        sodipodi:nodetypes="ccccc"
@@ -82,7 +82,7 @@
        sodipodi:nodetypes="ccccc"
        id="path2195"
        d="m 73,24 h 26 v 80 H 73 Z"
-       style="fill:#333333;fill-opacity:0.72727272;stroke:#fffeff;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       style="fill:#ffffff;fill-opacity:1;stroke:#3f3f3f;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
        inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/icons/pause_cur.svg
+++ b/icons/pause_cur.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   id="svg3186"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   version="1.0"
+   sodipodi:docname="pause_cur.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   sodipodi:modified="true">
+  <defs
+     id="defs3188" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="62.75"
+     inkscape:cy="63.163233"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     width="128px"
+     height="128px"
+     showgrid="true"
+     inkscape:window-width="1204"
+     inkscape:window-height="827"
+     inkscape:window-x="717"
+     inkscape:window-y="46"
+     inkscape:window-maximized="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       id="GridFromPre046Settings"
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingx="8"
+       spacingy="8"
+       color="#3f3fff"
+       empcolor="#3f3fff"
+       opacity="0.15"
+       empopacity="0.38"
+       empspacing="5" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3191">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#333333;fill-opacity:0.7254902;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 28,24 h 26 v 80 H 28 Z"
+       id="path2618"
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       id="path2195"
+       d="m 73,24 h 26 v 80 H 73 Z"
+       style="fill:#333333;fill-opacity:0.72727272;stroke:#fffeff;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/icons/play_cur.svg
+++ b/icons/play_cur.svg
@@ -30,8 +30,8 @@
      objecttolerance="10"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.375"
-     inkscape:cx="63.72093"
+     inkscape:zoom="5.734375"
+     inkscape:cx="64"
      inkscape:cy="64"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -73,7 +73,7 @@
      id="layer1">
     <path
        sodipodi:type="star"
-       style="fill:#333333;fill-opacity:0.7254902;fill-rule:nonzero;stroke:#fffbff;stroke-width:6;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#3f3f3f;stroke-width:6;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
        id="path6653"
        sodipodi:sides="3"
        sodipodi:cx="-52"

--- a/icons/play_cur.svg
+++ b/icons/play_cur.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   id="svg3186"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   version="1.0"
+   sodipodi:docname="play_cur.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   sodipodi:modified="true">
+  <defs
+     id="defs3188" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.375"
+     inkscape:cx="63.72093"
+     inkscape:cy="64"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     width="128px"
+     height="128px"
+     showgrid="true"
+     inkscape:window-width="1559"
+     inkscape:window-height="936"
+     inkscape:window-x="0"
+     inkscape:window-y="45"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       id="GridFromPre046Settings"
+       type="xygrid"
+       originx="0px"
+       originy="0px"
+       spacingx="8px"
+       spacingy="8px"
+       color="#3f3fff"
+       empcolor="#3f3fff"
+       opacity="0.15"
+       empopacity="0.38"
+       empspacing="5" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3191">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       sodipodi:type="star"
+       style="fill:#333333;fill-opacity:0.7254902;fill-rule:nonzero;stroke:#fffbff;stroke-width:6;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path6653"
+       sodipodi:sides="3"
+       sodipodi:cx="-52"
+       sodipodi:cy="-64"
+       sodipodi:r1="48"
+       sodipodi:r2="24"
+       sodipodi:arg1="3"
+       sodipodi:arg2="42"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.01"
+       inkscape:randomized="0"
+       d="m -99.51964,-57.22624 c -0.117325,-0.823064 64.641754,-51.62378 65.413211,-51.31386 0.771457,0.30993 12.38663,81.793297 11.732497,82.306435 -0.654132,0.513139 -77.028383,-30.16951 -77.145708,-30.992575 z"
+       transform="rotate(-171.9,4.7710716,-3.4646818)"
+       inkscape:transform-center-x="-15.242671"
+       inkscape:transform-center-y="-2.9132747" />
+  </g>
+</svg>

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -458,7 +458,7 @@ will be reset after leaving and returning to a slide.
 .PP
 Movies may be included in PDF files as "screen annotations". In LaTeX, such
 movies may be added to a presentation with the "multimedia" package. Note that
-the poster and autoplay options are not yet supported.
+the autoplay option is not yet supported.
 
 .PP
 pdfpc will also play back movies linked from a hyperlink of type "launch".

--- a/src/classes/action/action_mapping.vala
+++ b/src/classes/action/action_mapping.vala
@@ -102,11 +102,12 @@ namespace pdfpc {
         }
 
         /**
-         * Handle mouse press events in the area.  Return true to indicate that
-         * the event was handled (and therefore we should not advance to the next
-         * page.
+         * Handle mouse press/release/motion events in the area. Return true to
+         * indicate that the event has been handled.
          */
         public abstract bool on_button_press(Gtk.Widget widget, Gdk.EventButton event);
+        public abstract bool on_button_release(Gtk.Widget widget, Gdk.EventButton event);
+        public abstract bool on_mouse_move(Gtk.Widget widget, Gdk.EventMotion event);
 
         /**
          * Override this method to get notified of the freeze toggle events.

--- a/src/classes/action/action_mapping.vala
+++ b/src/classes/action/action_mapping.vala
@@ -86,28 +86,29 @@ namespace pdfpc {
          * Override this method to get notified of the mouse entering the area.
          */
         public virtual void on_mouse_enter(Gtk.Widget widget, Gdk.EventMotion event) {
-            // Set the cursor to the X11 theme default link cursor
-            event.window.set_cursor(
-                new Gdk.Cursor.from_name(Gdk.Display.get_default(), "hand2")
-            );
+            return;
         }
 
         /**
          * Override this method to get notified of the mouse exiting the area.
          */
         public virtual void on_mouse_leave(Gtk.Widget widget, Gdk.EventMotion event) {
-            // Restore the cursor to its default state (The parent cursor
-            // configuration is used)
-            event.window.set_cursor(null);
+            return;
         }
 
         /**
          * Handle mouse press/release/motion events in the area. Return true to
          * indicate that the event has been handled.
          */
-        public abstract bool on_button_press(Gtk.Widget widget, Gdk.EventButton event);
-        public abstract bool on_button_release(Gtk.Widget widget, Gdk.EventButton event);
-        public abstract bool on_mouse_move(Gtk.Widget widget, Gdk.EventMotion event);
+        public virtual bool on_button_press(Gtk.Widget widget, Gdk.EventButton event) {
+            return false;
+        }
+        public virtual bool on_button_release(Gtk.Widget widget, Gdk.EventButton event) {
+            return false;
+        }
+        public virtual bool on_mouse_move(Gtk.Widget widget, Gdk.EventMotion event) {
+            return false;
+        }
 
         /**
          * Override this method to get notified of the freeze toggle events.

--- a/src/classes/action/action_mapping.vala
+++ b/src/classes/action/action_mapping.vala
@@ -112,6 +112,14 @@ namespace pdfpc {
         }
 
         /**
+         * By default, all mappings are active only in the normal mode.
+         * Override to change this (probably, there will never be a need).
+         */
+        public virtual bool is_sensitive() {
+            return this.controller.in_normal_mode();
+        }
+
+        /**
          * Override this method to get notified of the freeze toggle events.
          */
         public virtual void on_freeze(bool frozen) {

--- a/src/classes/action/action_mapping.vala
+++ b/src/classes/action/action_mapping.vala
@@ -43,11 +43,6 @@ namespace pdfpc {
         protected PresentationController controller;
 
         /**
-         * The PDF document in question.
-         */
-        protected Poppler.Document document;
-
-        /**
          * Constructors of ActionMapping classes shouldn't actually do much.  These
          * objects will generally be made with the new_from_... methods, below.
          * Unlike constructors, these have the option of returning null.  Since I
@@ -62,11 +57,10 @@ namespace pdfpc {
         /**
          * Instead of in the constructor, most setup is done in the init method.
          */
-        public virtual void init(Poppler.Rectangle area, PresentationController controller,
-                Poppler.Document document) {
+        public virtual void init(Poppler.Rectangle area,
+            PresentationController controller) {
             this.area = area;
             this.controller = controller;
-            this.document = document;
         }
 
         /**
@@ -76,7 +70,7 @@ namespace pdfpc {
          * to figure out if you're in a subclass.
          */
         public virtual ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
-                PresentationController controller, Poppler.Document document) {
+                PresentationController controller) {
             return null;
         }
 
@@ -85,7 +79,7 @@ namespace pdfpc {
          * return null if this class doesn't handle this type of AnnotMapping.
          */
         public virtual ActionMapping? new_from_annot_mapping(Poppler.AnnotMapping mapping,
-                PresentationController controller, Poppler.Document document) {
+                PresentationController controller) {
             return null;
         }
 

--- a/src/classes/action/action_mapping.vala
+++ b/src/classes/action/action_mapping.vala
@@ -25,6 +25,13 @@ namespace pdfpc {
      * Base action mapping, encapsulating actions that result from links or annotations.
      */
     public abstract class ActionMapping: GLib.Object {
+        public enum ActionType {
+            LINK,
+            MOVIE
+        }
+
+        public ActionType type;
+
         /**
          * The area on the PDF page associated with the action.
          */

--- a/src/classes/action/link_action.vala
+++ b/src/classes/action/link_action.vala
@@ -63,6 +63,13 @@ namespace pdfpc {
             return new_obj as ActionMapping;
         }
 
+        protected override void on_mouse_enter(Gtk.Widget widget, Gdk.EventMotion event) {
+            // Set the cursor to the X11 theme default link cursor
+            event.window.set_cursor(
+                new Gdk.Cursor.from_name(Gdk.Display.get_default(), "hand2")
+            );
+        }
+
         /**
          * Goto the link's destination on left clicks.
          */
@@ -94,14 +101,6 @@ namespace pdfpc {
             }
 
             return true;
-        }
-
-        protected override bool on_button_release(Gtk.Widget widget, Gdk.EventButton event) {
-            return false;
-        }
-
-        protected override bool on_mouse_move(Gtk.Widget widget, Gdk.EventMotion event) {
-            return false;
         }
     }
 }

--- a/src/classes/action/link_action.vala
+++ b/src/classes/action/link_action.vala
@@ -79,6 +79,10 @@ namespace pdfpc {
         protected override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
                 PresentationController controller) {
             switch (mapping.action.type) {
+            case Poppler.ActionType.URI:
+                var new_obj = new LinkAction();
+                new_obj.init(mapping, controller);
+                return new_obj as ActionMapping;
             case Poppler.ActionType.GOTO_DEST:
                 unowned var goto_action = (Poppler.ActionGotoDest*) mapping.action;
                 if (goto_action.dest.type == Poppler.DestType.NAMED) {

--- a/src/classes/action/link_action.vala
+++ b/src/classes/action/link_action.vala
@@ -41,9 +41,9 @@ namespace pdfpc {
         /**
          * Initializer.
          */
-        public new void init(Poppler.LinkMapping mapping, PresentationController controller,
-                Poppler.Document document) {
-            base.init(mapping.area, controller, document);
+        public new void init(Poppler.LinkMapping mapping,
+            PresentationController controller) {
+            base.init(mapping.area, controller);
             this.action = mapping.action.copy();
         }
 
@@ -77,13 +77,13 @@ namespace pdfpc {
          * destination inside the PDF file.
          */
         protected override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
-                PresentationController controller, Poppler.Document document) {
+                PresentationController controller) {
             switch (mapping.action.type) {
             case Poppler.ActionType.GOTO_DEST:
                 unowned var goto_action = (Poppler.ActionGotoDest*) mapping.action;
                 if (goto_action.dest.type == Poppler.DestType.NAMED) {
                     var new_obj = new LinkAction();
-                    new_obj.init(mapping, controller, document);
+                    new_obj.init(mapping, controller);
                     return new_obj as ActionMapping;
                 }
                 break;
@@ -92,7 +92,7 @@ namespace pdfpc {
                 var movie = movie_action.movie;
                 if (movie != null) {
                     var new_obj = new LinkAction();
-                    new_obj.init(mapping, controller, document);
+                    new_obj.init(mapping, controller);
                     return new_obj as ActionMapping;
                 }
                 break;
@@ -130,10 +130,10 @@ namespace pdfpc {
                 break;
             case Poppler.ActionType.GOTO_DEST:
                 unowned var action = (Poppler.ActionGotoDest*) this.action;
-                Poppler.Dest destination;
-                destination = this.document.find_dest(action.dest.named_dest);
+                var metadata = this.controller.metadata;
 
-                this.controller.switch_to_slide_number((int)(destination.page_num - 1));
+                int slide_number = metadata.find_dest(action.dest);
+                this.controller.switch_to_slide_number(slide_number);
 
                 break;
             case Poppler.ActionType.MOVIE:

--- a/src/classes/action/link_action.vala
+++ b/src/classes/action/link_action.vala
@@ -51,7 +51,7 @@ namespace pdfpc {
          * Create from the LinkMapping if the link is an internal link to a named
          * destination inside the PDF file.
          */
-        public override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
+        protected override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
                 PresentationController controller, Poppler.Document document) {
             if (   (mapping.action.type != Poppler.ActionType.GOTO_DEST || ((Poppler.ActionGotoDest*)mapping.action).dest.type != Poppler.DestType.NAMED)
                 && mapping.action.type != Poppler.ActionType.URI) {
@@ -66,7 +66,7 @@ namespace pdfpc {
         /**
          * Goto the link's destination on left clicks.
          */
-        public override bool on_button_press(Gtk.Widget widget, Gdk.EventButton event) {
+        protected override bool on_button_press(Gtk.Widget widget, Gdk.EventButton event) {
             if (event.button != 1)
                 return false;
 
@@ -94,6 +94,14 @@ namespace pdfpc {
             }
 
             return true;
+        }
+
+        protected override bool on_button_release(Gtk.Widget widget, Gdk.EventButton event) {
+            return false;
+        }
+
+        protected override bool on_mouse_move(Gtk.Widget widget, Gdk.EventMotion event) {
+            return false;
         }
     }
 }

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -237,14 +237,8 @@ namespace pdfpc {
          * movies in presentations.  As a bonus, a query string on the video
          * filename can activate the autostart and loop properties.  (E.g., link
          * to movie.avi?autostart&loop to make movie.avi start playing with the
-         * page is entered and loop back to the beginning when it reaches the end.)
-         *
-         * In LaTeX, create such links with
-         *      \usepackage{hyperref}
-         *      \href{run:<movie file>}{<placeholder content>}
-         * Since the video will take the shape of the placeholder content, you
-         * probably want to use a frame from the movie to get the right aspect
-         * ratio.
+         * page is entered and loop back to the beginning when it reaches the
+         * end.)
          */
         protected override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
                 PresentationController controller, Poppler.Document document) {
@@ -301,24 +295,9 @@ namespace pdfpc {
 
         /**
          * Create a new Movie from an annotation mapping, if the annotation is a
-         * screen annotation with a video file or a movie annotation.  Various
+         * screen annotation with a video file or a movie annotation.  Some
          * options to modify the behavior of the playback are not yet supported,
          * since they're missing from poppler.
-         *
-         * In LaTeX, create screen annotations with
-         *      \usepackage{movie15}
-         *      \includemovie[text=<placeholder content>]{}{}{<movie file>}
-         * The movie size is determined by the size of the placeholder content, so
-         * a frame from the movie is a good choice.  Note that the poster, autoplay,
-         * and repeat options are not yet supported.  (Also note that movie15 is
-         * deprecated, but it works as long as you run ps2pdf with the -dNOSAFER flag.)
-         *
-         * In LaTeX, create movie annotations with
-         *      \usepackage{multimedia}
-         *      \movie[<options>]{<placeholder content>}{<movie file>}
-         * The movie size is determined from the size of the placeholder content or
-         * the width and height options.  Note that the autostart, loop/repeat, and
-         * poster options are not yet supported.
          */
         protected override ActionMapping? new_from_annot_mapping(Poppler.AnnotMapping mapping,
                 PresentationController controller, Poppler.Document document) {

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -150,9 +150,14 @@ namespace pdfpc {
         protected int64 duration;
 
         /**
-         * Settings for the appearance of the progress bar.
+         * The desired font size (in *video* pixels!)
          */
-        protected double seek_bar_height = 20;
+        protected double seek_bar_fontsize = 16;
+
+        /**
+         * Settings for the appearance of the progress bar (in screen pixels).
+         */
+        protected double seek_bar_height;
         protected double seek_bar_padding = 2;
 
         /**
@@ -625,6 +630,8 @@ namespace pdfpc {
             this.video_h = info.height;
             this.scalex = (double) this.video_w/rect.width;
             this.scaley = (double) this.video_h/rect.height;
+            this.seek_bar_height = (this.seek_bar_fontsize +
+                2*seek_bar_padding)/this.scaley;
 
             overlay.query_duration(Gst.Format.TIME, out duration);
         }
@@ -797,6 +804,8 @@ namespace pdfpc {
                             this.rect = rect;
                             this.scalex = (double) this.video_w/rect.width;
                             this.scaley = (double) this.video_h/rect.height;
+                            this.seek_bar_height = (this.seek_bar_fontsize +
+                                2*seek_bar_padding)/this.scaley;
                         }
                         video_surface.resize_video(video_area, rect);
                     });

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -201,11 +201,11 @@ namespace pdfpc {
                 return;
             }
 
-            // initial seek to set the starting point. *Cause the video to
-            // be displayed on the page*.
             movie.pipeline.set_state(Gst.State.PAUSED);
-            // waits until the pipeline is actually in PAUSED mode
+            // wait until the pipeline is actually in PAUSED mode
             movie.pipeline.get_state(null, null, Gst.CLOCK_TIME_NONE);
+
+            // initial seek to set the starting point
             movie.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH,
                 movie.options.starttime*Gst.SECOND);
 
@@ -457,14 +457,6 @@ namespace pdfpc {
                 return false;
             }
 
-            Gst.State state;
-            Gst.ClockTime time = Gst.Util.get_timestamp();
-            this.pipeline.get_state(out state, null, time);
-            if (state == Gst.State.NULL) {
-                this.toggle_play();
-                return true;
-            }
-
             this.set_mouse_in(event.x, event.y);
             if (!this.in_seek_bar) {
                 this.toggle_play();
@@ -611,8 +603,6 @@ namespace pdfpc {
 
             if (this.mouse_drag) {
                 this.mouse_seek(event.x, event.y);
-            } else if (this.paused_at >= 0 || this.eos) {
-                this.pipeline.seek_simple(Gst.Format.TIME, Gst.SeekFlags.FLUSH, this.paused_at);
             }
 
             return false;

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -226,10 +226,10 @@ namespace pdfpc {
          * Inits  the movie
          */
         protected void init_movie(ControlledMovie movie, Poppler.Rectangle area,
-                PresentationController controller, Poppler.Document document,
+                PresentationController controller,
                 string uri, string? suburi, PlaybackOptions options,
                 bool temp = false) {
-            movie.init(area, controller, document);
+            movie.init(area, controller);
 
             movie.options = options;
 
@@ -257,7 +257,7 @@ namespace pdfpc {
          * end.)
          */
         protected override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
-                PresentationController controller, Poppler.Document document) {
+                PresentationController controller) {
             if (mapping.action.type != Poppler.ActionType.LAUNCH) {
                 return null;
             }
@@ -307,7 +307,7 @@ namespace pdfpc {
 
             Type type = Type.from_instance(this);
             ControlledMovie new_obj = (ControlledMovie) GLib.Object.new(type);
-            this.init_movie(new_obj, mapping.area, controller, document, uri,
+            this.init_movie(new_obj, mapping.area, controller, uri,
                 suburi, options);
             return new_obj;
         }
@@ -319,7 +319,7 @@ namespace pdfpc {
          * since they're missing from poppler.
          */
         protected override ActionMapping? new_from_annot_mapping(Poppler.AnnotMapping mapping,
-                PresentationController controller, Poppler.Document document) {
+                PresentationController controller) {
             Poppler.Annot annot = mapping.annot;
             string uri, suburi = null;
             bool temp = false;
@@ -400,7 +400,7 @@ namespace pdfpc {
             ControlledMovie new_obj = (ControlledMovie) GLib.Object.new(type);
             new_obj.filename = file;
 
-            this.init_movie(new_obj, mapping.area, controller, document, uri,
+            this.init_movie(new_obj, mapping.area, controller, uri,
                 suburi, options, temp);
             return new_obj;
         }

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -825,6 +825,8 @@ namespace pdfpc {
          * Seek to the time indicated by the mouse position on the progress bar.
          */
         protected int64 mouse_seek(double x, double y) {
+            // shift by the widget offset
+            x -= rect.x;
             double seek_fraction = (x - this.seek_bar_padding) / (rect.width -
                 2 * this.seek_bar_padding);
             if (seek_fraction < 0) {
@@ -874,6 +876,9 @@ namespace pdfpc {
          * Set a flag about whether the mouse is currently in the progress bar.
          */
         private void set_mouse_in(double x, double y) {
+            // shift coordinates by the widget offsets
+            x -= this.rect.x;
+            y -= this.rect.y;
             this.in_seek_bar =
                 x > 0 &&
                 x < this.rect.width &&

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -123,7 +123,6 @@ namespace pdfpc {
          */
         protected double scalex;
         protected double scaley;
-        protected int vheight;
 
         /**
          * The length of the movie, in nanoseconds (!).
@@ -478,7 +477,7 @@ namespace pdfpc {
         public void on_draw(Gst.Element overlay, Cairo.Context cr, uint64 timestamp,
                 uint64 duration) {
             // Transform to work from bottom left, in screen coordinates
-            cr.translate(0, this.vheight);
+            cr.translate(0, this.video_h);
             cr.scale(this.scalex, -this.scaley);
 
             this.draw_seek_bar(cr, timestamp);
@@ -559,7 +558,6 @@ namespace pdfpc {
             this.video_h = info.height;
             this.scalex = (double) this.video_w/rect.width;
             this.scaley = (double) this.video_h/rect.height;
-            this.vheight = this.video_h;
 
             overlay.query_duration(Gst.Format.TIME, out duration);
         }

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -417,6 +417,11 @@ namespace pdfpc {
                 return false;
             }
 
+            // don't intercept events in the drawing mode
+            if (this.controller.in_drawing_mode()) {
+                return false;
+            }
+
             Gst.State state;
             Gst.ClockTime time = Gst.Util.get_timestamp();
             this.pipeline.get_state(out state, null, time);
@@ -443,6 +448,11 @@ namespace pdfpc {
          * depending on the previous state.
          */
         public bool on_button_release(Gdk.EventButton event) {
+            // don't intercept events in the drawing mode
+            if (this.controller.in_drawing_mode()) {
+                return false;
+            }
+
             this.set_mouse_in(event.x, event.y);
             if (this.mouse_drag) {
                 var seek_time = this.mouse_seek(event.x, event.y);
@@ -454,7 +464,8 @@ namespace pdfpc {
                 }
             }
             this.mouse_drag = false;
-            return false;
+
+            return true;
         }
 
         public override void on_freeze(bool frozen) {

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -118,7 +118,6 @@ namespace pdfpc {
         protected Gdk.Cursor pause_cursor;
         protected Gdk.Cursor play_cursor;
         protected Gdk.Cursor drag_cursor;
-        protected Gdk.Cursor blank_cursor;
 
         /**
          * A flag to indicate when we've reached the End Of Stream, so we
@@ -187,7 +186,6 @@ namespace pdfpc {
             this.pause_cursor = this.load_cursor(display, "pause_cur.svg");
             this.play_cursor  = this.load_cursor(display, "play_cur.svg");
             this.drag_cursor  = new Gdk.Cursor.from_name(display, "hand1");
-            this.blank_cursor = new Gdk.Cursor.from_name(display, "none");
         }
 
         ~ControlledMovie() {
@@ -434,17 +432,13 @@ namespace pdfpc {
 
         private void update_cursor(Gdk.Window window) {
             Gdk.Cursor cursor;
-            if (!this.controller.in_drawing_mode()) {
-                if (this.in_seek_bar) {
-                    cursor = this.drag_cursor;
-                } else
-                if (this.paused_at >= 0) {
-                    cursor = this.play_cursor;
-                } else {
-                    cursor = this.pause_cursor;
-                }
+            if (this.in_seek_bar) {
+                cursor = this.drag_cursor;
+            } else
+            if (this.paused_at >= 0) {
+                cursor = this.play_cursor;
             } else {
-                cursor = this.blank_cursor;
+                cursor = this.pause_cursor;
             }
             window.set_cursor(cursor);
         }
@@ -460,11 +454,6 @@ namespace pdfpc {
             }
 
             this.update_cursor(event.window);
-
-            // don't intercept events in the drawing mode
-            if (this.controller.in_drawing_mode()) {
-                return false;
-            }
 
             this.set_mouse_in(event.x, event.y);
             if (!this.in_seek_bar) {
@@ -485,11 +474,6 @@ namespace pdfpc {
          */
         protected override bool on_button_release(Gtk.Widget widget, Gdk.EventButton event) {
             this.update_cursor(event.window);
-
-            // don't intercept events in the drawing mode
-            if (this.controller.in_drawing_mode()) {
-                return false;
-            }
 
             this.set_mouse_in(event.x, event.y);
             if (this.mouse_drag) {
@@ -662,10 +646,6 @@ namespace pdfpc {
         }
 
         protected void draw_seek_bar(Cairo.Context cr, uint64 timestamp) {
-            if (this.controller.in_drawing_mode()) {
-                return;
-            }
-
             double start = (double) options.starttime*Gst.SECOND/this.duration;
             double stop = (double) options.stoptime*Gst.SECOND/this.duration;
 

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -227,7 +227,7 @@ namespace pdfpc {
          * probably want to use a frame from the movie to get the right aspect
          * ratio.
          */
-        public override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
+        protected override ActionMapping? new_from_link_mapping(Poppler.LinkMapping mapping,
                 PresentationController controller, Poppler.Document document) {
             if (mapping.action.type != Poppler.ActionType.LAUNCH) {
                 return null;
@@ -301,7 +301,7 @@ namespace pdfpc {
          * the width and height options.  Note that the autostart, loop/repeat, and
          * poster options are not yet supported.
          */
-        public override ActionMapping? new_from_annot_mapping(Poppler.AnnotMapping mapping,
+        protected override ActionMapping? new_from_annot_mapping(Poppler.AnnotMapping mapping,
                 PresentationController controller, Poppler.Document document) {
             Poppler.Annot annot = mapping.annot;
             string uri, suburi = null;
@@ -384,7 +384,7 @@ namespace pdfpc {
         /**
          * When we leave the page, stop the movie and delete any temporary files.
          */
-        public override void deactivate() {
+        protected override void deactivate() {
             this.stop();
             if (this.temp != "") {
                 if (FileUtils.unlink(this.temp) != 0) {
@@ -412,7 +412,7 @@ namespace pdfpc {
          * Inside the progress bar, pause or stop the timeout, and start the
          * drag state.
          */
-        public override bool on_button_press(Gtk.Widget widget, Gdk.EventButton event) {
+        protected override bool on_button_press(Gtk.Widget widget, Gdk.EventButton event) {
             if (this.pipeline == null) {
                 return false;
             }
@@ -447,7 +447,7 @@ namespace pdfpc {
          * Stop the drag state and restart either playback or the timeout,
          * depending on the previous state.
          */
-        public bool on_button_release(Gdk.EventButton event) {
+        protected override bool on_button_release(Gtk.Widget widget, Gdk.EventButton event) {
             // don't intercept events in the drawing mode
             if (this.controller.in_drawing_mode()) {
                 return false;
@@ -468,7 +468,7 @@ namespace pdfpc {
             return true;
         }
 
-        public override void on_freeze(bool frozen) {
+        protected override void on_freeze(bool frozen) {
             // if a video was forcefully hidden but we're no longer in the
             // freeze mode, show it and clear the respective flag
             foreach (var sink in this.sinks) {
@@ -546,7 +546,7 @@ namespace pdfpc {
         /**
          * Seek if we're dragging the progress bar.
          */
-        public bool on_motion(Gdk.EventMotion event) {
+        protected override bool on_mouse_move(Gtk.Widget widget, Gdk.EventMotion event) {
             this.set_mouse_in(event.x, event.y);
             if (this.mouse_drag) {
                 this.mouse_seek(event.x, event.y);
@@ -710,15 +710,6 @@ namespace pdfpc {
                     Gst.Element ad_element = this.add_video_control(queue, bin,
                         conf.rect);
                     ad_element.link(sink);
-
-                    video_area.add_events(
-                          Gdk.EventMask.BUTTON_PRESS_MASK
-                        | Gdk.EventMask.BUTTON_RELEASE_MASK
-                        | Gdk.EventMask.POINTER_MOTION_MASK
-                    );
-                    video_area.motion_notify_event.connect(this.on_motion);
-                    video_area.button_press_event.connect(this.on_button_press);
-                    video_area.button_release_event.connect(this.on_button_release);
                 } else {
                     queue.link(sink);
                 }

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -856,6 +856,7 @@ namespace pdfpc.Metadata {
                 mapping.deactivate();
             }
             this.action_mapping.clear();
+            this.mapping_page_num = -1;
         }
 
         /**

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -1554,11 +1554,13 @@ namespace pdfpc.Metadata {
             if (page_num != this.mapping_page_num) {
                 this.deactivate_mappings();
 
-                GLib.List<Poppler.LinkMapping> link_mappings;
-                link_mappings = this.get_document().get_page(page_num).get_link_mapping();
+                var page = this.get_document().get_page(page_num);
+
+                var link_mappings = page.get_link_mapping();
                 foreach (unowned Poppler.LinkMapping mapping in link_mappings) {
                     foreach (var blank in blanks) {
-                        var action = blank.new_from_link_mapping(mapping, this.controller, this.document);
+                        var action = blank.new_from_link_mapping(mapping,
+                            this.controller, this.document);
                         if (action != null) {
                             this.action_mapping.add(action);
                             break;
@@ -1566,11 +1568,11 @@ namespace pdfpc.Metadata {
                     }
                 }
 
-                GLib.List<Poppler.AnnotMapping> annot_mappings;
-                annot_mappings = this.get_document().get_page(page_num).get_annot_mapping();
+                var annot_mappings = page.get_annot_mapping();
                 foreach (unowned Poppler.AnnotMapping mapping in annot_mappings) {
                     foreach (var blank in blanks) {
-                        var action = blank.new_from_annot_mapping(mapping, this.controller, this.document);
+                        var action = blank.new_from_annot_mapping(mapping,
+                            this.controller, this.document);
                         if (action != null) {
                             this.action_mapping.add(action);
                             break;

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -1560,7 +1560,7 @@ namespace pdfpc.Metadata {
                 foreach (unowned Poppler.LinkMapping mapping in link_mappings) {
                     foreach (var blank in blanks) {
                         var action = blank.new_from_link_mapping(mapping,
-                            this.controller, this.document);
+                            this.controller);
                         if (action != null) {
                             this.action_mapping.add(action);
                             break;
@@ -1572,7 +1572,7 @@ namespace pdfpc.Metadata {
                 foreach (unowned Poppler.AnnotMapping mapping in annot_mappings) {
                     foreach (var blank in blanks) {
                         var action = blank.new_from_annot_mapping(mapping,
-                            this.controller, this.document);
+                            this.controller);
                         if (action != null) {
                             this.action_mapping.add(action);
                             break;
@@ -1583,6 +1583,21 @@ namespace pdfpc.Metadata {
                 this.mapping_page_num = page_num;
             }
             return this.action_mapping;
+        }
+
+        /**
+         * Return slide number corresponding to a named destination
+         */
+        public int find_dest(Poppler.Dest dest) {
+            if (dest.type == Poppler.DestType.NAMED) {
+                var found_dest =
+                    this.document.find_dest(dest.named_dest);
+                if (found_dest != null) {
+                    return found_dest.page_num - 1;
+                }
+            }
+
+            return -1;
         }
 
         public bool has_beamer_notes {

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -88,7 +88,9 @@ namespace pdfpc.Metadata {
         /**
          * Poppler document of the associated PDF file
          */
-        protected Poppler.Document document;
+        public Poppler.Document document {
+            get; protected set;
+        }
 
         /**
          * Number of pages in the PDF document
@@ -1495,13 +1497,6 @@ namespace pdfpc.Metadata {
         }
 
         /**
-         * Return the Poppler.Document associated with this file
-         */
-        public Poppler.Document get_document() {
-            return this.document;
-        }
-
-        /**
          * Return the PDF title
          */
         public string get_title() {
@@ -1554,7 +1549,7 @@ namespace pdfpc.Metadata {
             if (page_num != this.mapping_page_num) {
                 this.deactivate_mappings();
 
-                var page = this.get_document().get_page(page_num);
+                var page = this.document.get_page(page_num);
 
                 var link_mappings = page.get_link_mapping();
                 foreach (unowned Poppler.LinkMapping mapping in link_mappings) {

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -615,6 +615,10 @@ namespace pdfpc {
             return is_pointer_active() || is_spotlight_active();
         }
 
+        public bool in_normal_mode() {
+            return annotation_mode == AnnotationMode.NORMAL;
+        }
+
         public string get_mode_string() {
             switch (this.annotation_mode) {
                 case POINTER:

--- a/src/classes/renderer/image.vala
+++ b/src/classes/renderer/image.vala
@@ -1,0 +1,70 @@
+/**
+ * Image renderer
+ *
+ * This file is part of pdfpc.
+ *
+ * Copyright 2021 Evgeny Stambulchik
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc.Renderer {
+    public class Image {
+       /**
+         * Load an (SVG) image, replacing a substring in it in special cases
+         */
+        public static Cairo.Surface? render(string filename,
+            int width, int height) {
+            // attempt to load from a local path (if the user hasn't installed)
+            // if that fails, attempt to load from the global path
+            string load_icon_path;
+            if (Options.no_install) {
+                load_icon_path = Path.build_filename(Paths.SOURCE_PATH, "icons",
+                    filename);
+            } else {
+                load_icon_path = Path.build_filename(Paths.SHARE_PATH, "icons",
+                    filename);
+            }
+            File icon_file = File.new_for_path(load_icon_path);
+
+            try {
+                Gdk.Pixbuf pixbuf;
+                if (filename == "highlight.svg") {
+                    uint8[] contents;
+                    string etag_out;
+                    icon_file.load_contents(null, out contents, out etag_out);
+
+                    string buf = (string) contents;
+                    buf = buf.replace("pointer_color", Options.pointer_color);
+
+                    MemoryInputStream stream =
+                        new MemoryInputStream.from_data(buf.data);
+
+                    pixbuf = new Gdk.Pixbuf.from_stream_at_scale(stream,
+                        width, width, true);
+                } else {
+                    pixbuf = new Gdk.Pixbuf.from_file_at_scale(load_icon_path,
+                        width, width, true);
+                }
+
+                return Gdk.cairo_surface_create_from_pixbuf(pixbuf, 0, null);
+            } catch (Error e) {
+                GLib.printerr("Warning: Could not load image %s (%s)\n",
+                    load_icon_path, e.message);
+                return null;
+            }
+        }
+    }
+}

--- a/src/classes/renderer/pdf.vala
+++ b/src/classes/renderer/pdf.vala
@@ -91,7 +91,7 @@ namespace pdfpc {
             Timer timer = new Timer();
 
             // Retrieve the Poppler.Page for the page to render
-            var page = metadata.get_document().get_page(slide_number);
+            var page = metadata.document.get_page(slide_number);
 
             // A lot of Pdfs have transparent backgrounds defined. We render
             // every page before a white background because of this.

--- a/src/classes/view/behaviour/pdf_link.vala
+++ b/src/classes/view/behaviour/pdf_link.vala
@@ -58,6 +58,7 @@ namespace pdfpc.View.Behaviour {
             view.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
 
             view.button_press_event.connect(this.on_button_press);
+            view.button_release_event.connect(this.on_button_release);
             view.motion_notify_event.connect(this.on_mouse_move);
             view.entering_slide.connect(this.on_entering_slide);
             view.leaving_slide.connect(this.on_leaving_slide);
@@ -105,6 +106,21 @@ namespace pdfpc.View.Behaviour {
         }
 
         /**
+         * Similarly, for button release events
+         */
+        protected bool on_button_release(Gtk.Widget source, Gdk.EventButton e) {
+            // In case the coords belong to a link we will get its action. If
+            // they are pointing nowhere we just get null.
+            ActionMapping mapping = this.get_link_mapping_by_coordinates(e.x, e.y);
+
+            if (mapping == null) {
+                return false;
+            }
+
+            return mapping.on_button_release(source, e);
+        }
+
+        /**
          * Called whenever the mouse is moved on the surface of the View.Pdf
          *
          * The signal emitted by this method may for example be used to change
@@ -124,7 +140,11 @@ namespace pdfpc.View.Behaviour {
             }
             this.active_mapping = link_mapping;
 
-            return false;
+            if (link_mapping != null) {
+                return link_mapping.on_mouse_move(source, event);
+            } else {
+                return false;
+            }
         }
 
         /**

--- a/src/classes/view/behaviour/pdf_link.vala
+++ b/src/classes/view/behaviour/pdf_link.vala
@@ -98,7 +98,7 @@ namespace pdfpc.View.Behaviour {
             // they are pointing nowhere we just get null.
             ActionMapping mapping = this.get_link_mapping_by_coordinates(e.x, e.y);
 
-            if (mapping == null) {
+            if (mapping == null || !mapping.is_sensitive()) {
                 return false;
             }
 
@@ -113,7 +113,7 @@ namespace pdfpc.View.Behaviour {
             // they are pointing nowhere we just get null.
             ActionMapping mapping = this.get_link_mapping_by_coordinates(e.x, e.y);
 
-            if (mapping == null) {
+            if (mapping == null || !mapping.is_sensitive()) {
                 return false;
             }
 
@@ -137,13 +137,13 @@ namespace pdfpc.View.Behaviour {
                     this.active_mapping.on_mouse_leave(source, event);
                 }
 
-                if (link_mapping != null) {
+                if (link_mapping != null && link_mapping.is_sensitive()) {
                     link_mapping.on_mouse_enter(source, event);
                 }
             }
             this.active_mapping = link_mapping;
 
-            if (link_mapping != null) {
+            if (link_mapping != null && link_mapping.is_sensitive()) {
                 return link_mapping.on_mouse_move(source, event);
             } else {
                 return false;
@@ -155,7 +155,7 @@ namespace pdfpc.View.Behaviour {
          * further requests and checks.
          */
         protected void on_entering_slide(View.Pdf source, int page_number) {
-            // if target is not mapped (ie. the size is not known) post pone
+            // if target is not mapped (ie. the size is not known) postpone
             // the mapping calculatation since the results wouldn't be correct
             if (!target.get_mapped()) {
                 target.realize.connect(() => {

--- a/src/classes/view/behaviour/pdf_link.vala
+++ b/src/classes/view/behaviour/pdf_link.vala
@@ -131,6 +131,9 @@ namespace pdfpc.View.Behaviour {
 
             if (link_mapping != this.active_mapping) {
                 if (this.active_mapping != null) {
+                    // Restore the cursor to its default state (the parent
+                    // cursor configuration is used)
+                    event.window.set_cursor(null);
                     this.active_mapping.on_mouse_leave(source, event);
                 }
 

--- a/src/classes/view/transition_manager.vala
+++ b/src/classes/view/transition_manager.vala
@@ -69,7 +69,7 @@ namespace pdfpc {
             if (this.fps > 0 &&
                 slide_number >= 0 &&
                 slide_number < metadata.get_slide_count()) {
-                var page = metadata.get_document().get_page(slide_number);
+                var page = metadata.document.get_page(slide_number);
 
                 var trans = page.get_transition();
                 // If undefined or is the simple replace transition, assume the

--- a/src/classes/view/video.vala
+++ b/src/classes/view/video.vala
@@ -37,6 +37,7 @@ namespace pdfpc {
             video.set_size_request(position.width, position.height);
             this.put(video, position.x, position.y);
             this.videos.append(video);
+            video.get_window().set_pass_through(true);
             this.show_all();
         }
 

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -162,17 +162,18 @@ namespace pdfpc.Window {
             this.overlay_layout.add_overlay(this.pen_drawing_surface);
             this.overlay_layout.add_overlay(this.pointer_drawing_surface);
 
+            this.pointer_drawing_surface.no_show_all = true;
+            this.pen_drawing_surface.no_show_all = true;
+
             this.video_surface.realize.connect(() => {
                 this.set_widget_event_pass_through(this.video_surface, true);
             });
             this.pen_drawing_surface.realize.connect(() => {
-                this.enable_pen(false);
                 this.pen_drawing_surface.get_window().set_pass_through(true);
                 this.set_widget_event_pass_through(this.pen_drawing_surface,
                     true);
             });
             this.pointer_drawing_surface.realize.connect(() => {
-                this.enable_pointer(false);
                 this.pointer_drawing_surface.get_window().set_pass_through(true);
                 this.set_widget_event_pass_through(this.pointer_drawing_surface,
                     true);

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -921,61 +921,21 @@ namespace pdfpc.Window {
         }
 
        /**
-         * Load an (SVG) icon, replacing a substring in it in special cases
+         * Load an icon (essentially, a quadratic image)
          */
-        protected Gtk.Image load_icon(string filename, int icon_height) {
-            // attempt to load from a local path (if the user hasn't installed)
-            // if that fails, attempt to load from the global path
-            string load_icon_path;
-            if (Options.no_install) {
-                load_icon_path = Path.build_filename(Paths.SOURCE_PATH, "icons",
-                    filename);
-            } else {
-                load_icon_path = Path.build_filename(Paths.SHARE_PATH, "icons",
-                    filename);
-            }
-            File icon_file = File.new_for_path(load_icon_path);
-
+        protected Gtk.Image load_icon(string filename, int size) {
             Gtk.Image icon;
-            try {
-                int width = icon_height;
-                int height = icon_height;
-
-                if (!Pdfpc.is_Wayland_backend() && !Pdfpc.is_Quartz_backend()) {
-                    width *= this.gdk_scale;
-                    height *= this.gdk_scale;
-                }
-
-                Gdk.Pixbuf pixbuf;
-                if (filename == "highlight.svg") {
-                    uint8[] contents;
-                    string etag_out;
-                    icon_file.load_contents(null, out contents, out etag_out);
-
-                    string buf = (string) contents;
-                    buf = buf.replace("pointer_color", Options.pointer_color);
-
-                    MemoryInputStream stream =
-                        new MemoryInputStream.from_data(buf.data);
-
-                    pixbuf = new Gdk.Pixbuf.from_stream_at_scale(stream,
-                        width, height, true);
-                } else {
-                    pixbuf = new Gdk.Pixbuf.from_file_at_scale(load_icon_path,
-                        width, height, true);
-                }
-
-                Cairo.Surface surface =
-                    Gdk.cairo_surface_create_from_pixbuf(pixbuf, 0, null);
-
+            if (!Pdfpc.is_Wayland_backend() && !Pdfpc.is_Quartz_backend()) {
+                size *= this.gdk_scale;
+            }
+            var surface = Renderer.Image.render(filename, size, size);
+            if (surface != null) {
                 icon = new Gtk.Image.from_surface(surface);
-                icon.no_show_all = true;
-            } catch (Error e) {
-                GLib.printerr("Warning: Could not load icon %s (%s)\n",
-                    load_icon_path, e.message);
+            } else {
                 icon = new Gtk.Image.from_icon_name("image-missing",
                     Gtk.IconSize.LARGE_TOOLBAR);
             }
+            icon.no_show_all = true;
             return icon;
         }
 


### PR DESCRIPTION
* Fix #606;
* Implement #348 (not 100%, which would be a lot of work, just for the current slide);
* Use different cursors when the pointer is above the video frame - play/stop/drag.

* Q1: The cursors (and the respective actions) are enabled in all modes except the drawing (pen/eraser) one. The idea is that e.g., while in the "laser pointer" mode, the video can still be controlled without switching the mode. On the other hand, the cursors may be annoying. Maybe restrict the video controls only to the "normal" mode?
* Q2: Maybe the colors in the play/stop cursors should be swapped (black outline, light fill)?