### PR TITLE
Support beamer "next" note placement

### DIFF
--- a/src/classes/renderer/pdf.vala
+++ b/src/classes/renderer/pdf.vala
@@ -91,7 +91,7 @@ namespace pdfpc {
             Timer timer = new Timer();
 
             // Retrieve the Poppler.Page for the page to render
-            var page = metadata.document.get_page(slide_number);
+            var page = metadata.get_slide_page(slide_number, notes_area);
 
             // A lot of Pdfs have transparent backgrounds defined. We render
             // every page before a white background because of this.

--- a/src/classes/view/transition_manager.vala
+++ b/src/classes/view/transition_manager.vala
@@ -69,7 +69,7 @@ namespace pdfpc {
             if (this.fps > 0 &&
                 slide_number >= 0 &&
                 slide_number < metadata.get_slide_count()) {
-                var page = metadata.document.get_page(slide_number);
+                var page = metadata.get_slide_page(slide_number);
 
                 var trans = page.get_transition();
                 // If undefined or is the simple replace transition, assume the


### PR DESCRIPTION
Well, I'm fed up with the troubles and ugliness that `show notes on second screen=*` causes.

The bug (not going to blame specifically `beamer`, `pgfpages`, `hyperref`, or some combination thereof; but for brevity, will call it a beamer bug) is obviously a long-standing one and nobody of the maintainers of those packages is willing to find a proper fix.

To clarify, the issue is the `PageLabels` entry; it is a "number tree" object in the PDF parlance, but for the purpose of this discussion (and the way `beamer` uses it) it's essentially an array of strings -- each page index is associated with a label. When  a variant of the `show notes *` option is set, `beamer` does the following: all real slides are labeled correctly taking into account the "overlayness", but the "notes" slides are assigned sequential numbers starting from 1, and these labels are *interleaving*. That is, if the real slides are `A`, `B`, `C`, `D`,..., `PageLabels` will contain  `A`, `1`, `B`, `2`, `C`, `3`, `D`, `4`,....
Now, with each notes slide shoved in the same page as the slide proper, the actual number of the pages halves, so the second half of the `PageLabels` array points to nowhere, while the first one (`A`, `1`, `B`, `2`) is obviously different from the intended `A`, `B`, `C`, `D`. That's the root of the problem. BTW, I'm surprised that such a non-kosher PDF doesn't make any PDF reader issue a warning...

Anyway, it's the end of the preamble.

Now the idea. Why do we need this hack (`show notes on second screen=*`) at all?! Let beamer notes fans use the "bare" `show notes`, where the slides and notes do interleave, so the labels in `PageLabels` are correct. We just need to deal with even pages as real slides and odd ones as notes. The whole logic is fit into a few trivial lines of `get_slide_page()`. And autogrouping works.

Comments?