### PR TITLE
Make command line presenter and presentation screen take precedence

### DIFF
--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -291,10 +291,16 @@ namespace pdfpc {
                     Options.prerender_slides = int.parse(fields[2]);
                     break;
                 case "presentation-screen":
-                    Options.presentation_screen = fields[2];
+                    // Don't override command-line setting
+                    if (Options.presentation_screen == null) {
+                        Options.presentation_screen = fields[2];
+                    }
                     break;
                 case "presenter-screen":
-                    Options.presenter_screen = fields[2];
+                    // Don't override command-line setting
+                    if (Options.presenter_screen == null) {
+                        Options.presenter_screen = fields[2];
+                    }
                     break;
 #if REST
                 case "rest-https":


### PR DESCRIPTION
It would seem natural that the presenter screen and presentation screen set in the configuration file can be overridden by command line options.  This is currently not the case.