### PR TITLE
Make sure to activate markdown support when MDVIEW is enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ endif ()
 if (MDVIEW)
     pkg_check_modules(WEBKIT REQUIRED webkit2gtk-4.0)
     set(MDVIEW_PACKAGES webkit2gtk-4.0)
+    set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D MDVIEW)
 endif ()
 
 if (REST)


### PR DESCRIPTION
When activating markdown support with MDVIEW=ON in CMake, MDVIEW must be
defined to activate the appropriate code sections.