### PR TITLE
Require vala > 0.48 & poppler >= 0.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/vala)
 
-find_package(Vala "0.34" REQUIRED)
+find_package(Vala "0.48" REQUIRED)
 include(${VALA_USE_FILE})
 
 include(GNUInstallDirs)

--- a/README.rst
+++ b/README.rst
@@ -98,10 +98,10 @@ Requirements
 In order to compile and run pdfpc, the following requirements need to be met:
 
 - cmake >= 3.0
-- vala  >= 0.34
+- vala  >= 0.48
 - gtk+  >= 3.22
 - gee   >= 0.8
-- poppler with glib bindings
+- poppler >= 0.8 with glib bindings
 - pangocairo
 - gstreamer >= 1.0 with gst-plugins-good
 - discount (aka markdown2)
@@ -110,7 +110,7 @@ In order to compile and run pdfpc, the following requirements need to be met:
 - libsoup
 - libqrencode
 
-E.g., on Ubuntu 18.04 onward, you can install these dependencies with::
+E.g., on Ubuntu 20.04 onward, you can install these dependencies with::
 
     sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev
     libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
@@ -151,13 +151,13 @@ Downloading and compilation
 
 You can download the latest stable release of pdfpc in the release section of
 github (https://github.com/pdfpc/pdfpc/releases). Uncompress the tarball (we
-use v4.2.1 as an example here)::
+use v4.6.0 as an example here)::
 
-    tar xvf pdfpc-4.2.1.tar.gz
+    tar xvf pdfpc-4.6.0.tar.gz
 
 Change to the extracted directory::
 
-    cd pdfpc-4.2.1
+    cd pdfpc-4.6.0
 
 Compile and install::
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(PkgConfig)
 pkg_check_modules(GOBJECT REQUIRED gobject-2.0)
 pkg_check_modules(GIO REQUIRED gio-2.0)
 pkg_check_modules(GEE REQUIRED gee-0.8)
-pkg_check_modules(POPPLER REQUIRED poppler-glib>=0.22)
+pkg_check_modules(POPPLER REQUIRED poppler-glib>=0.80)
 pkg_check_modules(GTK REQUIRED gtk+-3.0>=3.22)
 pkg_check_modules(MARKDOWN REQUIRED libmarkdown)
 pkg_check_modules(JSON REQUIRED json-glib-1.0)
@@ -47,10 +47,6 @@ if (REST)
         set(WSOCK32_LIB wsock32)
     endif ()
 endif ()
-
-if ("${POPPLER_VERSION}" VERSION_GREATER_EQUAL 0.80 AND "${VALA_VERSION}" VERSION_GREATER 0.48.0)
-    set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D NEW_POPPLER)
-endif()
 
 include_directories(
     ${GOBJECT_INCLUDE_DIRS}

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -381,13 +381,11 @@ namespace pdfpc {
                 options.poster = movie.need_poster();
                 options.noprogress = !movie.show_controls();
                 options.loop = movie.get_play_mode() == Poppler.MoviePlayMode.REPEAT;
-                #if NEW_POPPLER
                 options.starttime = (int) (movie.get_start()/1000000000L);
                 int duration = (int) (movie.get_duration()/1000000000L);
                 if (duration > 0) {
                     options.stoptime = options.starttime + duration;
                 }
-                #endif
                 break;
 
             default:

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -259,12 +259,7 @@ namespace pdfpc.Window {
             this.n_slides = newn;
             Gtk.TreeIter iter;
             this.slides.get_iter_from_string(out iter, @"$(this.current_slide)");
-#if VALA_0_36
-            // Updated bindings in Vala 0.36: "iter" param of ListStore.remove() marked as ref
             this.slides.remove(ref iter);
-#else
-            this.slides.remove(iter);
-#endif
             if (this.current_slide >= this.n_slides) {
                 this.current_slide = this.n_slides - 1;
             }


### PR DESCRIPTION
I think it's time to move forward with the minimum required versions of packages. Ubuntu-18.04 is anyway reaching its EOL in two months.