### PR TITLE
Wayland events

### DIFF
--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -339,8 +339,8 @@ namespace pdfpc.Window {
          * Handle mouse scrolling
          */
         protected bool w_on_scroll(Gdk.EventScroll scroll) {
-            bool up   = false;
-            bool down = false;
+            bool up = false, down = false;
+
             switch (scroll.direction) {
             case Gdk.ScrollDirection.UP:
             case Gdk.ScrollDirection.LEFT:
@@ -349,6 +349,15 @@ namespace pdfpc.Window {
             case Gdk.ScrollDirection.DOWN:
             case Gdk.ScrollDirection.RIGHT:
                 down = true;
+                break;
+            case Gdk.ScrollDirection.SMOOTH:
+                double dx, dy;
+                scroll.get_scroll_deltas(out dx, out dy);
+                if (dx > 0 || dy > 0) {
+                    down = true;
+                } else if (dx < 0 || dy < 0) {
+                    up = true;
+                }
                 break;
             default:
                 break;

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -139,10 +139,6 @@ namespace pdfpc.Window {
                     true);
             });
 
-            if (this.interactive) {
-                this.register_presenter_handlers();
-            }
-
             // Soft cursor drawing events
             this.pointer_drawing_surface.draw.connect(this.draw_pointer);
             this.pen_drawing_surface.draw.connect(this.draw_pen);
@@ -155,6 +151,13 @@ namespace pdfpc.Window {
             this.restart_hide_cursor_timer();
 
             this.destroy.connect((source) => controller.quit());
+        }
+
+        protected void add_top_container(Gtk.Widget top) {
+            this.add(top);
+            if (this.interactive) {
+                this.register_presenter_handlers(top);
+            }
         }
 
         public void enable_pointer(bool onoff) {
@@ -173,7 +176,7 @@ namespace pdfpc.Window {
             }
         }
 
-        protected void register_presenter_handlers() {
+        protected void register_presenter_handlers(Gtk.Widget top) {
             // Main view events
             var view = this.main_view;
             view.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK |
@@ -187,8 +190,12 @@ namespace pdfpc.Window {
 
             // General controlling events acting on the whole window
             this.key_press_event.connect(this.w_on_key_press);
-            this.button_press_event.connect(this.w_on_button_press);
             this.scroll_event.connect(this.w_on_scroll);
+
+            // Wayland treats the window decorations as part of the window.
+            // Thus, we assign the mouse handler to the top widget instead,
+            // so the WM actions like resize & drag continue working.
+            top.button_press_event.connect(this.w_on_button_press);
         }
 
         /**

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -190,6 +190,8 @@ namespace pdfpc.Window {
 
             // General controlling events acting on the whole window
             this.key_press_event.connect(this.w_on_key_press);
+
+            this.add_events(Gdk.EventMask.SCROLL_MASK);
             this.scroll_event.connect(this.w_on_scroll);
 
             // Wayland treats the window decorations as part of the window.

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -54,7 +54,8 @@ namespace pdfpc.Window {
             var frame = new Gtk.AspectFrame(null, 0.5f, 0.5f,
                 (float) ratio, false);
             frame.add(overlay_layout);
-            this.add(frame);
+
+            this.add_top_container(frame);
         }
 
         /**

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -687,7 +687,7 @@ namespace pdfpc.Window {
             full_overlay.add_overlay(this.toolbox);
             full_overlay.set_overlay_pass_through(this.toolbox, true);
 
-            this.add(full_overlay);
+            this.add_top_container(full_overlay);
         }
 
         public void session_saved() {


### PR DESCRIPTION
1. Handle mouse button events by the top widget instead of the window (otherwise, under Wayland the WM move/resize operations are not handled).
2. Restore the mouse scroll functionality (regression from cfa0020f9d37e791c91e95f7a3adbfaad78109c1).
3. Handle "smooth" scrolling events (at least in the nested mode mutter/wayland converts normal scroll events into smooth ones).