### PR TITLE
Next slide view: Show first (instead of last) from overlay group

### DIFF
--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -123,6 +123,11 @@ shown. This option enables a workaround (bool, Default is false).
 .B next-height
 Percentage of the height of the presenter screen to be used for the next slide (int, Default is 70).
 .TP
+.B next-slide-first-overlay
+If the next slide is an overlay group, show the first slide of that group in the
+next slide view instead of the last slide of that group (bool, Default is false).
+This option is ignored if "final-slide" is enabled.
+.TP
 .B overview-min-size
 Minimum width for the overview miniatures, in pixels (int, Default is 150).
 .TP

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -126,7 +126,6 @@ Percentage of the height of the presenter screen to be used for the next slide (
 .B next-slide-first-overlay
 If the next slide is an overlay group, show the first slide of that group in the
 next slide view instead of the last slide of that group (bool, Default is false).
-This option is ignored if "final-slide" is enabled.
 .TP
 .B overview-min-size
 Minimum width for the overview miniatures, in pixels (int, Default is 150).

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -272,6 +272,9 @@ namespace pdfpc {
                 case "next-height":
                     Options.next_height = int.parse(fields[2]);
                     break;
+                case "next-slide-first-overlay":
+                    Options.next_slide_first_overlay = bool.parse(fields[2]);
+                    break;
                 case "overview-min-size":
                     Options.min_overview_width = int.parse(fields[2]);
                     break;

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -311,6 +311,12 @@ namespace pdfpc {
          * instead of the next slide.
          */
         public static bool final_slide_overlay = false;
+
+        /**
+         * If the next slide is an overlay group, show the first slide of
+         * that group in "next slide" view instead of the last slide.
+         */
+        public static bool next_slide_first_overlay = false;
 #if REST
         /**
          * Run REST server

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -1011,13 +1011,13 @@ namespace pdfpc.Window {
             this.current_view.display(current_slide_number);
 
             var next_view_user_slide = current_user_slide_number;
-            if (!Options.final_slide_overlay ||
-                this.metadata.is_user_slide(current_slide_number)) {
+            bool show_final_slide_of_current_overlay = Options.final_slide_overlay && !this.metadata.is_user_slide(current_slide_number);
+            if (!show_final_slide_of_current_overlay) {
                 next_view_user_slide++;
             }
 
             var view_slide_number =
-                this.metadata.user_slide_to_real_slide(next_view_user_slide, Options.final_slide_overlay || !Options.next_slide_first_overlay);
+                this.metadata.user_slide_to_real_slide(next_view_user_slide, show_final_slide_of_current_overlay || !Options.next_slide_first_overlay);
             view_slide_number = metadata.nearest_nonhidden(view_slide_number);
             this.next_view.disabled = (view_slide_number < 0);
             this.next_view.display(view_slide_number);

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -1011,13 +1011,17 @@ namespace pdfpc.Window {
             this.current_view.display(current_slide_number);
 
             var next_view_user_slide = current_user_slide_number;
-            bool show_final_slide_of_current_overlay = Options.final_slide_overlay && !this.metadata.is_user_slide(current_slide_number);
+            bool show_final_slide_of_current_overlay =
+                Options.final_slide_overlay &&
+                !this.metadata.is_user_slide(current_slide_number);
             if (!show_final_slide_of_current_overlay) {
                 next_view_user_slide++;
             }
 
             var view_slide_number =
-                this.metadata.user_slide_to_real_slide(next_view_user_slide, show_final_slide_of_current_overlay || !Options.next_slide_first_overlay);
+                this.metadata.user_slide_to_real_slide(next_view_user_slide,
+                show_final_slide_of_current_overlay ||
+                !Options.next_slide_first_overlay);
             view_slide_number = metadata.nearest_nonhidden(view_slide_number);
             this.next_view.disabled = (view_slide_number < 0);
             this.next_view.display(view_slide_number);

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -1017,7 +1017,7 @@ namespace pdfpc.Window {
             }
 
             var view_slide_number =
-                this.metadata.user_slide_to_real_slide(next_view_user_slide);
+                this.metadata.user_slide_to_real_slide(next_view_user_slide, Options.final_slide_overlay || !Options.next_slide_first_overlay);
             view_slide_number = metadata.nearest_nonhidden(view_slide_number);
             this.next_view.disabled = (view_slide_number < 0);
             this.next_view.display(view_slide_number);


### PR DESCRIPTION
When presenting a LaTeX Beamer presentation, I find it confusing that the "next slide" preview for the presenter shows the last slide of the following overlay group instead of what the audience will see next (the first slide from the following overlay group).
This is especially annoying when using the Metropolis theme, because it generates section pages (plain slide with just the title of the section) that have no page number and thus belong to the overlay group of the previous slide. So if you have slide 1, slide 2, section page, slide 3, then the when being on slide 1 the next slide preview shows the section page instead of slide 2 because it has the same page number as slide 2. This might have been the confusion in #620.

I have added an option to switch the behaviour of the "next slide" preview window to show the *first slide* of the following group. Unfortunately, I didn't find a better name for that option, maybe you can suggest something else.

If anything is missing to get this merges please let me know. Thanks for your great work!