### PR TITLE
Prefer prebuilt binary packages for FreeBSD example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,8 @@ Installation
 
 - On FreeBSD::
 
-    It is available under graphics/pdfpc. A pre-built binary is also available.
+    sudo pkg install pdfpc
+    # It is also available under graphics/pdfpc in the ports tree.
 
 - On macOS with Homebrew::
 


### PR DESCRIPTION
The standard way to install on FreeBSD is just `pkg install pdfpc`,
so present that as the normal case (but also mention where in the
ports tree it can be found).