### PR TITLE
Rewrite Fullscreen and PresentationController classes

### DIFF
--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -91,6 +91,10 @@ Percentage of the height of the presenter screen to be used for the current slid
 .B current-size
 Percentage of the presenter screen to be used for the current slide (int, Default is 60).
 .TP
+.B cursor-timeout
+Mouse inactivity timeout (in units of s) after which the cursor gets hidden
+(int, Default is 2).
+.TP
 .BI disable-input-autodetection
 Do not automatically detect type (pen or eraser) of tablet input devices (bool,
 Default is false).

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -153,6 +153,12 @@ Number of slides ahead of the current one to pre-render (int, default is 2). Set
 to 0 to disable the pre-rendering; set to a negative number to pre-render all at
 once.
 .TP
+.B presentation-interactive
+Let the presentation window react to user actions, similar to the presenter
+(bool, default is false). Note that if the presentation window is the only pdfpc
+GUI (i.e., if run with \fB\-sS\fR), it will be interactive irrespective of this
+flag.
+.TP
 .B presentation-screen
 Screen to be used for the presentation (output name, see e.g. "xrandr --listmonitors").
 .TP

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -766,7 +766,7 @@ namespace pdfpc {
                 Gst.Element queue = Gst.ElementFactory.make("queue", @"queue$n");
                 bin.add_many(queue, sink);
                 tee.link(queue);
-                if (conf.window.is_presenter) {
+                if (conf.window.interactive) {
                     Gst.Element ad_element = this.add_video_control(queue, bin,
                         conf.rect);
                     ad_element.link(sink);
@@ -777,7 +777,7 @@ namespace pdfpc {
 
                 // mark the video widget on the "frozen" presentation screen
                 // with a custom flag
-                if (!conf.window.is_presenter && controller.frozen) {
+                if (!conf.window.interactive && controller.frozen) {
                     video_area.set_data("pdfpc_frozen", true);
                 }
 
@@ -792,7 +792,7 @@ namespace pdfpc {
 
                         // Update the rectangle
                         conf.rect = rect;
-                        if (window.is_presenter) {
+                        if (window.interactive) {
                             this.rect = rect;
                             this.scalex = (double) this.video_w/rect.width;
                             this.scaley = (double) this.video_h/rect.height;

--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -39,7 +39,7 @@ namespace pdfpc {
     public class VideoConf : Object {
         public int display_num { get; set; }
         public Gdk.Rectangle rect { get; set; }
-        public Window.Fullscreen window { get; set; }
+        public Window.ControllableWindow window { get; set; }
     }
 
     protected struct PlaybackOptions {
@@ -735,7 +735,7 @@ namespace pdfpc {
             Gee.List<VideoConf> video_confs = new Gee.ArrayList<VideoConf>();
             while (true) {
                 Gdk.Rectangle rect;
-                Window.Fullscreen window;
+                Window.ControllableWindow window;
                 this.controller.overlay_pos(n, this.area, out rect, out window);
                 if (window == null) {
                     break;
@@ -785,7 +785,7 @@ namespace pdfpc {
                 video_surface.add_video(video_area, conf.rect);
                 video_surface.size_allocate.connect((a) => {
                         Gdk.Rectangle rect;
-                        Window.Fullscreen window;
+                        Window.ControllableWindow window;
 
                         this.controller.overlay_pos(conf.display_num,
                             this.area, out rect, out window);

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -245,6 +245,9 @@ namespace pdfpc {
                 case "current-size":
                     Options.current_size = int.parse(fields[2]);
                     break;
+                case "cursor-timeout":
+                    Options.cursor_timeout = int.parse(fields[2]);
+                    break;
                 case "disable-input-autodetection":
                     Options.disable_input_autodetection = bool.parse(fields[2]);
                     break;

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -296,6 +296,9 @@ namespace pdfpc {
                 case "prerender-slides":
                     Options.prerender_slides = int.parse(fields[2]);
                     break;
+                case "presentation-interactive":
+                    Options.presentation_interactive = bool.parse(fields[2]);
+                    break;
                 case "presentation-screen":
                     // Don't override command-line setting
                     if (Options.presentation_screen == null) {

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -236,6 +236,11 @@ namespace pdfpc {
         public static string? notes_position = null;
 
         /**
+         * Whether the presentation window is always interactive
+         */
+        public static bool presentation_interactive = false;
+
+        /**
          * Screen to be used for the presentation (output name)
          */
         public static string? presentation_screen = null;

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -108,6 +108,11 @@ namespace pdfpc {
         public static int prerender_slides = 2;
 
         /**
+         * Time to wait before hiding cursor on the main slide view [s]
+         */
+        public static int cursor_timeout = 2;
+
+        /**
          * Config option to enable a workaround for fullscreen window placement
          * (needed for some WM's, e.g., fvwm)
          */

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -264,8 +264,6 @@ namespace pdfpc {
                 _presenter = value;
                 if (value != null) {
                     this.register_controllable(value);
-
-                    this.init_pen_and_pointer();
                 }
             }
         }
@@ -614,6 +612,8 @@ namespace pdfpc {
             this.pointer   = new PointerTool(false);
             this.spotlight = new PointerTool(true);
             this.current_pointer = null;
+
+            this.init_pen_and_pointer();
 
             this.history_bck = new Gee.ArrayQueue<int>();
             this.history_fwd = new Gee.ArrayQueue<int>();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1098,7 +1098,8 @@ namespace pdfpc {
                 Source.remove(this.pointer_timeout_id);
             }
 
-            this.pointer_timeout_id = Timeout.add_seconds(2, () => {
+            this.pointer_timeout_id =
+                Timeout.add_seconds(Options.cursor_timeout, () => {
                     this.pointer_timeout_id = 0;
                     this.pointer_hidden = true;
                     this.queue_pointer_surface_draws();

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -601,17 +601,13 @@ namespace pdfpc {
 
         protected PointerTool pointer;
         protected PointerTool spotlight;
-        public PointerTool? current_pointer { get; protected set; }
+        public PointerTool current_pointer { get; protected set; }
 
         /**
          * Instantiate a new controller
          */
         public PresentationController() {
             this.controllables = new Gee.ArrayList<Controllable>();
-
-            this.pointer   = new PointerTool(false);
-            this.spotlight = new PointerTool(true);
-            this.current_pointer = null;
 
             this.init_pen_and_pointer();
 
@@ -888,6 +884,10 @@ namespace pdfpc {
         }
 
         private void init_pen_and_pointer() {
+            this.pointer   = new PointerTool(false);
+            this.spotlight = new PointerTool(true);
+            this.current_pointer = this.pointer;
+
             this.pointer.size = Options.pointer_size;
             if (this.pointer.size > 500) {
                 this.pointer.size = 500;

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -36,6 +36,27 @@ public interface ScreenSaver : Object {
 }
 
 namespace pdfpc {
+    protected class KeyDef : GLib.Object, Gee.Hashable<KeyDef> {
+        public uint keycode { get; set; }
+        public uint modMask { get; set; }
+
+        public KeyDef(uint k, uint m) {
+            this.keycode = k;
+            this.modMask = m;
+        }
+
+        public uint hash() {
+            // see gdk/gdkkeysyms.h modMask is usally in the form of
+            // 0xFF??. Keycodes are usally 0x??. We shift modMask by 8 bits
+            // to combine both codes.
+            return (this.modMask << 8) | this.keycode;
+        }
+
+        public bool equal_to(KeyDef other) {
+            return this.keycode == other.keycode && this.modMask == other.modMask;
+        }
+    }
+
     /**
      * Controller handling all the triggered events/signals
      */
@@ -245,7 +266,6 @@ namespace pdfpc {
                     this.register_controllable(value);
 
                     this.init_pen_and_pointer();
-                    this.register_mouse_handlers();
                 }
             }
         }
@@ -276,11 +296,6 @@ namespace pdfpc {
                         !this._presentation.is_monitor_connected());
             }
         }
-
-        /**
-         * Key modifiers that we support
-         */
-        public uint accepted_key_mods = Gdk.ModifierType.SHIFT_MASK | Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.META_MASK;
 
         /**
          * Ignore input events. Useful e.g. for editing notes.
@@ -443,8 +458,8 @@ namespace pdfpc {
          * The presenters overview. We need to communicate with it for toggling
          * skips
          */
-        protected Window.Overview overview;
-        protected bool overview_shown {
+        public Window.Overview overview { get; set; }
+        public bool overview_shown {
             get {
                 if (presenter == null) {
                     return false;
@@ -453,11 +468,6 @@ namespace pdfpc {
                 }
             }
         }
-
-        /**
-         * Timestamp of the last key event
-         */
-        protected uint last_key_ev_time = 0;
 
         /**
          * Store the backward/forward "history" of the slides
@@ -490,27 +500,6 @@ namespace pdfpc {
 
         protected Gee.ArrayList<ActionDescription> action_descriptions =
             new Gee.ArrayList<ActionDescription>();
-
-        protected class KeyDef : GLib.Object, Gee.Hashable<KeyDef> {
-            public uint keycode { get; set; }
-            public uint modMask { get; set; }
-
-            public KeyDef(uint k, uint m) {
-                this.keycode = k;
-                this.modMask = m;
-            }
-
-            public uint hash() {
-                // see gdk/gdkkeysyms.h modMask is usally in the form of
-                // 0xFF??. Keycodes are usally 0x??. We shift modMask by 8 bits
-                // to combine both codes.
-                return (this.modMask << 8) | this.keycode;
-            }
-
-            public bool equal_to(KeyDef other) {
-                return this.keycode == other.keycode && this.modMask == other.modMask;
-            }
-        }
 
         protected class ActionAndParameter : GLib.Object {
             public GLib.Action action { get; set; }
@@ -667,7 +656,7 @@ namespace pdfpc {
         private uint pen_step = 2;
         public double pen_last_x;
         public double pen_last_y;
-        private bool pen_is_pressed = false;
+        public bool pen_is_pressed = false;
 
         public bool is_pointer_active() {
             return this.annotation_mode == AnnotationMode.POINTER;
@@ -712,9 +701,10 @@ namespace pdfpc {
             }
         }
 
-        private void move_pen(double x, double y) {
+        public void move_pen(double x, double y) {
             if (this.pen_is_pressed) {
-                pen_drawing.add_line(this.current_pen_drawing_tool, this.pen_last_x, this.pen_last_y, x, y);
+                pen_drawing.add_line(this.current_pen_drawing_tool,
+                this.pen_last_x, this.pen_last_y, x, y);
             }
             this.pen_last_x = x;
             this.pen_last_y = y;
@@ -749,7 +739,7 @@ namespace pdfpc {
             return current_pen_drawing_tool.width;
         }
 
-        private void set_pen_pressure(double pressure) {
+        public void set_pen_pressure(double pressure) {
             current_pen_drawing_tool.pressure = pressure;
         }
 
@@ -950,21 +940,13 @@ namespace pdfpc {
 
         public double drag_x = -1;
         public double drag_y = -1;
-        public double pointer_x;
-        public double pointer_y;
 
         /**
-         * Convert device coordinates to normalized ones
+         * Coordinates of the "soft" pointer, continuously updated
+         * irrespective of the mode
          */
-        private void device_to_normalized(double dev_x, double dev_y,
-            out double x, out double y) {
-            var view = this.presenter.main_view;
-            Gtk.Allocation a;
-            view.get_allocation(out a);
-
-            x = dev_x/a.width;
-            y = dev_y/a.height;
-        }
+        public double pointer_x;
+        public double pointer_y;
 
         private void queue_pointer_surface_draws() {
             if (presenter != null) {
@@ -975,122 +957,95 @@ namespace pdfpc {
             }
         }
 
-        protected void register_mouse_handlers() {
-            var view = presenter.main_view;
-            view.set_events(
-                  Gdk.EventMask.BUTTON_PRESS_MASK
-                | Gdk.EventMask.BUTTON_RELEASE_MASK
-                | Gdk.EventMask.POINTER_MOTION_MASK
-                | Gdk.EventMask.ENTER_NOTIFY_MASK
-                | Gdk.EventMask.LEAVE_NOTIFY_MASK
-            );
-
-            view.motion_notify_event.connect(on_motion);
-            view.button_press_event.connect(on_button_press);
-            view.button_release_event.connect(on_button_release);
-            view.enter_notify_event.connect(() => {
-                    this.pointer_hidden = false;
-                    return true;
-                });
-            view.leave_notify_event.connect(() => {
-                    this.pointer_hidden = true;
-                    // make sure the pointer is cleared
-                    if (this.in_pointing_mode()) {
-                        this.queue_pointer_surface_draws();
-                    } else if (this.in_drawing_mode()) {
-                        this.queue_pen_surface_draws();
-                    }
-                    return true;
-                });
-        }
-
         /**
-         * Handle mouse events on the window and, if necessary send
-         * them to the presentation controller
+         * Handle mouse motion events from controllables' main views
          */
-        private bool on_motion(Gdk.EventMotion event) {
-            // We need to always update the pointer position, even if it is not
-            // shown. Otherwise, the pointer will appear at the old position
-            // when it is first shown and will jump around at the next mouse
-            // move.
-            this.device_to_normalized(event.x, event.y,
-                out pointer_x, out pointer_y);
-
-            if (this.in_pointing_mode()) {
-                return on_move_pointer(event);
-            } else if (this.in_drawing_mode()) {
-                return on_move_pen(event);
-            } else {
-                return false;
-            }
-        }
-
-        private bool on_button_press(Gdk.EventButton event) {
-            if (this.annotation_mode == AnnotationMode.POINTER) {
-                this.device_to_normalized(event.x, event.y,
-                    out drag_x, out drag_y);
-                this.highlight.width = 0;
-                this.highlight.height = 0;
-                return true;
-            } else if (this.in_drawing_mode()) {
-                double x, y;
-                this.device_to_normalized(event.x, event.y, out x, out y);
-                move_pen(x, y);
-                pen_is_pressed = true;
-                return true;
-            } else {
-                return false;
-            }
-        }
-
-        private bool on_button_release(Gdk.EventButton event) {
-            if (this.annotation_mode == AnnotationMode.POINTER) {
-                double x, y;
-                this.device_to_normalized(event.x, event.y, out x, out y);
-                update_highlight(x, y);
-                drag_x = -1;
-                drag_y = -1;
-                return true;
-            } else if (this.in_drawing_mode()) {
-                double x, y;
-                this.device_to_normalized(event.x, event.y, out x, out y);
-                move_pen(x, y);
-                pen_is_pressed = false;
-                return true;
-            } else {
-                return false;
-            }
-        }
-
-        private bool on_move_pen(Gdk.EventMotion event) {
-            var dev = event.get_source_device();
-            if (!Options.disable_input_autodetection) {
-                Gdk.InputSource source_type = dev.get_source();
-                if (source_type == Gdk.InputSource.ERASER) {
-                    this.set_mode(AnnotationMode.ERASER);
-                } else if (source_type == Gdk.InputSource.PEN) {
-                    this.set_mode(AnnotationMode.PEN);
-                }
-            }
-
-            if (!Options.disable_input_pressure && pen_is_pressed) {
-                double pressure;
-                if (dev.get_axis(event.axes, Gdk.AxisUse.PRESSURE,
-                    out pressure) != true) {
-                    pressure = -1.0;
-                }
-                set_pen_pressure(pressure);
-            }
-
+        public bool on_move_pen() {
             // restart the pointer timeout timer
             this.restart_pointer_timer();
             this.pointer_hidden = false;
 
-            double x, y;
-            this.device_to_normalized(event.x, event.y, out x, out y);
-            move_pen(x, y);
+            move_pen(pointer_x, pointer_y);
 
             return true;
+        }
+
+        public bool on_enter_notify() {
+            this.pointer_hidden = false;
+            return true;
+        }
+
+        public bool on_leave_notify() {
+            this.pointer_hidden = true;
+            // make sure the pointer is cleared
+            if (this.in_pointing_mode()) {
+                this.queue_pointer_surface_draws();
+            } else if (this.in_drawing_mode()) {
+                this.queue_pen_surface_draws();
+            }
+            return true;
+        }
+
+        /**
+         * Handle key presses from controllables
+         */
+        public bool on_key_press(KeyDef keydef) {
+            if (!ignore_keyboard_events) {
+                var action_with_parameter = this.keyBindings.get(keydef);
+
+                if (action_with_parameter != null) {
+                    var param = action_with_parameter.parameter;
+                    action_with_parameter.action.activate(param);
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Handle mouse clicks from controllables
+         */
+        public bool on_button_press(KeyDef keydef) {
+            if (!ignore_mouse_events) {
+                var action_with_parameter = this.mouseBindings.get(keydef);
+                if (action_with_parameter != null) {
+                    var param = action_with_parameter.parameter;
+                    action_with_parameter.action.activate(param);
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Handle mouse scrolls from controllables
+         */
+        public bool on_scroll(bool up, uint state) {
+            if (!this.ignore_mouse_events && !Options.disable_scrolling) {
+                if (up) {
+                    if ((state & Gdk.ModifierType.SHIFT_MASK) != 0) {
+                        this.back10();
+                    } else {
+                        this.previous_page();
+                    }
+                } else {
+                    if ((state & Gdk.ModifierType.SHIFT_MASK) != 0) {
+                        this.jump10();
+                    } else {
+                        this.next_page();
+                    }
+                }
+
+                return true;
+            } else {
+                return false;
+            }
         }
 
         protected void restart_pointer_timer() {
@@ -1144,7 +1099,7 @@ namespace pdfpc {
             this.update_highlight(pointer_x, pointer_y);
         }
 
-        private bool on_move_pointer(Gdk.EventMotion event) {
+        public bool on_move_pointer() {
             // restart the pointer timeout timer
             this.restart_pointer_timer();
             this.pointer_hidden = false;
@@ -1155,7 +1110,7 @@ namespace pdfpc {
             return true;
         }
 
-        private void update_highlight(double x, double y) {
+        public void update_highlight(double x, double y) {
             if (drag_x!=-1) {
                 this.highlight.width=Math.fabs(drag_x-x);
                 this.highlight.height=Math.fabs(drag_y-y);
@@ -1164,7 +1119,6 @@ namespace pdfpc {
                 queue_pointer_surface_draws();
             }
         }
-
 
         public void increase_pointer_size() {
             if (this.current_pointer.size < 500) {
@@ -1229,10 +1183,6 @@ namespace pdfpc {
                 }
             }
             Gtk.main_quit();
-        }
-
-        public void set_overview(Window.Overview o) {
-            this.overview = o;
         }
 
         public void set_pen_color_to_string(Variant? color_variant) {
@@ -1573,83 +1523,6 @@ namespace pdfpc {
          */
         public void unbindAllMouse() {
             this.mouseBindings.clear();
-        }
-
-        /**
-         * Handle keypresses to each of the controllables
-         *
-         * This separate handling is needed because keypresses from any of the
-         * window have implications on the behaviour of both of them. Therefore
-         * this controller is needed to take care of the needed actions.
-         */
-        public bool key_press(Gdk.EventKey key) {
-            if (key.time != last_key_ev_time && !ignore_keyboard_events ) {
-                last_key_ev_time = key.time;
-                if (this.overview_shown) {
-                    this.overview.key_press_event(key);
-                    return true;
-                }
-
-                // Punctuation characters are usually generated by keyboards
-                // with the Shift mod pressed; we ignore it in this case.
-                if (((char) key.keyval).ispunct()) {
-                    key.state &= ~Gdk.ModifierType.SHIFT_MASK;
-                }
-                var action_with_parameter = this.keyBindings.get(new KeyDef(key.keyval,
-                    key.state & this.accepted_key_mods));
-
-                if (action_with_parameter != null)
-                    action_with_parameter.action.activate(action_with_parameter.parameter);
-                return true;
-            } else {
-                return false;
-            }
-        }
-
-        /**
-         * Handle mouse clicks to each of the controllables
-         */
-        public bool button_press(Gdk.EventButton button) {
-            if (!ignore_mouse_events && button.type == Gdk.EventType.BUTTON_PRESS ) {
-                var action_with_parameter = this.mouseBindings.get(new KeyDef(button.button,
-                    button.state & this.accepted_key_mods));
-                if (action_with_parameter != null)
-                    action_with_parameter.action.activate(action_with_parameter.parameter);
-                return true;
-            } else {
-                return false;
-            }
-        }
-
-        /**
-         * Notify each of the controllables of mouse scrolling
-         */
-        public bool scroll(Gdk.EventScroll scroll) {
-            if (!this.ignore_mouse_events && !Options.disable_scrolling) {
-                switch (scroll.direction) {
-                case Gdk.ScrollDirection.UP:
-                case Gdk.ScrollDirection.LEFT:
-                    if ((scroll.state & Gdk.ModifierType.SHIFT_MASK) != 0) {
-                        this.back10();
-                    } else {
-                        this.previous_page();
-                    }
-                    break;
-
-                case Gdk.ScrollDirection.DOWN:
-                case Gdk.ScrollDirection.RIGHT:
-                    if ((scroll.state & Gdk.ModifierType.SHIFT_MASK) != 0) {
-                        this.jump10();
-                    } else {
-                        this.next_page();
-                    }
-                    break;
-                default:
-                    break;
-                }
-                return true;
-            }
-            return false;
         }
 
         /**
@@ -2320,7 +2193,6 @@ namespace pdfpc {
                 this.in_customization = false;
             }
         }
-
 
 #if MOVIES
         /**

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -2326,16 +2326,18 @@ namespace pdfpc {
          * Give the Gdk.Rectangle corresponding to the Poppler.Rectangle for the nth
          * controllable's main view.
          */
-        public void overlay_pos(int n, Poppler.Rectangle area, out Gdk.Rectangle rect, out Window.Fullscreen window) {
+        public void overlay_pos(int n, Poppler.Rectangle area,
+            out Gdk.Rectangle rect, out Window.ControllableWindow window) {
             window = null;
 
-            Controllable c = (n < this.controllables.size) ? this.controllables.get(n) : null;
+            Controllable c = (n < this.controllables.size) ?
+                this.controllables.get(n) : null;
             // default scale, and make the compiler happy
             if (c == null) {
                 rect = Gdk.Rectangle();
                 return;
             }
-            window = c as Window.Fullscreen;
+            window = c as Window.ControllableWindow;
             if (c.main_view == null) {
                 rect = Gdk.Rectangle();
                 return;

--- a/src/classes/view/pdf.vala
+++ b/src/classes/view/pdf.vala
@@ -231,12 +231,12 @@ namespace pdfpc {
         }
 
         /**
-         * Create a new Pdf view from a Fullscreen window instance
+         * Create a new Pdf view from a ControllableWindow instance
          *
          * This is a convenience constructor which automatically creates a full
          * metadata and rendering chain to be used with the pdf view.
          */
-        public Pdf.from_fullscreen(Window.Fullscreen window,
+        public Pdf.from_controllable_window(Window.ControllableWindow window,
             bool notes_area, bool clickable_links, bool user_slides=false) {
             var controller = window.controller;
             var metadata = controller.metadata;

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -44,7 +44,7 @@ namespace pdfpc.Window {
             }
         }
 
-        public virtual View.Pdf main_view { get; }
+        public View.Pdf main_view { get; protected set; }
 
         /**
          * Whether the instance is presenter
@@ -75,8 +75,8 @@ namespace pdfpc.Window {
         public View.Video video_surface { get; protected set; }
 
         /**
-         * Timer id which monitors mouse motion to hide the cursor after 5
-         * seconds of inactivity
+         * Timer id monitoring mouse motion to hide the cursor on main_view
+         * after a few seconds of inactivity
          */
         protected uint hide_cursor_timeout = 0;
 
@@ -98,10 +98,14 @@ namespace pdfpc.Window {
 
             this.overlay_layout = new Gtk.Overlay();
 
+            this.main_view = new View.Pdf.from_controllable_window(this,
+                false, true);
+
             this.pointer_drawing_surface = new Gtk.DrawingArea();
             this.pen_drawing_surface = new Gtk.DrawingArea();
             this.video_surface = new View.Video();
 
+            this.overlay_layout.add(this.main_view);
             this.overlay_layout.add_overlay(this.video_surface);
             this.overlay_layout.add_overlay(this.pen_drawing_surface);
             this.overlay_layout.add_overlay(this.pointer_drawing_surface);

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -48,9 +48,9 @@ namespace pdfpc.Window {
         }
 
         /**
-         * Whether the instance is presenter
+         * Whether the user directly interacts with this window
          */
-        public bool is_presenter { get; protected set; }
+        public bool interactive { get; protected set; }
 
         /**
          * Drawing area for pointer mode
@@ -95,17 +95,13 @@ namespace pdfpc.Window {
          * Base constructor instantiating a new controllable window
          */
         public ControllableWindow(PresentationController controller,
-            bool is_presenter, int monitor_num, bool windowed,
+            bool interactive, int monitor_num, bool windowed,
             int width = -1, int height = -1) {
 
             base(monitor_num, windowed, width, height);
             this.controller = controller;
 
-            this.title = "pdfpc - %s (%s)".printf(
-                is_presenter ? "presenter" : "presentation",
-                controller.metadata.get_title());
-
-            this.is_presenter = is_presenter;
+            this.interactive = interactive;
 
             this.overlay_layout = new Gtk.Overlay();
 
@@ -138,7 +134,7 @@ namespace pdfpc.Window {
                     true);
             });
 
-            if (this.is_presenter) {
+            if (this.interactive) {
                 this.register_presenter_handlers();
             }
 
@@ -267,7 +263,7 @@ namespace pdfpc.Window {
                 context.set_source_surface(drawing_surface, 0, 0);
                 context.paint();
                 context.set_matrix(old_xform);
-                if (this.is_presenter && c.in_drawing_mode() &&
+                if (this.interactive && c.in_drawing_mode() &&
                     !c.pointer_hidden) {
                     double width_adjustment = (double) a.width / base_width;
                     context.set_operator(Cairo.Operator.OVER);

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -133,6 +133,10 @@ namespace pdfpc.Window {
             this.button_press_event.connect(this.controller.button_press);
             this.scroll_event.connect(this.controller.scroll);
 
+            this.controller.zoom_request.connect(this.on_zoom);
+
+            this.controller.reload_request.connect(this.on_reload);
+
             // Start the 5 seconds timeout after which the mouse cursor is
             // hidden
             this.restart_hide_cursor_timer();
@@ -302,6 +306,19 @@ namespace pdfpc.Window {
                 // another five seconds.
                 return true;
             }
+        }
+
+        /**
+         * Called on document reload.
+         * TODO: in principle the document geometry may change!
+         */
+        private void on_reload() {
+            this.main_view.invalidate();
+        }
+
+        private void on_zoom(PresentationController.ScaledRectangle? rect) {
+            this.main_view.display(this.controller.current_slide_number,
+                true, rect);
         }
     }
 }

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -141,8 +141,7 @@ namespace pdfpc.Window {
 
             this.controller.reload_request.connect(this.on_reload);
 
-            // Start the 5 seconds timeout after which the mouse cursor is
-            // hidden
+            // Start the timeout after which the mouse cursor gets hidden
             this.restart_hide_cursor_timer();
 
             this.destroy.connect((source) => controller.quit());
@@ -277,20 +276,21 @@ namespace pdfpc.Window {
             return false;
         }
         /**
-         * Restart the 5 seconds timeout before hiding the mouse cursor
+         * Restart the timeout before hiding the mouse cursor
          */
         protected void restart_hide_cursor_timer(){
             if (this.hide_cursor_timeout != 0) {
                 Source.remove(this.hide_cursor_timeout);
             }
 
-            this.hide_cursor_timeout = Timeout.add_seconds(5,
+            this.hide_cursor_timeout =
+                Timeout.add_seconds(Options.cursor_timeout,
                 this.on_hide_cursor_timeout);
         }
 
         /**
-         * Timeout method called if the mouse pointer has not been moved for 5
-         * seconds
+         * Timeout method called if the mouse pointer has not been moved for
+         * a while
          */
         protected bool on_hide_cursor_timeout() {
             this.hide_cursor_timeout = 0;

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -1,5 +1,5 @@
 /**
- * Fullscreen Window
+ * Controllable Fullscreen-capable Window
  *
  * This file is part of pdfpc.
  *

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -1,0 +1,307 @@
+/**
+ * Fullscreen Window
+ *
+ * This file is part of pdfpc.
+ *
+ * Copyright 2010-2011 Jakob Westhoff
+ * Copyright 2011,2012 David Vilar
+ * Copyright 2012,2015 Robert Schroll
+ * Copyright 2014,2016 Andy Barry
+ * Copyright 2015,2017 Andreas Bilke
+ * Copyright 2023 Evgeny Stambulchik
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc.Window {
+    public class ControllableWindow : Fullscreen, Controllable {
+
+        /**
+         * The registered PresentationController
+         */
+        public PresentationController controller {
+            get; protected set;
+        }
+
+        /**
+         * Metadata of the slides
+         */
+        protected Metadata.Pdf metadata {
+            get {
+                return this.controller.metadata;
+            }
+        }
+
+        public virtual View.Pdf main_view { get; }
+
+        /**
+         * Whether the instance is presenter
+         */
+        public bool is_presenter {
+            get; protected set;
+        }
+
+        /**
+         * Overlay layout. Holds all drawing layers (main_view,
+         * pointer & pen drawing areas, and the video surface)
+         */
+        protected Gtk.Overlay overlay_layout;
+
+        /**
+         * Drawing area for pointer mode
+         */
+        public Gtk.DrawingArea pointer_drawing_surface { get; protected set; }
+
+        /**
+         * Drawing area for pen mode
+         */
+        public Gtk.DrawingArea pen_drawing_surface { get; protected set; }
+
+        /**
+         * Video area for playback. All videos are added to this surface.
+         */
+        public View.Video video_surface { get; protected set; }
+
+        /**
+         * Timer id which monitors mouse motion to hide the cursor after 5
+         * seconds of inactivity
+         */
+        protected uint hide_cursor_timeout = 0;
+
+       /**
+         * Base constructor instantiating a new controllable window
+         */
+        public ControllableWindow(PresentationController controller,
+            bool is_presenter, int monitor_num, bool windowed,
+            int width = -1, int height = -1) {
+
+            base(monitor_num, windowed, width, height);
+            this.controller = controller;
+
+            this.title = "pdfpc - %s (%s)".printf(
+                is_presenter ? "presenter" : "presentation",
+                metadata.get_title());
+
+            this.is_presenter = is_presenter;
+
+            this.overlay_layout = new Gtk.Overlay();
+
+            this.pointer_drawing_surface = new Gtk.DrawingArea();
+            this.pen_drawing_surface = new Gtk.DrawingArea();
+            this.video_surface = new View.Video();
+
+            this.overlay_layout.add_overlay(this.video_surface);
+            this.overlay_layout.add_overlay(this.pen_drawing_surface);
+            this.overlay_layout.add_overlay(this.pointer_drawing_surface);
+
+            this.pointer_drawing_surface.no_show_all = true;
+            this.pen_drawing_surface.no_show_all = true;
+
+            this.video_surface.realize.connect(() => {
+                this.set_widget_event_pass_through(this.video_surface, true);
+            });
+            this.pen_drawing_surface.realize.connect(() => {
+                this.pen_drawing_surface.get_window().set_pass_through(true);
+                this.set_widget_event_pass_through(this.pen_drawing_surface,
+                    true);
+            });
+            this.pointer_drawing_surface.realize.connect(() => {
+                this.pointer_drawing_surface.get_window().set_pass_through(true);
+                this.set_widget_event_pass_through(this.pointer_drawing_surface,
+                    true);
+            });
+
+            this.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
+            this.motion_notify_event.connect(this.on_mouse_move);
+
+            this.pointer_drawing_surface.draw.connect(this.draw_pointer);
+            this.pen_drawing_surface.draw.connect(this.draw_pen);
+
+            this.key_press_event.connect(this.controller.key_press);
+            this.button_press_event.connect(this.controller.button_press);
+            this.scroll_event.connect(this.controller.scroll);
+
+            // Start the 5 seconds timeout after which the mouse cursor is
+            // hidden
+            this.restart_hide_cursor_timer();
+
+            this.destroy.connect((source) => controller.quit());
+        }
+
+        /**
+         * Set the widget passthrough.
+         *
+         * If set to true, the widget will not receive events and they will be
+         * forwarded to the underlying widgets within the Gtk.Overlay
+         */
+        protected void set_widget_event_pass_through(Gtk.Widget w,
+            bool pass_through) {
+            this.overlay_layout.set_overlay_pass_through(w, pass_through);
+        }
+
+        protected bool draw_pointer(Cairo.Context context) {
+            Gtk.Allocation a;
+            this.pointer_drawing_surface.get_allocation(out a);
+            PresentationController c = this.controller;
+
+            // Draw the highlighted area, but ignore very short drags
+            // made unintentionally by mouse clicks
+            if (!c.current_pointer.is_spotlight &&
+                c.highlight.width > 0.01 && c.highlight.height > 0.01) {
+                context.rectangle(0, 0, a.width, a.height);
+                context.new_sub_path();
+                context.rectangle((int)(c.highlight.x*a.width),
+                                  (int)(c.highlight.y*a.height),
+                                  (int)(c.highlight.width*a.width),
+                                  (int)(c.highlight.height*a.height));
+
+                context.set_fill_rule(Cairo.FillRule.EVEN_ODD);
+                context.set_source_rgba(0,0,0,0.5);
+                context.fill_preserve();
+
+                context.new_path();
+            }
+            // Draw the pointer when not dragging
+            if (c.drag_x == -1 &&
+                (!c.pointer_hidden || c.current_pointer.is_spotlight)) {
+                int x = (int)(a.width*c.pointer_x);
+                int y = (int)(a.height*c.pointer_y);
+                int r = (int)(a.height*0.001*c.current_pointer.size);
+
+                Gdk.RGBA rgba = c.current_pointer.get_rgba();
+                context.set_source_rgba(rgba.red,
+                                        rgba.green,
+                                        rgba.blue,
+                                        rgba.alpha);
+                if (c.current_pointer.is_spotlight) {
+                    context.rectangle(0, 0, a.width, a.height);
+                    context.new_sub_path();
+                    context.set_fill_rule(Cairo.FillRule.EVEN_ODD);
+                }
+                context.arc(x, y, r, 0, 2*Math.PI);
+                context.fill();
+            }
+
+            return true;
+        }
+
+        public void enable_pointer(bool onoff) {
+            if (onoff) {
+                this.pointer_drawing_surface.show();
+            } else {
+                this.pointer_drawing_surface.hide();
+            }
+        }
+
+        protected bool draw_pen(Cairo.Context context) {
+            Gtk.Allocation a;
+            this.pen_drawing_surface.get_allocation(out a);
+            PresentationController c = this.controller;
+
+            if (c.pen_drawing != null) {
+                Cairo.Surface? drawing_surface =
+                    c.pen_drawing.render_to_surface();
+                int x = (int)(a.width*c.pen_last_x);
+                int y = (int)(a.height*c.pen_last_y);
+                int base_width = c.pen_drawing.width;
+                int base_height = c.pen_drawing.height;
+                Cairo.Matrix old_xform = context.get_matrix();
+                context.scale(
+                    (double) a.width / base_width,
+                    (double) a.height / base_height
+                );
+                context.set_source_surface(drawing_surface, 0, 0);
+                context.paint();
+                context.set_matrix(old_xform);
+                if (this.is_presenter && c.in_drawing_mode() &&
+                    !c.pointer_hidden) {
+                    double width_adjustment = (double) a.width / base_width;
+                    context.set_operator(Cairo.Operator.OVER);
+                    context.set_line_width(2.0);
+                    context.set_source_rgba(
+                        c.current_pen_drawing_tool.red,
+                        c.current_pen_drawing_tool.green,
+                        c.current_pen_drawing_tool.blue,
+                        1.0
+                    );
+                    double arc_radius =
+                        c.current_pen_drawing_tool.width*width_adjustment/2.0;
+                    if (arc_radius < 1.0) {
+                        arc_radius = 1.0;
+                    }
+                    context.arc(x, y, arc_radius, 0, 2*Math.PI);
+                    context.stroke();
+                }
+            }
+
+            return true;
+        }
+
+        public void enable_pen(bool onoff) {
+            if (onoff) {
+                this.pen_drawing_surface.show();
+            } else {
+                this.pen_drawing_surface.hide();
+            }
+        }
+
+        /**
+         * Called every time the mouse cursor is moved
+         */
+        public bool on_mouse_move(Gtk.Widget source, Gdk.EventMotion event) {
+            // Restore the mouse cursor to its default value
+            this.get_window().set_cursor(null);
+
+            this.restart_hide_cursor_timer();
+
+            return false;
+        }
+        /**
+         * Restart the 5 seconds timeout before hiding the mouse cursor
+         */
+        protected void restart_hide_cursor_timer(){
+            if (this.hide_cursor_timeout != 0) {
+                Source.remove(this.hide_cursor_timeout);
+            }
+
+            this.hide_cursor_timeout = Timeout.add_seconds(5,
+                this.on_hide_cursor_timeout);
+        }
+
+        /**
+         * Timeout method called if the mouse pointer has not been moved for 5
+         * seconds
+         */
+        protected bool on_hide_cursor_timeout() {
+            this.hide_cursor_timeout = 0;
+
+            // Window might be null in case it has not been mapped
+            if (this.get_window() != null) {
+                var cursor =
+                    new Gdk.Cursor.for_display(Gdk.Display.get_default(),
+                        Gdk.CursorType.BLANK_CURSOR);
+                this.get_window().set_cursor(cursor);
+
+                // After the timeout disabled the cursor do not run it again
+                return false;
+            } else {
+                // The window was not available. Possibly it was not mapped
+                // yet. We simply try it again if the mouse isn't moved for
+                // another five seconds.
+                return true;
+            }
+        }
+    }
+}

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -128,7 +128,7 @@ namespace pdfpc.Window {
             });
 
             this.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
-            this.motion_notify_event.connect(this.on_mouse_move);
+            this.main_view.motion_notify_event.connect(this.on_mouse_move);
 
             this.pointer_drawing_surface.draw.connect(this.draw_pointer);
             this.pen_drawing_surface.draw.connect(this.draw_pen);
@@ -270,7 +270,7 @@ namespace pdfpc.Window {
          */
         public bool on_mouse_move(Gtk.Widget source, Gdk.EventMotion event) {
             // Restore the mouse cursor to its default value
-            this.get_window().set_cursor(null);
+            event.window.set_cursor(null);
 
             this.restart_hide_cursor_timer();
 
@@ -294,13 +294,14 @@ namespace pdfpc.Window {
          */
         protected bool on_hide_cursor_timeout() {
             this.hide_cursor_timeout = 0;
+            var w = this.main_view.get_window();
 
             // Window might be null in case it has not been mapped
-            if (this.get_window() != null) {
+            if (w != null) {
                 var cursor =
                     new Gdk.Cursor.for_display(Gdk.Display.get_default(),
                         Gdk.CursorType.BLANK_CURSOR);
-                this.get_window().set_cursor(cursor);
+                w.set_cursor(cursor);
 
                 // After the timeout disabled the cursor do not run it again
                 return false;

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -26,36 +26,10 @@
 
 namespace pdfpc.Window {
     /**
-     * Window extension implementing all the needed functionality, to be
-     * displayed fullscreen.
-     *
-     * Methods to specify the monitor to be displayed on in a multi-head setup
-     * are provided as well.
+     * Window extension implementing the needed functionality to be
+     * displayed/toggled fullscreen, including multi-head configurations.
      */
     public class Fullscreen : Gtk.Window {
-        /**
-         * The registered PresentationController
-         */
-        public PresentationController controller {
-            get; protected set;
-        }
-
-        /**
-         * Metadata of the slides
-         */
-        protected Metadata.Pdf metadata {
-            get {
-                return this.controller.metadata;
-            }
-        }
-
-        /**
-         * Whether the instance is presenter
-         */
-        public bool is_presenter {
-            get; protected set;
-        }
-
         /**
          * The geometry of this window
          */
@@ -66,33 +40,6 @@ namespace pdfpc.Window {
          * Currently selected windowed (!=fullscreen) mode
          */
         protected bool windowed;
-
-        /**
-         * Timer id which monitors mouse motion to hide the cursor after 5
-         * seconds of inactivity
-         */
-        protected uint hide_cursor_timeout = 0;
-
-        /**
-         * Overlay layout. Holds all drawing layers (like the pdf,
-         * the pointer mode etc)
-         */
-        protected Gtk.Overlay overlay_layout;
-
-        /**
-         * Drawing area for pointer mode
-         */
-        public Gtk.DrawingArea pointer_drawing_surface { get; protected set; }
-
-        /**
-         * Drawing area for pen mode
-         */
-        public Gtk.DrawingArea pen_drawing_surface { get; protected set; }
-
-        /**
-         * Video area for playback. All videos are added to this surface.
-         */
-        public View.Video video_surface { get; protected set; }
 
         /**
          * The GDK scale factor. Used for better slide rendering
@@ -119,17 +66,9 @@ namespace pdfpc.Window {
 
         protected virtual void resize_gui() {}
 
-        public Fullscreen(PresentationController controller, bool is_presenter,
-            int monitor_num, bool windowed, int width = -1, int height = -1) {
-            this.controller = controller;
-            this.is_presenter = is_presenter;
+        public Fullscreen(int monitor_num, bool windowed,
+            int width = -1, int height = -1) {
             this.windowed = windowed;
-
-            this.title = "pdfpc - %s (%s)".printf(
-                is_presenter ? "presenter" : "presentation",
-                metadata.get_title());
-
-            this.destroy.connect((source) => controller.quit());
 
             var display = Gdk.Display.get_default();
             if (monitor_num >= 0) {
@@ -151,33 +90,6 @@ namespace pdfpc.Window {
             }
 
             this.gdk_scale = this.monitor.get_scale_factor();
-
-            this.overlay_layout = new Gtk.Overlay();
-
-            this.pointer_drawing_surface = new Gtk.DrawingArea();
-            this.pen_drawing_surface = new Gtk.DrawingArea();
-            this.video_surface = new View.Video();
-
-            this.overlay_layout.add_overlay(this.video_surface);
-            this.overlay_layout.add_overlay(this.pen_drawing_surface);
-            this.overlay_layout.add_overlay(this.pointer_drawing_surface);
-
-            this.pointer_drawing_surface.no_show_all = true;
-            this.pen_drawing_surface.no_show_all = true;
-
-            this.video_surface.realize.connect(() => {
-                this.set_widget_event_pass_through(this.video_surface, true);
-            });
-            this.pen_drawing_surface.realize.connect(() => {
-                this.pen_drawing_surface.get_window().set_pass_through(true);
-                this.set_widget_event_pass_through(this.pen_drawing_surface,
-                    true);
-            });
-            this.pointer_drawing_surface.realize.connect(() => {
-                this.pointer_drawing_surface.get_window().set_pass_through(true);
-                this.set_widget_event_pass_through(this.pointer_drawing_surface,
-                    true);
-            });
 
             // By default, we go fullscreen
             var monitor_geometry = this.monitor.get_geometry();
@@ -213,13 +125,6 @@ namespace pdfpc.Window {
 
             this.set_default_size(this.window_w, this.window_h);
 
-            this.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
-            this.motion_notify_event.connect(this.on_mouse_move);
-
-            // Start the 5 seconds timeout after which the mouse cursor is
-            // hidden
-            this.restart_hide_cursor_timer();
-
             // Watch for window geometry changes; keep the local copy updated
             this.configure_event.connect((ev) => {
                     if (ev.width != this.window_w ||
@@ -232,13 +137,6 @@ namespace pdfpc.Window {
                     }
                     return false;
                 });
-
-            this.pointer_drawing_surface.draw.connect(this.draw_pointer);
-            this.pen_drawing_surface.draw.connect(this.draw_pen);
-
-            this.key_press_event.connect(this.controller.key_press);
-            this.button_press_event.connect(this.controller.button_press);
-            this.scroll_event.connect(this.controller.scroll);
         }
 
         protected void do_fullscreen() {
@@ -277,169 +175,6 @@ namespace pdfpc.Window {
 
         public bool is_monitor_connected() {
             return this.monitor != null ? true:false;
-        }
-
-        protected bool draw_pointer(Cairo.Context context) {
-            Gtk.Allocation a;
-            this.pointer_drawing_surface.get_allocation(out a);
-            PresentationController c = this.controller;
-
-            // Draw the highlighted area, but ignore very short drags
-            // made unintentionally by mouse clicks
-            if (!c.current_pointer.is_spotlight &&
-                c.highlight.width > 0.01 && c.highlight.height > 0.01) {
-                context.rectangle(0, 0, a.width, a.height);
-                context.new_sub_path();
-                context.rectangle((int)(c.highlight.x*a.width),
-                                  (int)(c.highlight.y*a.height),
-                                  (int)(c.highlight.width*a.width),
-                                  (int)(c.highlight.height*a.height));
-
-                context.set_fill_rule(Cairo.FillRule.EVEN_ODD);
-                context.set_source_rgba(0,0,0,0.5);
-                context.fill_preserve();
-
-                context.new_path();
-            }
-            // Draw the pointer when not dragging
-            if (c.drag_x == -1 &&
-                (!c.pointer_hidden || c.current_pointer.is_spotlight)) {
-                int x = (int)(a.width*c.pointer_x);
-                int y = (int)(a.height*c.pointer_y);
-                int r = (int)(a.height*0.001*c.current_pointer.size);
-
-                Gdk.RGBA rgba = c.current_pointer.get_rgba();
-                context.set_source_rgba(rgba.red,
-                                        rgba.green,
-                                        rgba.blue,
-                                        rgba.alpha);
-                if (c.current_pointer.is_spotlight) {
-                    context.rectangle(0, 0, a.width, a.height);
-                    context.new_sub_path();
-                    context.set_fill_rule(Cairo.FillRule.EVEN_ODD);
-                }
-                context.arc(x, y, r, 0, 2*Math.PI);
-                context.fill();
-            }
-
-            return true;
-        }
-
-        public void enable_pointer(bool onoff) {
-            if (onoff) {
-                this.pointer_drawing_surface.show();
-            } else {
-                this.pointer_drawing_surface.hide();
-            }
-        }
-
-        protected bool draw_pen(Cairo.Context context) {
-            Gtk.Allocation a;
-            this.pen_drawing_surface.get_allocation(out a);
-            PresentationController c = this.controller;
-
-            if (c.pen_drawing != null) {
-                Cairo.Surface? drawing_surface = c.pen_drawing.render_to_surface();
-                int x = (int)(a.width*c.pen_last_x);
-                int y = (int)(a.height*c.pen_last_y);
-                int base_width = c.pen_drawing.width;
-                int base_height = c.pen_drawing.height;
-                Cairo.Matrix old_xform = context.get_matrix();
-                context.scale(
-                    (double) a.width / base_width,
-                    (double) a.height / base_height
-                );
-                context.set_source_surface(drawing_surface, 0, 0);
-                context.paint();
-                context.set_matrix(old_xform);
-                if (this.is_presenter && c.in_drawing_mode() &&
-                    !c.pointer_hidden) {
-                    double width_adjustment = (double) a.width / base_width;
-                    context.set_operator(Cairo.Operator.OVER);
-                    context.set_line_width(2.0);
-                    context.set_source_rgba(
-                        c.current_pen_drawing_tool.red,
-                        c.current_pen_drawing_tool.green,
-                        c.current_pen_drawing_tool.blue,
-                        1.0
-                    );
-                    double arc_radius = c.current_pen_drawing_tool.width * width_adjustment / 2.0;
-                    if (arc_radius < 1.0) {
-                        arc_radius = 1.0;
-                    }
-                    context.arc(x, y, arc_radius, 0, 2*Math.PI);
-                    context.stroke();
-                }
-            }
-
-            return true;
-        }
-
-        public void enable_pen(bool onoff) {
-            if (onoff) {
-                this.pen_drawing_surface.show();
-            } else {
-                this.pen_drawing_surface.hide();
-            }
-        }
-
-        /**
-         * Called every time the mouse cursor is moved
-         */
-        public bool on_mouse_move(Gtk.Widget source, Gdk.EventMotion event) {
-            // Restore the mouse cursor to its default value
-            this.get_window().set_cursor(null);
-
-            this.restart_hide_cursor_timer();
-
-            return false;
-        }
-
-        /**
-         * Restart the 5 seconds timeout before hiding the mouse cursor
-         */
-        protected void restart_hide_cursor_timer(){
-            if (this.hide_cursor_timeout != 0) {
-                Source.remove(this.hide_cursor_timeout);
-            }
-
-            this.hide_cursor_timeout = Timeout.add_seconds(5,
-                this.on_hide_cursor_timeout);
-        }
-
-        /**
-         * Timeout method called if the mouse pointer has not been moved for 5
-         * seconds
-         */
-        protected bool on_hide_cursor_timeout() {
-            this.hide_cursor_timeout = 0;
-
-            // Window might be null in case it has not been mapped
-            if (this.get_window() != null) {
-                var cursor =
-                    new Gdk.Cursor.for_display(Gdk.Display.get_default(),
-                        Gdk.CursorType.BLANK_CURSOR);
-                this.get_window().set_cursor(cursor);
-
-                // After the timeout disabled the cursor do not run it again
-                return false;
-            } else {
-                // The window was not available. Possibly it was not mapped
-                // yet. We simply try it again if the mouse isn't moved for
-                // another five seconds.
-                return true;
-            }
-        }
-
-        /**
-         * Set the widget passthrough.
-         *
-         * If set to true, the widget will not receive events and they will be
-         * forwarded to the underlying widgets within the Gtk.Overlay
-         */
-        protected void set_widget_event_pass_through(Gtk.Widget w,
-            bool pass_through) {
-            this.overlay_layout.set_overlay_pass_through(w, pass_through);
         }
     }
 }

--- a/src/classes/window/fullscreen.vala
+++ b/src/classes/window/fullscreen.vala
@@ -33,8 +33,8 @@ namespace pdfpc.Window {
         /**
          * The geometry of this window
          */
-        protected int window_w;
-        protected int window_h;
+        public int window_w { get; protected set; }
+        public int window_h { get; protected set; }
 
         /**
          * Currently selected windowed (!=fullscreen) mode

--- a/src/classes/window/overview.vala
+++ b/src/classes/window/overview.vala
@@ -92,7 +92,7 @@ namespace pdfpc.Window {
          * When the section changes, we need to update the current slide number.
          * Also, make sure we don't end up with no selection.
          */
-        public void on_selection_changed() {
+        protected void on_selection_changed() {
             var ltp = this.slides_view.get_selected_items();
             if (ltp != null) {
                 var tp = ltp.data;
@@ -136,24 +136,12 @@ namespace pdfpc.Window {
             this.slides_view.button_release_event.connect(this.on_mouse_release);
             this.slides_view.key_press_event.connect(this.on_key_press);
             this.slides_view.selection_changed.connect(this.on_selection_changed);
-            this.key_press_event.connect((event) => this.slides_view.key_press_event(event));
         }
 
         public void set_available_space(int width, int height) {
             this.max_width = width;
             this.max_height = height;
             this.prepare_layout();
-        }
-
-        /**
-         * Get keyboard focus.  This requires that the window has focus.
-         */
-        public void ensure_focus() {
-            Gtk.Window top = this.get_toplevel() as Gtk.Window;
-            if (top != null && !top.has_toplevel_focus) {
-                top.present();
-            }
-            this.slides_view.grab_focus();
         }
 
         /**
@@ -271,30 +259,29 @@ namespace pdfpc.Window {
          * PresentationController.
          */
         public bool on_key_press(Gtk.Widget source, Gdk.EventKey key) {
-            bool handled = false;
+            bool handled = true;
             switch (key.keyval) {
                 case Gdk.Key.Left:
                 case Gdk.Key.Page_Up:
                     if (this.current_slide > 0) {
                         this.current_slide -= 1;
                     }
-                    handled = true;
                     break;
                 case Gdk.Key.Right:
                 case Gdk.Key.Page_Down:
                     if (this.current_slide < this.n_slides - 1) {
                         this.current_slide += 1;
                     }
-                    handled = true;
                     break;
                 case Gdk.Key.Return:
                     bool gotoFirst = (key.state & Gdk.ModifierType.SHIFT_MASK) != 0;
                     this.controller.goto_user_page(this.current_slide, !gotoFirst);
-                    handled = true;
                     break;
                 case Gdk.Key.Escape:
                     this.controller.controllables_hide_overview();
-                    handled = true;
+                    break;
+                default:
+                    handled = false;
                     break;
             }
 

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -29,11 +29,11 @@ namespace pdfpc.Window {
     /**
      * Window showing the currently active slide to be presented on a beamer
      */
-    public class Presentation : Fullscreen, Controllable {
+    public class Presentation : ControllableWindow {
         /**
          * The only view is the main view.
          */
-        public View.Pdf main_view {
+        public override View.Pdf main_view {
             get {
                 return this.view;
             }
@@ -55,7 +55,7 @@ namespace pdfpc.Window {
             this.controller.update_request.connect(this.update);
             this.controller.zoom_request.connect(this.on_zoom);
 
-            this.view = new View.Pdf.from_fullscreen(this, false, true);
+            this.view = new View.Pdf.from_controllable_window(this, false, true);
             this.view.transitions_enabled = true;
             this.view.entering_slide.connect(this.on_entering_slide);
 

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -36,7 +36,7 @@ namespace pdfpc.Window {
         public Presentation(PresentationController controller,
             int screen_num, bool windowed, int width = -1, int height = -1) {
             bool interactive = false;
-            if (Options.single_screen) {
+            if (Options.single_screen || Options.presentation_interactive) {
                 interactive = true;
             }
             base(controller, interactive, screen_num, windowed, width, height);

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -35,7 +35,14 @@ namespace pdfpc.Window {
          */
         public Presentation(PresentationController controller,
             int screen_num, bool windowed, int width = -1, int height = -1) {
-            base(controller, false, screen_num, windowed, width, height);
+            bool interactive = false;
+            if (Options.single_screen) {
+                interactive = true;
+            }
+            base(controller, interactive, screen_num, windowed, width, height);
+
+            this.title = "pdfpc - presentation (%s)".
+                printf(controller.metadata.get_title());
 
             this.controller.update_request.connect(this.update);
 

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -31,20 +31,6 @@ namespace pdfpc.Window {
      */
     public class Presentation : ControllableWindow {
         /**
-         * The only view is the main view.
-         */
-        public override View.Pdf main_view {
-            get {
-                return this.view;
-            }
-        }
-
-        /**
-         * View containing the slide to show
-         */
-        protected View.Pdf view;
-
-        /**
          * Base constructor instantiating a new presentation window
          */
         public Presentation(PresentationController controller,
@@ -53,11 +39,8 @@ namespace pdfpc.Window {
 
             this.controller.update_request.connect(this.update);
 
-            this.view = new View.Pdf.from_controllable_window(this, false, true);
-            this.view.transitions_enabled = true;
-            this.view.entering_slide.connect(this.on_entering_slide);
-
-            this.overlay_layout.add(this.view);
+            this.main_view.transitions_enabled = true;
+            this.main_view.entering_slide.connect(this.on_entering_slide);
 
             // TODO: update the ratio on document reload
             double ratio = metadata.get_page_width()/metadata.get_page_height();
@@ -77,15 +60,15 @@ namespace pdfpc.Window {
                 return;
             }
 
-            bool old_disabled = this.view.disabled;
+            bool old_disabled = this.main_view.disabled;
             if (this.controller.faded_to_black) {
-                this.view.disabled = true;
+                this.main_view.disabled = true;
             } else {
-                this.view.disabled = false;
+                this.main_view.disabled = false;
             }
 
-            bool force = old_disabled != this.view.disabled;
-            this.view.display(this.controller.current_slide_number, force);
+            bool force = old_disabled != this.main_view.disabled;
+            this.main_view.display(this.controller.current_slide_number, force);
         }
 
         private void on_entering_slide(int slide_number) {

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -51,9 +51,7 @@ namespace pdfpc.Window {
             int screen_num, bool windowed, int width = -1, int height = -1) {
             base(controller, false, screen_num, windowed, width, height);
 
-            this.controller.reload_request.connect(this.on_reload);
             this.controller.update_request.connect(this.update);
-            this.controller.zoom_request.connect(this.on_zoom);
 
             this.view = new View.Pdf.from_controllable_window(this, false, true);
             this.view.transitions_enabled = true;
@@ -70,21 +68,14 @@ namespace pdfpc.Window {
         }
 
         /**
-         * Called on document reload.
-         * TODO: in principle the document geometry may change!
-         */
-        public void on_reload() {
-            this.view.invalidate();
-        }
-
-        /**
          * Update the display
          */
         public void update() {
             this.visible = !this.controller.hidden;
 
-            if (this.controller.frozen)
+            if (this.controller.frozen) {
                 return;
+            }
 
             bool old_disabled = this.view.disabled;
             if (this.controller.faded_to_black) {
@@ -95,11 +86,6 @@ namespace pdfpc.Window {
 
             bool force = old_disabled != this.view.disabled;
             this.view.display(this.controller.current_slide_number, force);
-        }
-
-        private void on_zoom(PresentationController.ScaledRectangle? rect) {
-            this.main_view.display(this.controller.current_slide_number,
-                true, rect);
         }
 
         private void on_entering_slide(int slide_number) {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -560,7 +560,6 @@ namespace pdfpc.Window {
             this.controller.hide_overview_request.connect(this.hide_overview);
             this.controller.increase_font_size_request.connect(this.increase_font_size);
             this.controller.decrease_font_size_request.connect(this.decrease_font_size);
-            this.controller.zoom_request.connect(this.on_zoom);
 
             // TODO: update the page aspect ratio on document reload
             float page_ratio = (float)
@@ -1025,7 +1024,6 @@ namespace pdfpc.Window {
          * TODO: in principle the document geometry may change!
          */
         public void on_reload() {
-            this.current_view.invalidate();
             this.next_view.invalidate();
             this.strict_next_view.invalidate();
             this.strict_prev_view.invalidate();
@@ -1263,11 +1261,6 @@ namespace pdfpc.Window {
             var mdview_zoom = size/20.0;
             this.mdview.apply_zoom(mdview_zoom);
 #endif
-        }
-
-        private void on_zoom(PresentationController.ScaledRectangle? rect) {
-            this.main_view.display(this.controller.current_slide_number,
-                true, rect);
         }
 
         public void show_help_window(bool onoff) {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -1,5 +1,5 @@
 /**
- * Presentater window
+ * Presenter window
  *
  * This file is part of pdfpc.
  *

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -35,11 +35,11 @@ namespace pdfpc.Window {
      * Other useful information like time slide count, ... can be displayed here as
      * well.
      */
-    public class Presenter : Fullscreen, Controllable {
+    public class Presenter : ControllableWindow {
         /**
          * Only handle links and annotations on the current_view
          */
-        public View.Pdf main_view {
+        public override View.Pdf main_view {
             get {
                 return this.current_view;
             }
@@ -573,15 +573,15 @@ namespace pdfpc.Window {
             // count.
             int current_allocated_width = (int) Math.floor(
                 this.window_w*Options.current_size/100.0);
-            this.current_view = new View.Pdf.from_fullscreen(this,
+            this.current_view = new View.Pdf.from_controllable_window(this,
                 false, true);
 
-            this.next_view = new View.Pdf.from_fullscreen(this,
+            this.next_view = new View.Pdf.from_controllable_window(this,
                 false, false, true);
 
-            this.strict_next_view = new View.Pdf.from_fullscreen(this,
+            this.strict_next_view = new View.Pdf.from_controllable_window(this,
                 false, false);
-            this.strict_prev_view = new View.Pdf.from_fullscreen(this,
+            this.strict_prev_view = new View.Pdf.from_controllable_window(this,
                 false, false);
 
             this.css_provider = new Gtk.CssProvider();
@@ -607,7 +607,7 @@ namespace pdfpc.Window {
             notes_sw.add(this.notes_editor);
             notes_sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC);
 
-            this.notes_view = new View.Pdf.from_fullscreen(this,
+            this.notes_view = new View.Pdf.from_controllable_window(this,
                 true, false);
             frame = new Gtk.AspectFrame(null, 0.5f, 0.0f, page_ratio, false);
             frame.add(this.notes_view);

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -433,6 +433,9 @@ namespace pdfpc.Window {
             int screen_num, bool windowed) {
             base(controller, true, screen_num, windowed);
 
+            this.title = "pdfpc - presenter (%s)".
+                printf(controller.metadata.get_title());
+
             this.controller.reload_request.connect(this.on_reload);
             this.controller.update_request.connect(this.update);
             this.controller.edit_note_request.connect(this.edit_note);

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -559,17 +559,13 @@ namespace pdfpc.Window {
             this.status = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 2);
             this.load_icons();
 
-            this.add_events(Gdk.EventMask.KEY_PRESS_MASK);
-            this.add_events(Gdk.EventMask.BUTTON_PRESS_MASK);
-            this.add_events(Gdk.EventMask.SCROLL_MASK);
-
             this.resize_bottom_texts();
 
             this.overview = new Overview(this.controller);
             this.overview.vexpand = true;
             this.overview.hexpand = true;
             this.overview.set_n_slides(this.controller.user_n_slides);
-            this.controller.set_overview(this.overview);
+            this.controller.overview = this.overview;
 
             this.slide_views = create_paned(Gtk.Orientation.HORIZONTAL);
             this.slide_views.position = current_allocated_width;
@@ -584,11 +580,6 @@ namespace pdfpc.Window {
             frame = new Gtk.AspectFrame(null, 1.0f, 0.0f, page_ratio, false);
             frame.add(this.strict_next_view);
             strict_views.attach(frame, 1, 0);
-
-            this.video_surface.set_events(Gdk.EventMask.BUTTON_PRESS_MASK   |
-                                          Gdk.EventMask.BUTTON_RELEASE_MASK |
-                                          Gdk.EventMask.POINTER_MOTION_MASK);
-
 
             this.current_view_and_stricts =
                 create_paned(Gtk.Orientation.VERTICAL);
@@ -896,7 +887,7 @@ namespace pdfpc.Window {
 #endif
         }
 
-        public void show_overview() {
+        protected void show_overview() {
             // Ignore events coming from the presentation view
             if (!this.is_active) {
                 return;
@@ -904,11 +895,12 @@ namespace pdfpc.Window {
 
             this.overview.current_slide = this.controller.current_user_slide_number;
             this.slide_stack.set_visible_child_name("overview");
-            this.overview.ensure_focus();
+            this.controller.set_ignore_input_events(true);
         }
 
-        public void hide_overview() {
+        protected void hide_overview() {
             this.slide_stack.set_visible_child_name("slides");
+            this.controller.set_ignore_input_events(false);
         }
 
         public bool is_overview_shown() {

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -29,6 +29,23 @@
  */
 
 namespace pdfpc.Window {
+
+   /**
+     * An auxiliary function to load an icon (essentially, a square image)
+     */
+    public Gtk.Image load_icon(string filename, int size) {
+        Gtk.Image icon;
+        var surface = Renderer.Image.render(filename, size, size);
+        if (surface != null) {
+            icon = new Gtk.Image.from_surface(surface);
+        } else {
+            icon = new Gtk.Image.from_icon_name("image-missing",
+                Gtk.IconSize.LARGE_TOOLBAR);
+        }
+        icon.no_show_all = true;
+        return icon;
+    }
+
     /**
      * Window showing the currently active and next slide.
      *
@@ -157,136 +174,10 @@ namespace pdfpc.Window {
         protected Gtk.Stack slide_stack;
 
         /**
-         * Fixed layout - container of the toolbox.
-         */
-        protected Gtk.Fixed toolbox_container;
-
-        /**
          * The toolbox with action buttons
          */
-        protected Gtk.Box toolbox;
+        protected ToolBox toolbox;
 
-        /**
-         * Drawing color selector button of the toolbox
-         */
-        protected Gtk.ColorButton color_button;
-
-        /**
-         * Drawing scale selector button of the toolbox
-         */
-        protected Gtk.ScaleButton scale_button;
-
-        /**
-         * Coordinates of the click event at the beginning of toolbox dragging
-         **/
-        private int toolbox_x0;
-        private int toolbox_y0;
-
-        /**
-         * Size of the toolbox button icons
-         **/
-        private int toolbox_icon_height;
-
-        protected bool on_button_press(Gtk.Widget pbut, Gdk.EventButton event) {
-            if (event.button == 1 ) {
-                var w = this.get_window();
-
-                w.get_position(out this.toolbox_x0, out this.toolbox_y0);
-
-                this.toolbox_x0 += (int) event.x;
-                this.toolbox_y0 += (int) event.y;
-            }
-
-            return true;
-        }
-
-        protected bool on_move_pointer(Gtk.Widget pbut, Gdk.EventMotion event) {
-            int x = (int) event.x_root - this.toolbox_x0;
-            int y = (int) event.y_root - this.toolbox_y0;
-
-            if (true) {
-                int dest_x, dest_y;
-                toolbox.translate_coordinates(pbut, x, y,
-                    out dest_x, out dest_y);
-                this.toolbox_container.move(toolbox, dest_x, dest_y);
-            }
-
-            return true;
-        }
-
-        protected Gtk.Button add_toolbox_button(Gtk.Box panel,
-            bool tbox_inverse, string icon_fname, string? tooltip = null) {
-            var bimage = this.load_icon(icon_fname, toolbox_icon_height);
-            bimage.show();
-            var button = new Gtk.Button();
-            button.add(bimage);
-            button.can_focus = false;
-            button.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
-            if (!Options.disable_tooltips) {
-                button.set_tooltip_text(tooltip);
-            }
-            if (tbox_inverse) {
-                panel.pack_end(button);
-            } else {
-                panel.pack_start(button);
-            }
-
-            return button;
-        }
-
-        protected Gtk.ColorButton add_toolbox_cbutton(Gtk.Box panel,
-            bool tbox_inverse, string? tooltip = null) {
-            var button = new Gtk.ColorButton();
-            button.can_focus = false;
-            button.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
-            if (!Options.disable_tooltips) {
-                button.set_tooltip_text(tooltip);
-            }
-            if (tbox_inverse) {
-                panel.pack_end(button);
-            } else {
-                panel.pack_start(button);
-            }
-
-            return button;
-        }
-
-        protected Gtk.ScaleButton add_toolbox_sbutton(Gtk.Box panel,
-            bool tbox_inverse, string icon_fname, string? tooltip = null) {
-
-            var button = new Gtk.ScaleButton(Gtk.IconSize.DIALOG,
-                0, 50, 2, null);
-
-            var bimage = this.load_icon(icon_fname, toolbox_icon_height);
-            bimage.show();
-            button.set_image(bimage);
-
-            button.set_relief(Gtk.ReliefStyle.NORMAL);
-            button.get_adjustment().set_page_increment(4);
-
-            button.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
-            if (!Options.disable_tooltips) {
-                button.set_tooltip_text(tooltip);
-            }
-
-            if (tbox_inverse) {
-                panel.pack_end(button);
-            } else {
-                panel.pack_start(button);
-            }
-
-            // ignore input events on the main window while the scale popup
-            // is active
-            var popup = button.get_popup();
-            popup.show.connect(() => {
-                this.controller.set_ignore_input_events(true);
-            });
-            popup.hide.connect(() => {
-                this.controller.set_ignore_input_events(false);
-            });
-
-            return button;
-        }
 
         protected Gtk.ScrolledWindow create_help_window() {
             var help_sw = new Gtk.ScrolledWindow(null, null);
@@ -417,6 +308,10 @@ namespace pdfpc.Window {
             double bottom_height = (double) this.window_h/this.bottom_frac_inv;
             int icon_height = (int) (0.9*bottom_height);
 
+            if (!Pdfpc.is_Wayland_backend() && !Pdfpc.is_Quartz_backend()) {
+                icon_height *= this.gdk_scale;
+            }
+
             // Remove all existing icons
             var icons = this.status.get_children();
             foreach (Gtk.Widget icon in icons) {
@@ -424,18 +319,18 @@ namespace pdfpc.Window {
                 icon.destroy();
             }
 
-            this.blank_icon = this.load_icon("blank.svg", icon_height);
-            this.hidden_icon = this.load_icon("hidden.svg", icon_height);
-            this.frozen_icon = this.load_icon("snow.svg", icon_height);
-            this.pause_icon = this.load_icon("pause.svg", icon_height);
-            this.saved_icon = this.load_icon("saved.svg", icon_height);
-            this.loaded_icon = this.load_icon("loaded.svg", icon_height);
-            this.locked_icon = this.load_icon("locked.svg", icon_height);
+            this.blank_icon = load_icon("blank.svg", icon_height);
+            this.hidden_icon = load_icon("hidden.svg", icon_height);
+            this.frozen_icon = load_icon("snow.svg", icon_height);
+            this.pause_icon = load_icon("pause.svg", icon_height);
+            this.saved_icon = load_icon("saved.svg", icon_height);
+            this.loaded_icon = load_icon("loaded.svg", icon_height);
+            this.locked_icon = load_icon("locked.svg", icon_height);
 
-            this.highlight_icon = this.load_icon("highlight.svg", icon_height);
-            this.pen_icon = this.load_icon("pen.svg", icon_height);
-            this.eraser_icon = this.load_icon("eraser.svg", icon_height);
-            this.spotlight_icon = this.load_icon("spotlight.svg", icon_height);
+            this.highlight_icon = load_icon("highlight.svg", icon_height);
+            this.pen_icon = load_icon("pen.svg", icon_height);
+            this.eraser_icon = load_icon("eraser.svg", icon_height);
+            this.spotlight_icon = load_icon("spotlight.svg", icon_height);
 
             this.status.pack_start(this.blank_icon, false, false);
             this.status.pack_start(this.hidden_icon, false, false);
@@ -775,157 +670,14 @@ namespace pdfpc.Window {
             full_overlay.add(full_layout);
 
             // maybe should be calculated based on screen dimensions?
-            this.toolbox_icon_height = 36;
-
-            Gtk.Orientation toolbox_orientation = Gtk.Orientation.HORIZONTAL;
-            bool tbox_inverse = false;
-            int tb_offset = (int) (0.02*this.window_h);
-
-            int tbox_x = 0, tbox_y = 0;
-            switch (Options.toolbox_direction) {
-                case Options.ToolboxDirection.LtoR:
-                    toolbox_orientation = Gtk.Orientation.HORIZONTAL;
-                    tbox_inverse = false;
-                    tbox_x = (int) (0.15*this.window_w) + tb_offset;
-                    tbox_y = (int) (0.70*this.window_h) + tb_offset;
-                    break;
-                case Options.ToolboxDirection.RtoL:
-                    toolbox_orientation = Gtk.Orientation.HORIZONTAL;
-                    tbox_inverse = true;
-                    tbox_x = (int) (0.15*this.window_w) - tb_offset;
-                    tbox_y = (int) (0.70*this.window_h) + tb_offset;
-                    break;
-                case Options.ToolboxDirection.TtoB:
-                    toolbox_orientation = Gtk.Orientation.VERTICAL;
-                    tbox_inverse = false;
-                    tbox_x = 0*this.window_w + tb_offset;
-                    tbox_y = 0*this.window_h + tb_offset;
-                    break;
-                case Options.ToolboxDirection.BtoT:
-                    toolbox_orientation = Gtk.Orientation.VERTICAL;
-                    tbox_inverse = true;
-                    tbox_x = 0*this.window_w + tb_offset;
-                    tbox_y = 0*this.window_h + tb_offset;
-                    break;
+            int toolbox_icon_height = 36;
+            if (!Pdfpc.is_Wayland_backend() && !Pdfpc.is_Quartz_backend()) {
+                toolbox_icon_height *= this.gdk_scale;
             }
-            toolbox = new Gtk.Box(toolbox_orientation, 0);
-            toolbox.get_style_context().add_class("toolbox");
-            toolbox.halign = Gtk.Align.START;
-            toolbox.valign = Gtk.Align.START;
+            this.toolbox = new Window.ToolBox(this, toolbox_icon_height);
 
-            /* Toolbox handle consisting of an image + eventbox */
-            var himage = this.load_icon("move.svg", 30);
-            himage.show();
-
-            var heventbox = new Gtk.EventBox();
-            heventbox.button_press_event.connect(on_button_press);
-            heventbox.motion_notify_event.connect(on_move_pointer);
-            heventbox.add(himage);
-            heventbox.set_events(
-                  Gdk.EventMask.BUTTON_PRESS_MASK |
-                  Gdk.EventMask.BUTTON1_MOTION_MASK
-            );
-            if (tbox_inverse) {
-                this.toolbox.pack_end(heventbox);
-            } else {
-                this.toolbox.pack_start(heventbox);
-            }
-
-            Gtk.Button tb;
-            tb = add_toolbox_button(this.toolbox, tbox_inverse, "settings.svg",
-                "Toggle toolbox panel");
-
-            /* Toolbox panel that contains the buttons */
-            var button_panel = new Gtk.Box(toolbox_orientation, 0);
-            button_panel.set_spacing(0);
-            button_panel.set_homogeneous(true);
-
-            if (Options.toolbox_minimized) {
-                button_panel.hide();
-            }
-            if (tbox_inverse) {
-                this.toolbox.pack_end(button_panel);
-            } else {
-                this.toolbox.pack_start(button_panel);
-            }
-
-            tb.clicked.connect(() => {
-                    var state = button_panel.visible;
-                    if (state) {
-                        button_panel.hide();
-                    } else {
-                        button_panel.show();
-                    }
-                });
-
-            tb = add_toolbox_button(button_panel, tbox_inverse, "empty.svg",
-                "Normal mode");
-            tb.clicked.connect(() => {
-                    this.controller.set_normal_mode();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "highlight.svg",
-                "Pointer mode");
-            tb.clicked.connect(() => {
-                    this.controller.set_pointer_mode();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "pen.svg",
-                "Pen mode");
-            tb.clicked.connect(() => {
-                    this.controller.set_pen_mode();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "eraser.svg",
-                "Eraser mode");
-            tb.clicked.connect(() => {
-                    this.controller.set_eraser_mode();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "spotlight.svg",
-                "Spotlight mode");
-            tb.clicked.connect(() => {
-                    this.controller.set_spotlight_mode();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "snow.svg",
-                "Freeze presentation window");
-            tb.clicked.connect(() => {
-                    this.controller.toggle_freeze();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "blank.svg",
-                "Black presentation window");
-            tb.clicked.connect(() => {
-                    this.controller.fade_to_black();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "hidden.svg",
-                "Hide presentation window");
-            tb.clicked.connect(() => {
-                    this.controller.hide_presentation();
-                });
-            tb = add_toolbox_button(button_panel, tbox_inverse, "pause.svg",
-                "Pause/resume timer");
-            tb.clicked.connect(() => {
-                    this.controller.toggle_pause();
-                });
-
-            scale_button = add_toolbox_sbutton(button_panel, tbox_inverse,
-                "linewidth.svg", "Drawing tool size");
-            scale_button.hide();
-            scale_button.value_changed.connect((val) => {
-                this.controller.set_pen_size(val);
-            });
-
-            color_button = add_toolbox_cbutton(button_panel, tbox_inverse,
-                "Pen color");
-            color_button.hide();
-            color_button.color_set.connect(() => {
-                    var rgba = color_button.rgba;
-                    this.controller.pen_drawing.pen.set_rgba(rgba);
-                    this.controller.queue_pen_surface_draws();
-                });
-
-            this.toolbox_container = new Gtk.Fixed();
-
-            this.toolbox_container.put(toolbox, tbox_x, tbox_y);
-
-            full_overlay.add_overlay(this.toolbox_container);
-            full_overlay.set_overlay_pass_through(this.toolbox_container, true);
+            full_overlay.add_overlay(this.toolbox);
+            full_overlay.set_overlay_pass_through(this.toolbox, true);
 
             this.add(full_overlay);
         }
@@ -933,25 +685,6 @@ namespace pdfpc.Window {
         public override void show() {
             base.show();
             this.resize_overview();
-        }
-
-       /**
-         * Load an icon (essentially, a quadratic image)
-         */
-        protected Gtk.Image load_icon(string filename, int size) {
-            Gtk.Image icon;
-            if (!Pdfpc.is_Wayland_backend() && !Pdfpc.is_Quartz_backend()) {
-                size *= this.gdk_scale;
-            }
-            var surface = Renderer.Image.render(filename, size, size);
-            if (surface != null) {
-                icon = new Gtk.Image.from_surface(surface);
-            } else {
-                icon = new Gtk.Image.from_icon_name("image-missing",
-                    Gtk.IconSize.LARGE_TOOLBAR);
-            }
-            icon.no_show_all = true;
-            return icon;
         }
 
         public void session_saved() {
@@ -976,30 +709,6 @@ namespace pdfpc.Window {
             this.slide_progress.set_text("%d/%u".printf(current, total));
         }
 
-        protected void update_toolbox() {
-            if (Options.toolbox_shown) {
-                toolbox_container.show();
-            } else {
-                toolbox_container.hide();
-            }
-
-            var controller = this.controller;
-
-            var rgba = controller.pen_drawing.pen.get_rgba();
-            color_button.set_rgba(rgba);
-            if (controller.is_pen_active()) {
-                color_button.show();
-            } else {
-                color_button.hide();
-            }
-
-            scale_button.set_value(controller.get_pen_size());
-            if (controller.is_pen_active() || controller.is_eraser_active()) {
-                scale_button.show();
-            } else {
-                scale_button.hide();
-            }
-        }
 
         /**
          * Called on document reload.
@@ -1076,7 +785,7 @@ namespace pdfpc.Window {
             this.loaded_icon.hide();
             this.locked_icon.hide();
 
-            this.update_toolbox();
+            this.toolbox.update();
         }
 
         /**

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -37,20 +37,6 @@ namespace pdfpc.Window {
      */
     public class Presenter : ControllableWindow {
         /**
-         * Only handle links and annotations on the current_view
-         */
-        public override View.Pdf main_view {
-            get {
-                return this.current_view;
-            }
-        }
-
-        /**
-         * View showing the current slide
-         */
-        protected View.Pdf current_view;
-
-        /**
          * View showing a preview of the next slide
          */
         protected View.Pdf next_view;
@@ -572,8 +558,6 @@ namespace pdfpc.Window {
             // count.
             int current_allocated_width = (int) Math.floor(
                 this.window_w*Options.current_size/100.0);
-            this.current_view = new View.Pdf.from_controllable_window(this,
-                false, true);
 
             this.next_view = new View.Pdf.from_controllable_window(this,
                 false, false, true);
@@ -705,8 +689,6 @@ namespace pdfpc.Window {
             frame = new Gtk.AspectFrame(null, 1.0f, 0.0f, page_ratio, false);
             frame.add(this.strict_next_view);
             strict_views.attach(frame, 1, 0);
-
-            this.overlay_layout.add(this.current_view);
 
             this.video_surface.set_events(Gdk.EventMask.BUTTON_PRESS_MASK   |
                                           Gdk.EventMask.BUTTON_RELEASE_MASK |
@@ -1040,7 +1022,7 @@ namespace pdfpc.Window {
             int current_user_slide_number =
                 this.controller.current_user_slide_number;
 
-            this.current_view.display(current_slide_number);
+            this.main_view.display(current_slide_number);
 
             var next_view_user_slide = current_user_slide_number;
             bool show_final_slide_of_current_overlay =

--- a/src/classes/window/toolbox.vala
+++ b/src/classes/window/toolbox.vala
@@ -1,0 +1,332 @@
+/**
+ * Presenter toolbox
+ *
+ * This file is part of pdfpc.
+ *
+  * Copyright 2017 Evgeny Stambulchik
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace pdfpc.Window {
+    /**
+     * Fixed layout - container of the toolbox
+     */
+    public class ToolBox : Gtk.Fixed {
+        protected PresentationController controller;
+
+        /**
+         * The toolbox itself
+         */
+        protected Gtk.Box toolbox;
+
+        /**
+         * Drawing color selector button of the toolbox
+         */
+        protected Gtk.ColorButton color_button;
+
+        /**
+         * Drawing scale selector button of the toolbox
+         */
+        protected Gtk.ScaleButton scale_button;
+
+        /**
+         * Coordinates of the click event at the beginning of toolbox dragging
+         **/
+        private int x0;
+        private int y0;
+
+        /**
+         * Size of the toolbox button icons
+         **/
+        private int icon_height;
+
+        protected bool on_button_press(Gtk.Widget pbut, Gdk.EventButton event) {
+            if (event.button == 1 ) {
+                var w = this.get_parent().get_window();
+
+                w.get_position(out this.x0, out this.y0);
+
+                this.x0 += (int) event.x;
+                this.y0 += (int) event.y;
+            }
+
+            return true;
+        }
+
+        protected bool on_move_pointer(Gtk.Widget pbut, Gdk.EventMotion event) {
+            int x = (int) event.x_root - this.x0;
+            int y = (int) event.y_root - this.y0;
+
+            if (true) {
+                int dest_x, dest_y;
+                toolbox.translate_coordinates(pbut, x, y,
+                    out dest_x, out dest_y);
+                this.move(toolbox, dest_x, dest_y);
+            }
+
+            return true;
+        }
+
+        protected Gtk.Button add_button(Gtk.Box panel,
+            bool tbox_inverse, string icon_fname, string? tooltip = null) {
+            var bimage = load_icon(icon_fname, icon_height);
+            bimage.show();
+            var button = new Gtk.Button();
+            button.add(bimage);
+            button.can_focus = false;
+            button.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
+            if (!Options.disable_tooltips) {
+                button.set_tooltip_text(tooltip);
+            }
+            if (tbox_inverse) {
+                panel.pack_end(button);
+            } else {
+                panel.pack_start(button);
+            }
+
+            return button;
+        }
+
+        protected Gtk.ColorButton add_cbutton(Gtk.Box panel,
+            bool tbox_inverse, string? tooltip = null) {
+            var button = new Gtk.ColorButton();
+            button.can_focus = false;
+            button.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
+            if (!Options.disable_tooltips) {
+                button.set_tooltip_text(tooltip);
+            }
+            if (tbox_inverse) {
+                panel.pack_end(button);
+            } else {
+                panel.pack_start(button);
+            }
+
+            return button;
+        }
+
+        protected Gtk.ScaleButton add_sbutton(Gtk.Box panel,
+            bool tbox_inverse, string icon_fname, string? tooltip = null) {
+
+            var button = new Gtk.ScaleButton(Gtk.IconSize.DIALOG,
+                0, 50, 2, null);
+
+            var bimage = load_icon(icon_fname, icon_height);
+            bimage.show();
+            button.set_image(bimage);
+
+            button.set_relief(Gtk.ReliefStyle.NORMAL);
+            button.get_adjustment().set_page_increment(4);
+
+            button.add_events(Gdk.EventMask.POINTER_MOTION_MASK);
+            if (!Options.disable_tooltips) {
+                button.set_tooltip_text(tooltip);
+            }
+
+            if (tbox_inverse) {
+                panel.pack_end(button);
+            } else {
+                panel.pack_start(button);
+            }
+
+            // ignore input events on the main window while the scale popup
+            // is active
+            var popup = button.get_popup();
+            popup.show.connect(() => {
+                this.controller.set_ignore_input_events(true);
+            });
+            popup.hide.connect(() => {
+                this.controller.set_ignore_input_events(false);
+            });
+
+            return button;
+        }
+
+        public ToolBox(Window.Presenter presenter, int icon_height) {
+            this.icon_height = icon_height;
+            this.controller = presenter.controller;
+
+            Gtk.Orientation orientation = Gtk.Orientation.HORIZONTAL;
+            bool tbox_inverse = false;
+            int tb_offset = (int) (0.02*presenter.window_h);
+
+            int tbox_x = 0, tbox_y = 0;
+            switch (Options.toolbox_direction) {
+                case Options.ToolboxDirection.LtoR:
+                    orientation = Gtk.Orientation.HORIZONTAL;
+                    tbox_inverse = false;
+                    tbox_x = (int) (0.15*presenter.window_w) + tb_offset;
+                    tbox_y = (int) (0.70*presenter.window_h) + tb_offset;
+                    break;
+                case Options.ToolboxDirection.RtoL:
+                    orientation = Gtk.Orientation.HORIZONTAL;
+                    tbox_inverse = true;
+                    tbox_x = (int) (0.15*presenter.window_w) - tb_offset;
+                    tbox_y = (int) (0.70*presenter.window_h) + tb_offset;
+                    break;
+                case Options.ToolboxDirection.TtoB:
+                    orientation = Gtk.Orientation.VERTICAL;
+                    tbox_inverse = false;
+                    tbox_x = 0*presenter.window_w + tb_offset;
+                    tbox_y = 0*presenter.window_h + tb_offset;
+                    break;
+                case Options.ToolboxDirection.BtoT:
+                    orientation = Gtk.Orientation.VERTICAL;
+                    tbox_inverse = true;
+                    tbox_x = 0*presenter.window_w + tb_offset;
+                    tbox_y = 0*presenter.window_h + tb_offset;
+                    break;
+            }
+            toolbox = new Gtk.Box(orientation, 0);
+            toolbox.get_style_context().add_class("toolbox");
+            toolbox.halign = Gtk.Align.START;
+            toolbox.valign = Gtk.Align.START;
+
+            /* Toolbox handle consisting of an image + eventbox */
+            var himage = load_icon("move.svg", icon_height);
+            himage.show();
+
+            var heventbox = new Gtk.EventBox();
+            heventbox.button_press_event.connect(on_button_press);
+            heventbox.motion_notify_event.connect(on_move_pointer);
+            heventbox.add(himage);
+            heventbox.set_events(
+                  Gdk.EventMask.BUTTON_PRESS_MASK |
+                  Gdk.EventMask.BUTTON1_MOTION_MASK
+            );
+            if (tbox_inverse) {
+                this.toolbox.pack_end(heventbox);
+            } else {
+                this.toolbox.pack_start(heventbox);
+            }
+
+            Gtk.Button tb;
+            tb = add_button(this.toolbox, tbox_inverse, "settings.svg",
+                "Toggle toolbox panel");
+
+            /* Toolbox panel that contains the buttons */
+            var button_panel = new Gtk.Box(orientation, 0);
+            button_panel.set_spacing(0);
+            button_panel.set_homogeneous(true);
+
+            if (Options.toolbox_minimized) {
+                button_panel.hide();
+            }
+            if (tbox_inverse) {
+                this.toolbox.pack_end(button_panel);
+            } else {
+                this.toolbox.pack_start(button_panel);
+            }
+
+            tb.clicked.connect(() => {
+                    var state = button_panel.visible;
+                    if (state) {
+                        button_panel.hide();
+                    } else {
+                        button_panel.show();
+                    }
+                });
+
+            tb = add_button(button_panel, tbox_inverse, "empty.svg",
+                "Normal mode");
+            tb.clicked.connect(() => {
+                    this.controller.set_normal_mode();
+                });
+            tb = add_button(button_panel, tbox_inverse, "highlight.svg",
+                "Pointer mode");
+            tb.clicked.connect(() => {
+                    this.controller.set_pointer_mode();
+                });
+            tb = add_button(button_panel, tbox_inverse, "pen.svg",
+                "Pen mode");
+            tb.clicked.connect(() => {
+                    this.controller.set_pen_mode();
+                });
+            tb = add_button(button_panel, tbox_inverse, "eraser.svg",
+                "Eraser mode");
+            tb.clicked.connect(() => {
+                    this.controller.set_eraser_mode();
+                });
+            tb = add_button(button_panel, tbox_inverse, "spotlight.svg",
+                "Spotlight mode");
+            tb.clicked.connect(() => {
+                    this.controller.set_spotlight_mode();
+                });
+            tb = add_button(button_panel, tbox_inverse, "snow.svg",
+                "Freeze presentation window");
+            tb.clicked.connect(() => {
+                    this.controller.toggle_freeze();
+                });
+            tb = add_button(button_panel, tbox_inverse, "blank.svg",
+                "Black presentation window");
+            tb.clicked.connect(() => {
+                    this.controller.fade_to_black();
+                });
+            tb = add_button(button_panel, tbox_inverse, "hidden.svg",
+                "Hide presentation window");
+            tb.clicked.connect(() => {
+                    this.controller.hide_presentation();
+                });
+            tb = add_button(button_panel, tbox_inverse, "pause.svg",
+                "Pause/resume timer");
+            tb.clicked.connect(() => {
+                    this.controller.toggle_pause();
+                });
+
+            scale_button = add_sbutton(button_panel, tbox_inverse,
+                "linewidth.svg", "Drawing tool size");
+            scale_button.hide();
+            scale_button.value_changed.connect((val) => {
+                this.controller.set_pen_size(val);
+            });
+
+            color_button = add_cbutton(button_panel, tbox_inverse,
+                "Pen color");
+            color_button.hide();
+            color_button.color_set.connect(() => {
+                    var rgba = color_button.rgba;
+                    this.controller.pen_drawing.pen.set_rgba(rgba);
+                    this.controller.queue_pen_surface_draws();
+                });
+
+            this.put(this.toolbox, tbox_x, tbox_y);
+        }
+
+        public void update() {
+            if (Options.toolbox_shown) {
+                this.show();
+            } else {
+                this.hide();
+            }
+
+            var controller = this.controller;
+
+            var rgba = controller.pen_drawing.pen.get_rgba();
+            color_button.set_rgba(rgba);
+            if (controller.is_pen_active()) {
+                color_button.show();
+            } else {
+                color_button.hide();
+            }
+
+            scale_button.set_value(controller.get_pen_size());
+            if (controller.is_pen_active() || controller.is_eraser_active()) {
+                scale_button.show();
+            } else {
+                scale_button.hide();
+            }
+        }
+    }
+}

--- a/src/interfaces/controllable.vala
+++ b/src/interfaces/controllable.vala
@@ -37,7 +37,7 @@ namespace pdfpc {
         /**
          * The view on which links and annotations should be handled.
          */
-        public abstract View.Pdf main_view { get; }
+        public abstract View.Pdf main_view { get; protected set; }
     }
 }
 


### PR DESCRIPTION
It is a relatively massive rewrite of the main classes, separating functionality and toolkit GUI. To this end:

- Introduced `ControllableWindow` descending from `Fullscreen` and implementing the `Controllable` interface;
- `Fullscreen` remains a slim class implementing, well, only the (toggle-) fullscreen functionality;
- `Presenter` and `Presentation` now descend from ControllableWindow;
- Most of the Gtk/Gdk code moved from `PresentationController` to `ControllableWindow`;
- For a good measure, toolbox stuff split off to a separate class.

Further:
- Unified the timeouts of the Gtk cursor and the soft ones (pointer/pen/eraser) and made it configurable via pdfpcrc;
- The Gtk cursor timeout is limited to the main view (and fixed in the drawing mode, thus effectively resolving #659; I don't see much point specifically in the crosshair cursor);
- Added a pdfpcrc option to make the presentation window react to user keyboard/mouse actions identically to the presenter; it is always on when presentation is the only window (thus, fixing #518 and obsoleting #519).