### PR TITLE
Make support for viewing MD notes optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ include(GNUInstallDirs)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 option(MOVIES "Compile support for movie playback (requires gstreamer)" ON)
+option(MDVIEW "Enable viewing Markdown notes (requires webkit2gtk)" ON)
 option(REST "Compile support for REST server (requires libsoup and libqrencode)" ON)
 
 add_subdirectory(src)

--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,9 @@ can be removed by compiling without support for movie playback by passing
 To disable support for the built-in REST Web server, pass *-DREST=OFF* to cmake.
 In this case, libsoup and libqrencode are not needed.
 
+To disable support for viewing notes in the Markdown format, pass *-DMDVIEW=OFF*
+to cmake. In this case, webkit2gtk is not needed.
+
 Compilation troubleshooting
 ---------------------------
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,6 @@ pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(GEE REQUIRED gee-0.8)
 pkg_check_modules(POPPLER REQUIRED poppler-glib>=0.22)
 pkg_check_modules(GTK REQUIRED gtk+-3.0>=3.22)
-pkg_check_modules(WEBKIT REQUIRED webkit2gtk-4.0)
 pkg_check_modules(MARKDOWN REQUIRED libmarkdown)
 pkg_check_modules(JSON REQUIRED json-glib-1.0)
 list (FIND GTK_STATIC_LIBRARIES "X11" _index)
@@ -28,6 +27,11 @@ if (MOVIES)
         gstreamer-audio-1.0
         gstreamer-video-1.0
     )
+endif ()
+
+if (MDVIEW)
+    pkg_check_modules(WEBKIT REQUIRED webkit2gtk-4.0)
+    set(MDVIEW_PACKAGES webkit2gtk-4.0)
 endif ()
 
 if (REST)
@@ -141,6 +145,7 @@ PACKAGES
     pangocairo
     posix
     ${MOVIE_PACKAGES}
+    ${MDVIEW_PACKAGES}
     ${REST_PACKAGES}
 OPTIONS
     --enable-experimental

--- a/src/classes/view/markdown.vala
+++ b/src/classes/view/markdown.vala
@@ -21,6 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#if MDVIEW
 namespace pdfpc.View {
     public class MarkdownView : WebKit.WebView {
         WebKit.UserContentManager ucm;
@@ -75,3 +76,4 @@ namespace pdfpc.View {
         }
     }
 }
+#endif

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -68,8 +68,9 @@ namespace pdfpc.Window {
         protected Gtk.Stack notes_stack;
         protected Gtk.TextView notes_editor;
         protected View.Pdf notes_view;
+#if MDVIEW
         protected View.MarkdownView mdview;
-
+#endif
         protected Gtk.Paned slide_views;
         protected Gtk.Paned current_view_and_stricts;
         protected Gtk.Paned next_view_and_notes;
@@ -611,14 +612,15 @@ namespace pdfpc.Window {
             frame = new Gtk.AspectFrame(null, 0.5f, 0.0f, page_ratio, false);
             frame.add(this.notes_view);
 
-            // The Markdown rendering widget
-            this.mdview = new View.MarkdownView();
-
             // The full notes stack
             this.notes_stack = new Gtk.Stack();
             this.notes_stack.add_named(notes_sw, "editor");
             this.notes_stack.add_named(frame, "view");
+#if MDVIEW
+            // The Markdown rendering widget
+            this.mdview = new View.MarkdownView();
             this.notes_stack.add_named(this.mdview, "mdview");
+#endif
             this.notes_stack.homogeneous = true;
 
             var meta_font_size = this.metadata.get_font_size();
@@ -1043,7 +1045,9 @@ namespace pdfpc.Window {
                 this.notes_stack.set_visible_child_name("view");
                 this.notes_view.display(current_slide_number);
             } else {
+#if MDVIEW
                 this.notes_stack.set_visible_child_name("mdview");
+#endif
                 this.update_note();
             }
 
@@ -1147,9 +1151,11 @@ namespace pdfpc.Window {
                 this.metadata.set_note(this_note,
                     this.controller.current_slide_number);
                 this.controller.set_ignore_input_events(false);
+#if MDVIEW
                 this.mdview.render(this_note,
                     this.metadata.get_disable_markdown());
                 this.notes_stack.set_visible_child_name("mdview");
+#endif
                 return true;
             } else {
                 return false;
@@ -1163,9 +1169,10 @@ namespace pdfpc.Window {
             string this_note = this.metadata.get_note(
                 this.controller.current_slide_number);
             this.notes_editor.buffer.text = this_note;
-
+#if MDVIEW
             // render the note
             this.mdview.render(this_note, this.metadata.get_disable_markdown());
+#endif
         }
 
         public void show_overview() {
@@ -1219,10 +1226,11 @@ namespace pdfpc.Window {
             } catch (Error e) {
                 GLib.printerr("Warning: failed to set CSS for notes.\n");
             }
-
+#if MDVIEW
             // 20pt is set in notes.css
             var mdview_zoom = size/20.0;
             this.mdview.apply_zoom(mdview_zoom);
+#endif
         }
 
         private void on_zoom(PresentationController.ScaledRectangle? rect) {


### PR DESCRIPTION
Hence, webkit2gtk becomes optional as well, closing #622.