### PR TITLE
Recording of drawing commands for undo/redo

### DIFF
--- a/demo/pdfpc-demo.tex
+++ b/demo/pdfpc-demo.tex
@@ -245,6 +245,7 @@
     \item Press \keys{4} to use the eraser tool, if needed
       \singleitem{Or you can clear the entire current-page drawing with
         \keys{C}}
+    \item In drawing and eraser mode you can use \keys{\ctrl-Z} to undo and \keys{\ctrl-Y} to redo the drawings.
     \item Press \keys{1} to return to the normal presentation mode
     \item The drawings will stay on the slides you made them
       \singleitem{Press \keys{D} to toggle them on/off globally}

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -245,6 +245,12 @@ Exit any "special" state (pause, freeze, blank)
 .B Ctrl + n
 Edit notes for the current slide (press Escape to exit this mode)
 .TP
+.B Ctrl + z
+In drawing and eraser mode, undo the last added stroke or erase curve.
+.TP
+.B Ctrl + y
+In drawing and eraser mode, redo the last undone stroke or erase curve.
+.TP
 .B s
 Start timer
 .TP

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -44,6 +44,10 @@ bind S+space            histFwd
 bind S+End              nextUnseen
 bind S+Home             prevSeen
 
+# Undo and redo
+bind C+z                undo
+bind C+y                redo
+
 # The overview mode
 bind Tab                overview
 

--- a/src/classes/drawings/drawing_commands.vala
+++ b/src/classes/drawings/drawing_commands.vala
@@ -1,0 +1,174 @@
+/**
+ * Classes to handle drawings over slides.
+ *
+ * This file is part of pdfpc.
+ *
+ * Copyright 2017 Charles Reiss
+ * Copyright 2022 Dov Grobgeld <dov.grobgeld@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc {
+
+    // A drawing command is a cashed stroke with either a pen or
+    // the eraser.
+    public struct DrawingCommand {
+        bool new_path;
+        bool is_eraser;
+        double x1;
+        double y1;
+        double x2;
+        double y2;
+        double lwidth;
+        double red;
+        double green;
+        double blue;
+        double alpha;
+    }
+
+    // A class for caching and replaying drawingcommands
+    public class DrawingCommandList {
+        public List<DrawingCommand?> drawing_commands;
+
+        // The redo command list is manipulated by the undo and the
+        // redo commands. Whenever a new DrawingCommand is added, the
+        // redo is cleared (i.e. You can't redo if you've painted something
+        // else. The list is stored in reverse order
+        public List<DrawingCommand?> redo_commands;
+
+        public DrawingCommandList() {
+            clear();
+        }
+
+        public void clear() {
+            this.drawing_commands = new List<DrawingCommand>();
+            this.redo_commands = new List<DrawingCommand>();
+        }
+
+        public void add_line(bool is_eraser,
+                             double x1, double y1, double x2, double y2,
+                             double lwidth,
+                             double red, double green, double blue,
+                             double alpha) {
+            // The new_path which is used for undo and redo is currently
+            // done heuristically by checking if the previous command
+            // is not of the same eraser type or the previous (x2,y2)
+            // is different from the current (x1,y1)
+
+            // After adding a new line you can no longer redo the old
+            // path.
+            this.redo_commands = new List<DrawingCommand>(); // clear
+
+            bool new_path = true;
+            double epsilon = 1e-4; // Less than 0.1 pixel for a 1000x1000 img
+            if (drawing_commands != null) {
+                var last = this.drawing_commands.last().data;
+                if (is_eraser == last.is_eraser
+                    && Math.fabs(last.x2-x1)<epsilon
+                    && Math.fabs(last.y2-y1)<epsilon) {
+                    new_path = false;
+                }
+            }
+
+            var dc = DrawingCommand();
+            dc.new_path = new_path;
+            dc.is_eraser = is_eraser;
+            dc.x1 = x1;
+            dc.y1 = y1;
+            dc.x2 = x2;
+            dc.y2 = y2;
+            dc.lwidth = lwidth;
+            dc.red = red;
+            dc.green = green;
+            dc.blue = blue;
+            dc.alpha = alpha;
+            this.drawing_commands.append(dc);
+        }
+
+        // Paint the drawing commands in the surface
+        public void paint_in_surface(Cairo.ImageSurface surface) {
+            Cairo.Context cr = new Cairo.Context(surface);
+
+            // Clear the surface
+            cr.set_operator(Cairo.Operator.CLEAR);
+            cr.paint();
+
+            // Default settings
+            cr.set_operator(Cairo.Operator.OVER);
+            cr.set_source_rgba(1, 0, 0, 1);
+            cr.set_line_width(5);
+            cr.set_line_cap(Cairo.LineCap.ROUND);
+            cr.set_line_join(Cairo.LineJoin.ROUND);
+
+            // Loop over commands and carry them out
+            int width = surface.get_width();
+            int height = surface.get_height();
+            drawing_commands.foreach((dc) => {
+                if (dc.is_eraser) {
+                    cr.set_operator(Cairo.Operator.CLEAR);
+                } else {
+                    cr.set_operator(Cairo.Operator.OVER);
+                }
+
+                cr.set_line_width(dc.lwidth * width);
+                cr.set_source_rgba(dc.red,
+                                   dc.green,
+                                   dc.blue,
+                                   dc.alpha);
+
+                cr.move_to(dc.x1*width, dc.y1*height);
+                cr.line_to(dc.x2*width, dc.y2*height);
+
+                cr.stroke();
+            });
+        }
+
+        public void undo() {
+            // pop commands from the end of the drawing_command list
+            // and put them on the redo list until a new_path is found.
+
+            while (this.drawing_commands != null) {
+                unowned var el = this.drawing_commands.last();
+                DrawingCommand dc = el.data;
+                this.drawing_commands.remove_link(el);
+                this.redo_commands.append(dc);
+                if (dc.new_path) {
+                    break;
+                }
+            }
+        }
+
+        public void redo() {
+            // pop commands from the end of the redo_command list
+            // and put them on the drawing_command_list until a
+            // new_path is found.
+
+            bool first = true; // Allow the first command to be newpath
+            while (this.redo_commands != null) {
+                unowned var el = this.redo_commands.last();
+                DrawingCommand dc = el.data;
+
+                if (!first && dc.new_path) {
+                    break;
+                }
+                first = false;
+                this.redo_commands.remove_link(el);
+                this.drawing_commands.append(dc);
+            }
+        }
+    }
+}
+

--- a/src/classes/drawings/storage.vala
+++ b/src/classes/drawings/storage.vala
@@ -42,14 +42,14 @@ namespace pdfpc.Drawings.Storage {
         /**
          * Store an overlay drawing with the given index as an identifier.
          */
