### PR TITLE
Hidden slides

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -160,6 +160,12 @@ Go forward 10 slides
 .B Shift + Left cursor key / 3rd mouse button / Mouse wheel up
 Go back 10 slides
 .TP
+.B Shift + n
+Go forward 1 slide irrespectively of its "hidden" attribute
+.TP
+.B Shift + p
+Go backward 1 slide irrespectively of its "hidden" attribute
+.TP
 .B Home
 Go to the first slide
 .TP
@@ -244,7 +250,11 @@ Pause timer
 Reset timer
 .TP
 .B Ctrl + o
-Toggle the overlay flag for one particular slide (see Overlays
+Toggle the overlay flag for one particular slide (see \fBOverlays\fR
+below)
+.TP
+.B Ctrl + h
+Toggle the hidden attribute for the current slide (see \fBHidden slides\fR
 below)
 .TP
 .B Ctrl + e
@@ -424,6 +434,16 @@ with pdflatex).  If your preferred slide-producing method does not work
 correctly with this detection, you can supply this information using the \[aq]Ctrl + o\[aq] key
 for each slide that is part of an overlay (except the first one!).  The page
 numbering is also adapted.  This information is automatically stored.
+
+.SS Hidden slides
+.PP
+When preparing presentation from an existing set of slides, it is sometimes
+helpful to mark certain slides to be skipped during the talk. The \[aq]Ctrl +
+h\[aq] combination toggles the "hidden" attribute of the current slide, making
+it essentially invisible. It is still possible to navigate to a hidden slide
+either in the \fBOverview\fR mode, using the Goto action (\[aq]g\[aq]), or
+by hitting \[aq]Shift + n\[aq] or \[aq]Shift + p\[aq] to switch to the
+next/previous slide, respectively, ignoring the "hidden" attribute.
 
 .SS End slide
 .PP

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -25,6 +25,10 @@ bind S+Up               firstOverlay
 bind S+Right            next10
 bind S+Left             prev10
 
+# Incremental movement ignoring the "hidden" attribute
+bind S+n                nextForced
+bind S+p                prevForced
+
 # Jumps
 bind Home               gotoFirst
 bind End                gotoLast

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -70,6 +70,7 @@ bind C+t                resetTimer
 bind C+n                note
 bind C+o                overlay
 bind C+e                endSlide
+bind C+h                toggleHidden
 
 # Annotation modes
 bind 1                  switchMode normal

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -57,6 +57,11 @@ namespace pdfpc.Metadata {
         public bool forced_overlay;
 
         /**
+         * Slide to be skipped in the normal flow
+         */
+        public bool hidden;
+
+        /**
          * Note
          */
         public SlideNote note;
@@ -182,6 +187,14 @@ namespace pdfpc.Metadata {
 
         // END .pdfpc meta
 
+        protected PageMeta? get_page_meta(int slide_number) {
+            if (slide_number >= 0 && slide_number < this.pages.size) {
+                return this.pages.get(slide_number);
+            } else {
+                return null;
+            }
+        }
+
         public bool is_ready {
             get {
                 return (this.document != null);
@@ -205,7 +218,7 @@ namespace pdfpc.Metadata {
         public void set_note(string note_text, int slide_number,
             bool is_native = false) {
 
-            var page = this.pages.get(slide_number);
+            var page = this.get_page_meta(slide_number);
             if (page != null) {
                 if (page.note == null) {
                     page.note = new SlideNote();
@@ -225,7 +238,7 @@ namespace pdfpc.Metadata {
          * Return the text of a note
          */
         public string get_note(int slide_number) {
-            var page = this.pages.get(slide_number);
+            var page = this.get_page_meta(slide_number);
             if (page != null && page.note != null) {
                 return page.note.note_text;
             } else {
@@ -234,7 +247,7 @@ namespace pdfpc.Metadata {
         }
 
         public bool is_note_read_only(int slide_number) {
-            var page = this.pages.get(slide_number);
+            var page = this.get_page_meta(slide_number);
             if (page != null && page.note != null) {
                 return page.note.is_native;
             } else {
@@ -306,7 +319,7 @@ namespace pdfpc.Metadata {
                 }
 
                 // Only save pages with user-defined metadata
-                if (page.forced_overlay ||
+                if (page.forced_overlay || page.hidden ||
                     (page.note != null    &&
                      !page.note.is_native &&
                      page.note.note_text != null)) {
@@ -320,6 +333,10 @@ namespace pdfpc.Metadata {
                     builder.add_int_value(overlay);
                     if (page.forced_overlay) {
                         builder.set_member_name("forcedOverlay");
+                        builder.add_boolean_value(true);
+                    }
+                    if (page.hidden) {
+                        builder.set_member_name("hidden");
                         builder.add_boolean_value(true);
                     }
                     if (page.note != null &&
@@ -362,7 +379,7 @@ namespace pdfpc.Metadata {
 	    unowned Json.Object obj = node.get_object();
             string page_label = "", note = "";
             int idx = -1, overlay = 0, slide_number = -1;
-            bool forced_overlay = false;
+            bool forced_overlay = false, hidden = false;
             foreach (unowned string name in obj.get_members()) {
                 unowned Json.Node item = obj.get_member(name);
                 switch (name) {
@@ -378,6 +395,9 @@ namespace pdfpc.Metadata {
                 case "forcedOverlay":
 		    forced_overlay = item.get_boolean();
 		    break;
+                case "hidden":
+		    hidden = item.get_boolean();
+		    break;
                 case "note":
 		    note = item.get_string();
 		    break;
@@ -390,20 +410,20 @@ namespace pdfpc.Metadata {
             // Try to lookup the page by label; if fails, use the page index
             if (page_label != "") {
                 // first, try fast access by index
-                var page = this.pages.get(idx);
+                var page = this.get_page_meta(idx);
                 if (page != null &&
                     page.label == page_label &&
                     slide_get_overlay(idx) == overlay) {
                     slide_number = idx;
                 } else {
                     for (int i = 0; i < this.page_count; i++) {
-                        page = this.pages.get(i);
+                        page = this.get_page_meta(i);
                         if (page.label == page_label) {
                             slide_number = i + overlay;
                             break;
                         }
                     }
-                    page = this.pages.get(slide_number);
+                    page = this.get_page_meta(slide_number);
                     if (page == null || page.label != page_label) {
                         // Return to fallback
                         slide_number = idx;
@@ -413,6 +433,7 @@ namespace pdfpc.Metadata {
                 slide_number = idx;
             }
 
+            this.set_slide_hidden(slide_number, hidden);
             if (forced_overlay) {
                 this.add_overlay(slide_number);
             }
@@ -630,7 +651,7 @@ namespace pdfpc.Metadata {
                         user_slide_to_real_slide(user_slide, false);
                     // Assign to all slides from the same user slide
                     for (int i = slide_number; i < this.page_count; i++) {
-                        var page = this.pages.get(i);
+                        var page = this.get_page_meta(i);
                         if (page.user_slide == user_slide) {
                             set_note(notes_unescaped, i, false);
                         } else {
@@ -1102,7 +1123,7 @@ namespace pdfpc.Metadata {
                 string previous_label = null;
                 int user_slide = -1;
                 for (int i = 0; i < this.page_count; ++i) {
-                    var page = this.pages.get(i);
+                    var page = this.get_page_meta(i);
                     // Auto-detect which pages to skip, but respect overlays
                     // forcefully set by the user
                     string this_label = page.label;
@@ -1137,7 +1158,7 @@ namespace pdfpc.Metadata {
          */
         public int get_user_slide_count() {
             if (this.page_count > 0) {
-                var page = this.pages.get((int) this.page_count - 1);
+                var page = this.get_page_meta((int) this.page_count - 1);
                 return page.user_slide + 1;
             } else {
                 return 0;
@@ -1262,14 +1283,14 @@ namespace pdfpc.Metadata {
                 // We cannot skip the first slide
                 return 0;
             }
-            var prev_page = this.pages.get(slide_number - 1);
+            var prev_page = this.get_page_meta(slide_number - 1);
             if (prev_page == null) {
                 // Something is terribly wrong...
                 return 0;
             }
             int prev_user_slide_number = prev_page.user_slide;
 
-            var page = this.pages.get(slide_number);
+            var page = this.get_page_meta(slide_number);
             if (page == null || page.user_slide == prev_user_slide_number) {
                 // Nothing to do
                 return 0;
@@ -1277,13 +1298,98 @@ namespace pdfpc.Metadata {
             page.forced_overlay = true;
 
             for (int i = slide_number; i < this.page_count; i++) {
-                page = this.pages.get(i);
+                page = this.get_page_meta(i);
                 page.user_slide--;
             }
 
             this.dirty_state = true;
 
             return -1;
+        }
+
+        /**
+         * Get the "hidden" flag of a slide
+         *
+         * Note that for an invalid slide_number it returns false
+         */
+        public bool get_slide_hidden(int slide_number) {
+            var page = this.get_page_meta(slide_number);
+            if (page == null) {
+                return false;
+            } else {
+                return page.hidden;
+            }
+        }
+
+        /**
+         * Set the "hidden" flag of a slide
+         *
+         * If the new state = hidden, return the offset to the next
+         * non-hidden slide
+         */
+        public int set_slide_hidden(int slide_number, bool onoff) {
+            var page = this.get_page_meta(slide_number);
+            if (page == null || page.hidden == onoff) {
+                // Nothing to do
+                return 0;
+            }
+
+            page.hidden = onoff;
+            this.dirty_state = true;
+
+            if (onoff) {
+                for (int i = slide_number; i < this.page_count; i++) {
+                    page = this.get_page_meta(i);
+                    if (page != null && !page.hidden) {
+                        return i - slide_number;
+                    }
+                }
+
+                // if we're here, it was the last non-hidden slide;
+                // let's move backwards
+                for (int i = slide_number - 1; i >= 0; i--) {
+                    page = this.get_page_meta(i);
+                    if (page != null && !page.hidden) {
+                        return i - slide_number;
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        /**
+         * Check whether a user slide is (at least partially) hidden
+         *
+         * Note that for an invalid user_slide it returns false
+         */
+        public bool get_user_slide_hidden(int user_slide) {
+            int slide_number = user_slide_to_real_slide(user_slide, false);
+            do {
+                if (get_slide_hidden(slide_number)) {
+                    return true;
+                }
+                slide_number++;
+            } while (slide_number < this.page_count &&
+                     real_slide_to_user_slide(slide_number) == user_slide);
+
+            return false;
+        }
+
+        /**
+         * Find a nearest non-hidden slide, optionally looking up backwards
+         */
+        public int nearest_nonhidden(int slide_number, bool backwards = false) {
+            int new_slide_number = slide_number;
+            while (this.get_slide_hidden(new_slide_number)) {
+                if (backwards) {
+                    new_slide_number--;
+                } else {
+                    new_slide_number++;
+                }
+            }
+
+            return new_slide_number;
         }
 
         /**
@@ -1298,14 +1404,14 @@ namespace pdfpc.Metadata {
             } else {
                 if (lastSlide) {
                     for (int i = (int)this.page_count - 1; i >= 0; i--) {
-                        var page = this.pages.get(i);
+                        var page = this.get_page_meta(i);
                         if (page.user_slide == number) {
                             return i;
                         }
                     }
                 } else {
                     for (int i = 0; i < this.page_count; i++) {
-                        var page = this.pages.get(i);
+                        var page = this.get_page_meta(i);
                         if (page.user_slide == number) {
                             return i;
                         }
@@ -1327,7 +1433,7 @@ namespace pdfpc.Metadata {
             } else if (number >= this.page_count) {
                 return this.get_user_slide_count() - 1;
             } else {
-                var page = this.pages.get(number);
+                var page = this.get_page_meta(number);
                 return page.user_slide;
             }
         }

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -112,6 +112,7 @@ namespace pdfpc {
             }
 
             var next_slide = this.current_slide_number + 1;
+            next_slide = metadata.nearest_nonhidden(next_slide);
             if (duration > 0) {
                 this.autoadvance_timeout_id =
                     GLib.Timeout.add((int) (1000*duration), () => {
@@ -1227,6 +1228,8 @@ namespace pdfpc {
 
             add_action("overlay", this.add_overlay,
                 "Mark the current slide as an overlay slide");
+            add_action("toggleHidden", this.toggle_hidden,
+                "Toggle the hidden flag of the current slide");
             add_action("note", this.controllables_edit_note,
                 "Edit notes for the current slide");
             add_action("endSlide", this.set_end_user_slide,
@@ -1647,6 +1650,7 @@ namespace pdfpc {
         public void next_page() {
             var new_slide_number = this.current_slide_number + 1;
 
+            new_slide_number = metadata.nearest_nonhidden(new_slide_number);
             this.switch_to_slide_number(new_slide_number);
         }
 
@@ -1661,6 +1665,7 @@ namespace pdfpc {
                 new_slide_number = (int) this.n_slides - 1;
             }
 
+            new_slide_number = metadata.nearest_nonhidden(new_slide_number);
             this.switch_to_slide_number(new_slide_number);
         }
 
@@ -1696,6 +1701,7 @@ namespace pdfpc {
         public void previous_page() {
             var new_slide_number = this.current_slide_number - 1;
 
+            new_slide_number = metadata.nearest_nonhidden(new_slide_number, true);
             this.switch_to_slide_number(new_slide_number);
         }
 
@@ -1705,6 +1711,7 @@ namespace pdfpc {
         public void previous_user_page() {
             var new_slide_number = this.metadata.user_slide_to_real_slide(this.current_user_slide_number - 1);
 
+            new_slide_number = metadata.nearest_nonhidden(new_slide_number, true);
             this.switch_to_slide_number(new_slide_number);
         }
 
@@ -1767,6 +1774,7 @@ namespace pdfpc {
             var new_user_slide_number = int.min(this.current_user_slide_number + 10, this.user_n_slides - 1);
             var new_slide_number = this.metadata.user_slide_to_real_slide(new_user_slide_number);
 
+            new_slide_number = metadata.nearest_nonhidden(new_slide_number);
             this.switch_to_slide_number(new_slide_number);
         }
 
@@ -1777,6 +1785,7 @@ namespace pdfpc {
             var new_user_slide_number = int.max(this.current_user_slide_number - 10, 0);
             var new_slide_number = this.metadata.user_slide_to_real_slide(new_user_slide_number);
 
+            new_slide_number = metadata.nearest_nonhidden(new_slide_number, true);
             this.switch_to_slide_number(new_slide_number);
         }
 
@@ -1929,6 +1938,19 @@ namespace pdfpc {
                 } else {
                     this.overview.set_n_slides(this.user_n_slides);
                 }
+                this.controllables_update();
+            }
+        }
+
+        /**
+         * Toggle the hidden flag of the current slide
+         */
+        protected void toggle_hidden() {
+            bool hidden = this.metadata.get_slide_hidden(current_slide_number);
+            int offset = this.metadata.set_slide_hidden(current_slide_number,
+                !hidden);
+            if (offset != 0) {
+                this.switch_to_slide_number(current_slide_number + offset);
                 this.controllables_update();
             }
         }

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1183,6 +1183,10 @@ namespace pdfpc {
                 "Jump to the first overlay of the current slide");
             add_action("prevOverlay", this.previous_user_page,
                 "Jump back outside of the current overlay");
+            add_action("nextForced", this.next_page_forced,
+                "Go to the next slide, even if it is hidden");
+            add_action("prevForced", this.previous_page_forced,
+                "Go to the previous slide, even if it is hidden");
 
             add_action("goto", this.controllables_ask_goto_page,
                 "Ask for a page to jump to");
@@ -1655,6 +1659,15 @@ namespace pdfpc {
         }
 
         /**
+         * Go to the next slide, ignoring the "hidden" attribute
+         */
+        public void next_page_forced() {
+            var new_slide_number = this.current_slide_number + 1;
+
+            this.switch_to_slide_number(new_slide_number);
+        }
+
+        /**
          * Go to the next user slide
          */
         public void next_user_page() {
@@ -1702,6 +1715,15 @@ namespace pdfpc {
             var new_slide_number = this.current_slide_number - 1;
 
             new_slide_number = metadata.nearest_nonhidden(new_slide_number, true);
+            this.switch_to_slide_number(new_slide_number);
+        }
+
+        /**
+         * Go to the previous slide, ignoring the "hidden" attribute
+         */
+        public void previous_page_forced() {
+            var new_slide_number = this.current_slide_number - 1;
+
             this.switch_to_slide_number(new_slide_number);
         }
 

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -149,13 +149,14 @@ namespace pdfpc {
             // the pre-render loop
             int* p_slide = null;
 
+            var metadata = this.get_metadata();
+
             int first_page = this.current_slide_number + 1;
+            first_page = metadata.nearest_nonhidden(first_page);
             if (first_page >= this.n_slides) {
                 // nothing to pre-render
                 return GLib.Source.REMOVE;
             }
-
-            var metadata = this.get_metadata();
 
             int last_slide;
             if (this.user_slides) {
@@ -195,6 +196,7 @@ namespace pdfpc {
                 // Increment one slide for each call and stop the loop if we
                 // have reached the last slide
                 *p_slide = *p_slide + 1;
+                *p_slide = metadata.nearest_nonhidden(*p_slide);
                 if (*p_slide > last_slide) {
                     free(p_slide);
                     return GLib.Source.REMOVE;

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -311,11 +311,15 @@ namespace pdfpc {
                     return;
                 }
 
+                var metadata = this.get_metadata();
                 bool trans_inverse = false;
                 bool sequential_move = false;
-                if (slide_number == this.current_slide_number + 1) {
+                if (slide_number ==
+                    metadata.nearest_nonhidden(this.current_slide_number + 1)) {
                     sequential_move = true;
-                } else if (slide_number + 1 == this.current_slide_number) {
+                } else if (slide_number ==
+                    metadata.nearest_nonhidden(this.current_slide_number - 1,
+                        true)) {
                     sequential_move = true;
                     trans_inverse = true;
                 }
@@ -376,7 +380,6 @@ namespace pdfpc {
 
                 if (!this.disabled && this.transitions_enabled &&
                     sequential_move && previous_slide != null) {
-                    var metadata = this.get_metadata();
                     transman = new View.TransitionManager(metadata,
                         trans_slide_number, previous_slide, this.current_slide,
                         trans_inverse);

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -381,16 +381,24 @@ namespace pdfpc.Window {
                 cr.scale(1.0/scale_factor, 1.0/scale_factor);
             }
 
+            bool hidden = this.metadata.get_user_slide_hidden(slide_id);
+
             if ((flags & Gtk.CellRendererState.SELECTED) == 0) {
                 cr.rectangle(cell_area.x, cell_area.y, cell_area.width, cell_area.height);
-                cr.set_source_rgba(0, 0, 0, 0.4);
+                double alpha;
+                if (hidden) {
+                    alpha = 0.7;
+                } else {
+                    alpha = 0.4;
+                }
+                cr.set_source_rgba(0, 0, 0, alpha);
                 cr.fill();
             }
 
             // draw slide number
             var layout = Pango.cairo_create_layout(cr);
             layout.set_font_description(this.font_description);
-            if (this.metadata.get_user_slide_hidden(slide_id)) {
+            if (hidden) {
                 layout.set_markup(@"<s>$(slide_id + 1)</s>", -1);
             } else {
                 layout.set_text(@"$(slide_id + 1)", -1);
@@ -402,11 +410,7 @@ namespace pdfpc.Window {
             layout.get_pixel_extents(null, out logical_extent);
             cr.move_to(cell_area.x + (cell_area.width / 2), cell_area.y + (cell_area.height / 2) - (logical_extent.height / 2));
 
-            if ((flags & Gtk.CellRendererState.SELECTED) == 0) {
-                cr.set_source_rgba(0.7, 0.7, 0.7, 0.7);
-            } else {
-                cr.set_source_rgba(0.7, 0.7, 0.7, 0.2);
-            }
+            cr.set_source_rgba(0.7, 0.7, 0.7, 0.7);
 
             Pango.cairo_show_layout(cr, layout);
         }

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -390,7 +390,11 @@ namespace pdfpc.Window {
             // draw slide number
             var layout = Pango.cairo_create_layout(cr);
             layout.set_font_description(this.font_description);
-            layout.set_text(@"$(slide_id + 1)", -1);
+            if (this.metadata.get_user_slide_hidden(slide_id)) {
+                layout.set_markup(@"<s>$(slide_id + 1)</s>", -1);
+            } else {
+                layout.set_text(@"$(slide_id + 1)", -1);
+            }
             layout.set_width(cell_area.width);
             layout.set_alignment(Pango.Alignment.CENTER);
 

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -1016,20 +1016,24 @@ namespace pdfpc.Window {
                 next_view_user_slide++;
             }
 
-            var next_slide_number =
+            var view_slide_number =
                 this.metadata.user_slide_to_real_slide(next_view_user_slide);
-            this.next_view.disabled = (next_slide_number < 0);
-            this.next_view.display(next_slide_number);
+            view_slide_number = metadata.nearest_nonhidden(view_slide_number);
+            this.next_view.disabled = (view_slide_number < 0);
+            this.next_view.display(view_slide_number);
 
-            next_slide_number =
+            view_slide_number =
                 this.metadata.next_in_overlay(current_slide_number);
-            this.strict_next_view.disabled = (next_slide_number < 0);
-            this.strict_next_view.display(next_slide_number);
+            view_slide_number = metadata.nearest_nonhidden(view_slide_number);
+            this.strict_next_view.disabled = (view_slide_number < 0);
+            this.strict_next_view.display(view_slide_number);
 
-            var prev_slide_number =
+            view_slide_number =
                 this.metadata.prev_in_overlay(current_slide_number);
-            this.strict_prev_view.disabled = (prev_slide_number < 0);
-            this.strict_prev_view.display(prev_slide_number);
+            view_slide_number = metadata.nearest_nonhidden(view_slide_number,
+                true);
+            this.strict_prev_view.disabled = (view_slide_number < 0);
+            this.strict_prev_view.display(view_slide_number);
 
             if (this.metadata.has_beamer_notes) {
                 this.notes_stack.set_visible_child_name("view");


### PR DESCRIPTION
This implements #157.
* `Ctrl+h` to toggle the "hidden" flag
* Hidden slides are still seen in the overview mode (with the slide number strickenthrough)
* Added `nextForced`/`prevForced` actions (`Shift+n` and `Shift+p`) to change slides irrespective of the "hidden" status