-        public abstract void store(uint index, Cairo.ImageSurface surface);
-
+        public abstract void store(uint index,
+                                   DrawingCommandList drawing_commands);
         /**
          * Retrieve an overlay drawing from storage, or null if none was made.
          *
          * The returned reference can be modified without modifying the storage.
          */
-        public abstract Cairo.ImageSurface? retrieve(uint index);
+        public abstract pdfpc.DrawingCommandList? retrieve(uint index);
 
         /**
          * Clear the storage
@@ -61,31 +61,32 @@ namespace pdfpc.Drawings.Storage {
         /**
          * Actual overlay images.
          */
-        protected Cairo.ImageSurface[] storage = null;
+        protected DrawingCommandList[] drawing_commands_storage = null;
 
         /**
          * Initialize the storage
          */
         public MemoryUncompressed( Metadata.Pdf metadata ) {
             base(metadata);
-            // This is more slots than we might need, but prevents us from being out
-            // of bounds if the number of user slides is changed due to overlay marking
-            // changing.
-            storage = new Cairo.ImageSurface[this.metadata.get_slide_count()];
+            clear();
         }
 
-        public override void store(uint index, Cairo.ImageSurface surface) {
-            storage[index] = surface;
+        public override void store(uint index,
+                                   DrawingCommandList drawing_commands) {
+            drawing_commands_storage[index] = drawing_commands;
         }
 
-        public override Cairo.ImageSurface? retrieve(uint index) {
-            Cairo.ImageSurface? result = storage[index];
-            storage[index] = null;
+        public override pdfpc.DrawingCommandList? retrieve(uint index) {
+            var result = drawing_commands_storage[index];
+            drawing_commands_storage[index] = null;
             return result;
         }
 
         public override void clear() {
-            storage = new Cairo.ImageSurface[this.metadata.get_slide_count()];
+            // This is more slots than we might need, but prevents us from being out
+            // of bounds if the number of user slides is changed due to overlay marking
+            // changing.
+            drawing_commands_storage = new pdfpc.DrawingCommandList[this.metadata.get_slide_count()];
         }
     }
 

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1295,6 +1295,10 @@ namespace pdfpc {
                 "Reload the presentation");
             add_action("quit", this.quit,
                 "Exit pdfpc");
+            add_action("undo", this.undo,
+                "Undo the last paint action");
+            add_action("redo", this.redo,
+                "Redo the last paint action");
         }
 
         protected void add_action(string name, callback func,
@@ -1855,6 +1859,26 @@ namespace pdfpc {
             var new_slide_number = this.history_fwd.poll_head();
             this.history_bck.offer_head(this.current_slide_number);
             this.switch_to_slide_number(new_slide_number, true);
+        }
+
+        /**
+         * Undo the drawing
+         */
+        public void undo() {
+            if (in_drawing_mode()) {
+                this.pen_drawing.undo();
+                this.queue_pen_surface_draws();
+            }
+        }
+
+        /**
+         * Undo the drawing
+         */
+        public void redo() {
+            if (in_drawing_mode()) {
+                this.pen_drawing.redo();
+                this.queue_pen_surface_draws();
+            }
         }
 
         /**


### PR DESCRIPTION
This branch adds support for undo/redo as follows:

1. Added the class `DrawingCommand` that store either a pen or a erase action with all associated parameters. The coordinates are stored in relative window size coordinates.
2. Added the class `DrawingCommandList` that stores a list of drawing commands as well as a redo buffer. The undo command pushes the drawing commands from the drawing command list to redo command list. And the redo command does vice versa. The drawing command can also paint itself in a `Cairo.Surface`.
3. Changed `Storage` so that instead of storing images it stores a `DrawingCommandList` per slice. 
4. Change `Drawing` to use the DrawingCommandList to paint itself on undo, redo, or slide change.