### PR TITLE
Windows installer

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -31,7 +31,6 @@ jobs:
           mingw-w64-x86_64-cmake
           mingw-w64-x86_64-ninja
           mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-pkg-config
           mingw-w64-x86_64-vala       
           mingw-w64-x86_64-libgee
           mingw-w64-x86_64-poppler
@@ -42,9 +41,13 @@ jobs:
           mingw-w64-x86_64-libsoup
           mingw-w64-x86_64-qrencode
           mingw-w64-x86_64-discount
-
-    - name: Configure CMake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_MAKE_PROGRAM=ninja -DMDVIEW=OFF
+          mingw-w64-x86_64-nsis
 
     - name: Build
-      run: cd build && ninja
+      run: cd windows-setup && ./package.sh
+
+    - name: Upload installer artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: pdfpc-setup
+        path: windows-setup/pdfpc-setup.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .history
 .*.swp
 build/
+windows-setup/pdfpc_version.nsh
+windows-setup/dist
+windows-setup/pdfpc-setup.exe

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ if (${CMAKE_HOST_WIN32})
     set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D WIN)
 else ()
     LIST(REMOVE_ITEM VALA_SRC classes/resource.vala)
+    LIST(REMOVE_ITEM C_SRC console.c)
 endif ()
 
 # Check for some compiler flags to suppress excessive Vala-triggered warnings

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,7 @@ CUSTOM_VAPIS
     ${CMAKE_CURRENT_SOURCE_DIR}/libmarkdown.vapi
     ${CMAKE_CURRENT_SOURCE_DIR}/libqrencode.vapi
     ${CMAKE_CURRENT_SOURCE_DIR}/procinfo.vapi
+    ${CMAKE_CURRENT_SOURCE_DIR}/console.vapi
 )
 
 add_executable(pdfpc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,11 @@ endif ()
 if (NOT MARKDOWN_FOUND)
     LIST(REMOVE_ITEM VALA_SRC classes/renderer/markdown.vala)
 endif ()
+if (${CMAKE_HOST_WIN32})
+    set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D WIN)
+else ()
+    LIST(REMOVE_ITEM VALA_SRC classes/resource.vala)
+endif ()
 
 # Check for some compiler flags to suppress excessive Vala-triggered warnings
 # Since gcc >= 4.4 can silently ignore unrecognized -W-no* flags, we test
@@ -166,6 +171,7 @@ CUSTOM_VAPIS
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_binding.vapi
     ${CMAKE_CURRENT_SOURCE_DIR}/libmarkdown.vapi
     ${CMAKE_CURRENT_SOURCE_DIR}/libqrencode.vapi
+    ${CMAKE_CURRENT_SOURCE_DIR}/procinfo.vapi
 )
 
 add_executable(pdfpc

--- a/src/classes/renderer/image.vala
+++ b/src/classes/renderer/image.vala
@@ -32,6 +32,10 @@ namespace pdfpc.Renderer {
             string load_icon_path;
 #if WIN
             load_icon_path = ResourceLocator.getResourcePath(Path.build_filename("icons", filename));
+            if (load_icon_path == null) {
+                GLib.printerr("Warning: Could not load image %s (File not found)\n",
+                    filename);
+            }
 #else
             if (Options.no_install) {
                 load_icon_path = Path.build_filename(Paths.SOURCE_PATH, "icons",

--- a/src/classes/renderer/image.vala
+++ b/src/classes/renderer/image.vala
@@ -30,6 +30,9 @@ namespace pdfpc.Renderer {
             // attempt to load from a local path (if the user hasn't installed)
             // if that fails, attempt to load from the global path
             string load_icon_path;
+#if WIN
+            load_icon_path = ResourceLocator.getResourcePath(Path.build_filename("icons", filename));
+#else
             if (Options.no_install) {
                 load_icon_path = Path.build_filename(Paths.SOURCE_PATH, "icons",
                     filename);
@@ -37,6 +40,7 @@ namespace pdfpc.Renderer {
                 load_icon_path = Path.build_filename(Paths.SHARE_PATH, "icons",
                     filename);
             }
+#endif
             File icon_file = File.new_for_path(load_icon_path);
 
             try {

--- a/src/classes/resource.vala
+++ b/src/classes/resource.vala
@@ -1,0 +1,34 @@
+namespace pdfpc {
+    public class ResourceLocator {
+        /**
+         * Finds a path to a given resource
+         *
+         * Returns the path of the file or null if it wasn't found
+         */
+         public static string? getResourcePath(string resource) {
+            var shareSuffix  = "share/pdfpc";
+ 
+            char[] pathBuf = new char[ProcInfo.MAX_PATH_LENTH];
+            ProcInfo.GetProcessPath(ref pathBuf);
+            string appPath = (string) pathBuf;
+
+            var start = File.new_for_path(appPath).get_parent();
+            for (var i = 0; i < 3; ++i, start = start.get_parent()) {
+                {
+                    var file = start.resolve_relative_path(resource);
+                    if (file.query_exists()) {
+                            return file.get_path();
+                    }
+                }
+                {
+                    var file = start.resolve_relative_path(shareSuffix).resolve_relative_path(resource);
+                    if (file.query_exists()) {
+                            return file.get_path();
+                    }
+                }           
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/classes/rest_server.vala
+++ b/src/classes/rest_server.vala
@@ -500,9 +500,16 @@ namespace pdfpc {
             this.port_num = port_num;
 
             // If defined as an absolute path, use it as is
-            if (Options.rest_static_root.has_prefix("/")) {
+            if (Options.rest_static_root.has_prefix("/") || Regex.match_simple("[a-zA-Z]:\\.*", Options.rest_static_root)) {
                 this.static_root = Options.rest_static_root;
             } else {
+#if WIN
+                this.static_root = ResourceLocator.getResourcePath(Options.rest_static_root);
+                if (this.static_root == null) {
+                    GLib.printerr("rest-static-root-path not found!");
+                    this.static_root = ".";
+                }
+#else
                 if (Options.no_install) {
                     this.static_root = Path.build_filename(Paths.SOURCE_PATH,
                         Options.rest_static_root);
@@ -510,6 +517,7 @@ namespace pdfpc {
                     this.static_root = Path.build_filename(Paths.SHARE_PATH,
                         Options.rest_static_root);
                 }
+#endif
             }
 
             this.add_handler("/api", api_handler);

--- a/src/classes/view/markdown.vala
+++ b/src/classes/view/markdown.vala
@@ -29,11 +29,15 @@ namespace pdfpc.View {
             this.ucm = this.get_user_content_manager();
 
             string css_path;
+#if WIN
+            css_path = ResourceLocator.getResourcePath("css/notes.css");
+#else
             if (Options.no_install) {
                 css_path = Path.build_filename(Paths.SOURCE_PATH, "css/notes.css");
             } else {
                 css_path = Path.build_filename(Paths.SHARE_PATH, "css/notes.css");
             }
+#endif
 
             try {
                 File css_file = File.new_for_path(css_path);

--- a/src/console.c
+++ b/src/console.c
@@ -2,6 +2,8 @@
  * Taken from: https://github.com/xournalpp/xournalpp/blob/700308a27457116ae804429631d5f31a525ff9b7/src/exe/win32/console.cpp
  */
 
+#ifdef _WIN32
+
 #include "console.h"
 
 #include <windows.h>
@@ -79,3 +81,5 @@ void attachConsole() {
         ShowWindow(GetConsoleWindow(), SW_HIDE);
     }
 }
+
+#endif

--- a/src/console.c
+++ b/src/console.c
@@ -1,0 +1,81 @@
+/**
+ * Taken from: https://github.com/xournalpp/xournalpp/blob/700308a27457116ae804429631d5f31a525ff9b7/src/exe/win32/console.cpp
+ */
+
+#include "console.h"
+
+#include <windows.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+void attachConsole() {
+    if (GetConsoleWindow() != NULL) {
+        // Console is already attached.
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+        return;
+    }
+
+    // Make sure the console starts hidden.
+    STARTUPINFOW startupInfo = {0};
+    startupInfo.dwFlags = STARTF_USESHOWWINDOW;
+    startupInfo.wShowWindow = SW_HIDE;
+    startupInfo.cb = sizeof(startupInfo);
+
+    PROCESS_INFORMATION processInformation = {0};
+
+    bool consoleAttached = false;
+
+    if (CreateProcessW(L"C:\\Windows\\System32\\cmd.exe", NULL, NULL, NULL, FALSE, 0, NULL, NULL, &startupInfo,
+                       &processInformation)) {
+
+        HANDLE job = CreateJobObject(NULL, NULL);
+
+        if (job != NULL) {
+            // Terminate the console process automatically when Xournal++ exits.
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInformation = {0};
+            jobInformation.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &jobInformation,
+                                         sizeof(jobInformation)) ||
+                !AssignProcessToJobObject(job, processInformation.hProcess)) {
+                TerminateProcess(processInformation.hProcess, 0);
+                CloseHandle(processInformation.hProcess);
+                CloseHandle(processInformation.hThread);
+                CloseHandle(job);
+                processInformation.hProcess = processInformation.hThread = job = NULL;
+            } else {
+                // It takes a short time before the console becomes ready to be attached, unfortunately
+                // there is no API that would let us wait for it.
+                for (unsigned short i = 0; i < 20; i++) {
+                    if (AttachConsole(processInformation.dwProcessId)) {
+                        consoleAttached = true;
+                        break;
+                    }
+                    Sleep(50);
+                }
+            }
+        } else {
+            TerminateProcess(processInformation.hProcess, 0);
+            CloseHandle(processInformation.hProcess);
+            CloseHandle(processInformation.hThread);
+            processInformation.hProcess = processInformation.hThread = NULL;
+        }
+
+        if (processInformation.hProcess != NULL) {
+            if (!consoleAttached) {
+                TerminateProcess(processInformation.hProcess, 0);
+                CloseHandle(job);
+            }
+
+            CloseHandle(processInformation.hProcess);
+            CloseHandle(processInformation.hThread);
+        }
+    }
+
+    if (!consoleAttached) {
+        // Could not attach to the manually created console process, request one from the system instead.
+        // This will make the console window flash briefly before we hide it.
+        AllocConsole();
+        ShowWindow(GetConsoleWindow(), SW_HIDE);
+    }
+}

--- a/src/console.h
+++ b/src/console.h
@@ -1,10 +1,10 @@
 #pragma once
 
-/**
- * Taken from: https://github.com/xournalpp/xournalpp/blob/700308a27457116ae804429631d5f31a525ff9b7/src/exe/win32/console.h
- */
+#ifdef _WIN32
 
 /**
- * Allocates a new (hidden) console and associates the standard input and output handles with it.
+ * Detatches console if not needed (if parent process is not cmd.exe or powershell.exe)
  */
-void attachConsole();
+void hideConsoleIfNotNeeded();
+
+#endif

--- a/src/console.h
+++ b/src/console.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/**
+ * Taken from: https://github.com/xournalpp/xournalpp/blob/700308a27457116ae804429631d5f31a525ff9b7/src/exe/win32/console.h
+ */
+
+/**
+ * Allocates a new (hidden) console and associates the standard input and output handles with it.
+ */
+void attachConsole();

--- a/src/console.vapi
+++ b/src/console.vapi
@@ -1,5 +1,5 @@
 [CCode (cheader_filename = "console.h")]
 namespace Console {
-    [CCode (cname = "attachConsole")]
-    public void attachConsole();
+    [CCode (cname = "hideConsoleIfNotNeeded")]
+    public void hideConsoleIfNotNeeded();
 }

--- a/src/console.vapi
+++ b/src/console.vapi
@@ -1,0 +1,5 @@
+[CCode (cheader_filename = "console.h")]
+namespace Console {
+    [CCode (cname = "attachConsole")]
+    public void attachConsole();
+}

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -209,17 +209,21 @@ namespace pdfpc {
                 userProvider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
 
             string distCssPath;
+#if WIN
+            distCssPath = ResourceLocator.getResourcePath("css/pdfpc.css");
+#else
             if (Options.no_install) {
                 distCssPath = Path.build_filename(Paths.SOURCE_PATH, "css/pdfpc.css");
             } else {
                 distCssPath = Path.build_filename(Paths.SHARE_PATH, "css/pdfpc.css");
             }
+#endif
             var legacyUserCssPath = Path.build_filename(GLib.Environment.get_user_config_dir(), "pdfpc.css");
             var userCssPath = Path.build_filename(GLib.Environment.get_user_config_dir(), "pdfpc", "pdfpc.css");
 
             try {
                 // pdfpc.css in dist path is mandatory
-                if (GLib.FileUtils.test(distCssPath, (GLib.FileTest.IS_REGULAR))) {
+                if (distCssPath != null && GLib.FileUtils.test(distCssPath, (GLib.FileTest.IS_REGULAR))) {
                     globalProvider.load_from_path(distCssPath);
                 } else {
                     GLib.printerr("No CSS file found\n");
@@ -284,6 +288,11 @@ namespace pdfpc {
             ConfigFileReader configFileReader = new ConfigFileReader();
 
             string systemConfig;
+#if WIN
+            if ((systemConfig = ResourceLocator.getResourcePath("etc/pdfpcrc")) == null){
+                systemConfig = ResourceLocator.getResourcePath("rc/pdfpcrc");
+            }
+#else
             if (Options.no_install) {
                 systemConfig = Path.build_filename(Paths.SOURCE_PATH,
                     "rc/pdfpcrc");
@@ -291,6 +300,7 @@ namespace pdfpc {
                 systemConfig = Path.build_filename(Paths.CONF_PATH,
                     "pdfpcrc");
             }
+#endif
             configFileReader.readConfig(systemConfig);
 
             // First, try the XDG config directory

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -247,7 +247,7 @@ namespace pdfpc {
          */
         public void run(string[] args) {
 #if WIN
-            Console.attachConsole();
+            Console.hideConsoleIfNotNeeded();
 #endif
 #if X11
             X.init_threads();

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -246,6 +246,9 @@ namespace pdfpc {
          * initializes the Gtk system.
          */
         public void run(string[] args) {
+#if WIN
+            Console.attachConsole();
+#endif
 #if X11
             X.init_threads();
 #endif

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -293,7 +293,9 @@ namespace pdfpc {
             string systemConfig;
 #if WIN
             if ((systemConfig = ResourceLocator.getResourcePath("etc/pdfpcrc")) == null){
-                systemConfig = ResourceLocator.getResourcePath("rc/pdfpcrc");
+                if ((systemConfig = ResourceLocator.getResourcePath("rc/pdfpcrc")) == null) {
+                    GLib.printerr("system pdfpcrc could not be found");
+                }
             }
 #else
             if (Options.no_install) {
@@ -304,7 +306,9 @@ namespace pdfpc {
                     "pdfpcrc");
             }
 #endif
-            configFileReader.readConfig(systemConfig);
+            if (systemConfig != null) {
+                configFileReader.readConfig(systemConfig);
+            }
 
             // First, try the XDG config directory
             var userConfig =

--- a/src/procinfo.c
+++ b/src/procinfo.c
@@ -1,0 +1,9 @@
+#ifdef _WIN32
+#include <Windows.h>
+#include "console.h"
+
+void GetProcessPath(char **path_array, int *path_length) {
+    GetModuleFileNameA(NULL, *path_array, *path_length);
+} 
+
+#endif

--- a/src/procinfo.h
+++ b/src/procinfo.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <Windows.h>
+
+const int MAX_PATH_LENTH = MAX_PATH + 1; 
+
+void GetProcessPath(char **path_array, int *path_length);
+
+#endif

--- a/src/procinfo.vapi
+++ b/src/procinfo.vapi
@@ -1,0 +1,8 @@
+[CCode (cheader_filename = "procinfo.h")]
+namespace ProcInfo {
+    [CCode (cname = "MAX_PATH_LENTH")]
+    public const int MAX_PATH_LENTH;
+
+    [CCode (cname = "GetProcessPath")]
+    public void GetProcessPath(ref char[] path);
+}

--- a/windows-setup/FileAssociation.nsh
+++ b/windows-setup/FileAssociation.nsh
@@ -1,0 +1,190 @@
+/*
+_____________________________________________________________________________
+ 
+                       File Association
+_____________________________________________________________________________
+ 
+ Based on code taken from http://nsis.sourceforge.net/File_Association 
+ 
+ Usage in script:
+ 1. !include "FileAssociation.nsh"
+ 2. [Section|Function]
+      ${FileAssociationFunction} "Param1" "Param2" "..." $var
+    [SectionEnd|FunctionEnd]
+ 
+ FileAssociationFunction=[RegisterExtension|UnRegisterExtension]
+ 
+_____________________________________________________________________________
+ 
+ ${RegisterExtension} "[executable]" "[extension]" "[description]"
+ 
+"[executable]"     ; executable which opens the file format
+                   ;
+"[extension]"      ; extension, which represents the file format to open
+                   ;
+"[description]"    ; description for the extension. This will be display in Windows Explorer.
+                   ;
+ 
+ 
+ ${UnRegisterExtension} "[extension]" "[description]"
+ 
+"[extension]"      ; extension, which represents the file format to open
+                   ;
+"[description]"    ; description for the extension. This will be display in Windows Explorer.
+                   ;
+ 
+_____________________________________________________________________________
+ 
+                         Macros
+_____________________________________________________________________________
+ 
+ Change log window verbosity (default: 3=no script)
+ 
+ Example:
+ !include "FileAssociation.nsh"
+ !insertmacro RegisterExtension
+ ${FileAssociation_VERBOSE} 4   # all verbosity
+ !insertmacro UnRegisterExtension
+ ${FileAssociation_VERBOSE} 3   # no script
+*/
+ 
+ 
+!ifndef FileAssociation_INCLUDED
+!define FileAssociation_INCLUDED
+ 
+!include Util.nsh
+ 
+!verbose push
+!verbose 3
+!ifndef _FileAssociation_VERBOSE
+  !define _FileAssociation_VERBOSE 3
+!endif
+!verbose ${_FileAssociation_VERBOSE}
+!define FileAssociation_VERBOSE `!insertmacro FileAssociation_VERBOSE`
+!verbose pop
+ 
+!macro FileAssociation_VERBOSE _VERBOSE
+  !verbose push
+  !verbose 3
+  !undef _FileAssociation_VERBOSE
+  !define _FileAssociation_VERBOSE ${_VERBOSE}
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!macro RegisterExtensionCall _EXECUTABLE _EXTENSION _DESCRIPTION
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+  Push `${_DESCRIPTION}`
+  Push `${_EXTENSION}`
+  Push `${_EXECUTABLE}`
+  ${CallArtificialFunction} RegisterExtension_
+  !verbose pop
+!macroend
+ 
+!macro UnRegisterExtensionCall _EXTENSION _DESCRIPTION
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+  Push `${_EXTENSION}`
+  Push `${_DESCRIPTION}`
+  ${CallArtificialFunction} UnRegisterExtension_
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!define RegisterExtension `!insertmacro RegisterExtensionCall`
+!define un.RegisterExtension `!insertmacro RegisterExtensionCall`
+ 
+!macro RegisterExtension
+!macroend
+ 
+!macro un.RegisterExtension
+!macroend
+ 
+!macro RegisterExtension_
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+ 
+  Exch $R2 ;exe
+  Exch
+  Exch $R1 ;ext
+  Exch
+  Exch 2
+  Exch $R0 ;desc
+  Exch 2
+  Push $0
+  Push $1
+ 
+  ReadRegStr $1 HKCR $R1 ""  ; read current file association
+  StrCmp "$1" "" NoBackup  ; is it empty
+  StrCmp "$1" "$R0" NoBackup  ; is it our own
+    WriteRegStr HKCR $R1 "backup_val" "$1"  ; backup current value
+NoBackup:
+  WriteRegStr HKCR $R1 "" "$R0"  ; set our file association
+ 
+  ReadRegStr $0 HKCR $R0 ""
+  StrCmp $0 "" 0 Skip
+    WriteRegStr HKCR "$R0" "" "$R0"
+    WriteRegStr HKCR "$R0\shell" "" "open"
+    WriteRegStr HKCR "$R0\DefaultIcon" "" "$R2,0"
+Skip:
+  WriteRegStr HKCR "$R0\shell\open\command" "" '"$R2" "%1"'
+  WriteRegStr HKCR "$R0\shell\edit" "" "Edit $R0"
+  WriteRegStr HKCR "$R0\shell\edit\command" "" '"$R2" "%1"'
+ 
+  Pop $1
+  Pop $0
+  Pop $R2
+  Pop $R1
+  Pop $R0
+ 
+  !verbose pop
+!macroend
+ 
+ 
+ 
+!define UnRegisterExtension `!insertmacro UnRegisterExtensionCall`
+!define un.UnRegisterExtension `!insertmacro UnRegisterExtensionCall`
+ 
+!macro UnRegisterExtension
+!macroend
+ 
+!macro un.UnRegisterExtension
+!macroend
+ 
+!macro UnRegisterExtension_
+  !verbose push
+  !verbose ${_FileAssociation_VERBOSE}
+ 
+  Exch $R1 ;desc
+  Exch
+  Exch $R0 ;ext
+  Exch
+  Push $0
+  Push $1
+ 
+  ReadRegStr $1 HKCR $R0 ""
+  StrCmp $1 $R1 0 NoOwn ; only do this if we own it
+  ReadRegStr $1 HKCR $R0 "backup_val"
+  StrCmp $1 "" 0 Restore ; if backup="" then delete the whole key
+  DeleteRegKey HKCR $R0
+  Goto NoOwn
+ 
+Restore:
+  WriteRegStr HKCR $R0 "" $1
+  DeleteRegValue HKCR $R0 "backup_val"
+  DeleteRegKey HKCR $R1 ;Delete key with association name settings
+ 
+NoOwn:
+ 
+  Pop $1
+  Pop $0
+  Pop $R1
+  Pop $R0
+ 
+  !verbose pop
+!macroend
+ 
+!endif # !FileAssociation_INCLUDED

--- a/windows-setup/make_version_nsh.sh
+++ b/windows-setup/make_version_nsh.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+version=$( head -n 1 ../src/pdfpc.version )
+cat << EOF > pdfpc_version.nsh
+!define PDFPC_VERSION "$version"
+EOF

--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Windows packaging script. This does the following:
+# 1. Run "install" target from CMake into setup folder
+# 2. Copy runtime dependencies into setup folder
+# 3. Create version file and execute NSIS to create installer
+
+# go to script directory
+cd $(dirname $(readlink -f "$0"))
+# delete old setup, if there
+echo "clean dist folder"
+
+setup_dir=dist
+
+rm -rf "$setup_dir"
+rm -rf pdfpc-setup.exe
+
+mkdir "$setup_dir"
+mkdir "$setup_dir"/lib
+mkdir -p ../build
+
+echo "copy installed files"
+(cd ../build && cmake .. -DMDVIEW=OFF -DCMAKE_MAKE_PROGRAM=ninja -DMOVIES=ON -DCMAKE_INSTALL_PREFIX= && DESTDIR=../windows-setup/"$setup_dir" cmake --build . --target install)
+
+echo $(pwd)
+echo "copy libraries"
+ldd ../build/bin/pdfpc.exe | grep '\/mingw.*\.dll' -o | sort -u | xargs -I{} cp "{}" "$setup_dir"/bin/
+
+echo "copy pixbuf libs"
+cp -r /mingw64/lib/gdk-pixbuf-2.0 "$setup_dir"/lib/
+
+echo "copy pixbuf lib dependencies"
+ldd /mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll | grep '\/mingw.*\.dll' -o | xargs -I{} cp "{}" "$setup_dir"/bin/
+
+echo "copy icons"
+cp -r /mingw64/share/icons "$setup_dir"/share/
+
+echo "copy glib shared"
+cp -r /mingw64/share/glib-2.0 "$setup_dir"/share/
+
+echo "copy poppler shared"
+cp -r /mingw64/share/poppler "$setup_dir"/share/
+
+echo "copy gspawn-win64-helper"
+cp /mingw64/bin/gspawn-win64-helper.exe "$setup_dir"/bin
+cp /mingw64/bin/gspawn-win64-helper-console.exe "$setup_dir"/bin
+
+echo "copy gdbus"
+cp /mingw64/bin/gdbus.exe "$setup_dir"/bin
+
+echo "create installer"
+bash make_version_nsh.sh
+exit
+"/c/Program Files (x86)/NSIS/Bin/makensis.exe" pdfpc.nsi
+
+echo "finished"

--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -5,6 +5,8 @@
 # 2. Copy runtime dependencies into setup folder
 # 3. Create version file and execute NSIS to create installer
 
+set -e
+
 # go to script directory
 cd $(dirname $(readlink -f "$0"))
 # delete old setup, if there

--- a/windows-setup/package.sh
+++ b/windows-setup/package.sh
@@ -20,7 +20,7 @@ mkdir "$setup_dir"/lib
 mkdir -p ../build
 
 echo "copy installed files"
-(cd ../build && cmake .. -DMDVIEW=OFF -DCMAKE_MAKE_PROGRAM=ninja -DMOVIES=ON -DCMAKE_INSTALL_PREFIX= && DESTDIR=../windows-setup/"$setup_dir" cmake --build . --target install)
+(cd ../build && cmake .. -DMDVIEW=OFF -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE=Release -DMOVIES=ON -DCMAKE_INSTALL_PREFIX= && DESTDIR=../windows-setup/"$setup_dir" cmake --build . --target install)
 
 echo $(pwd)
 echo "copy libraries"
@@ -50,7 +50,6 @@ cp /mingw64/bin/gdbus.exe "$setup_dir"/bin
 
 echo "create installer"
 bash make_version_nsh.sh
-exit
 "/c/Program Files (x86)/NSIS/Bin/makensis.exe" pdfpc.nsi
 
 echo "finished"

--- a/windows-setup/pdfpc.nsi
+++ b/windows-setup/pdfpc.nsi
@@ -1,0 +1,248 @@
+; pdfpc NSIS installation script for Windows
+; Original Authors: The Xournal++ Team (https://github.com/xournalpp/xournalpp/)
+; Adapted for pdfpc: malex14
+
+;--------------------------------
+; NSIS setup
+
+Unicode true
+
+;--------------------------------
+; Includes
+
+!include "MUI2.nsh"
+!include x64.nsh
+!include "FileAssociation.nsh"
+!include nsDialogs.nsh
+!include "pdfpc_version.nsh"
+
+;--------------------------------
+; Initialization
+
+Function .onInit
+	${If} ${RunningX64}
+		# 64 bit code
+		SetRegView 64
+	${Else}
+		# 32 bit code
+		MessageBox MB_OK "pdfpc requires 64-bit Windows. Sorry!"
+		Abort
+	${EndIf}
+FunctionEnd
+
+; Name and file
+Name "pdfpc ${PDFPC_VERSION}"
+OutFile "pdfpc-setup.exe"
+
+; Default installation folder
+InstallDir $PROGRAMFILES64\pdfpc
+
+; Get installation folder from registry if available
+InstallDirRegKey HKLM "Software\pdfpc" ""
+
+; Request admin privileges for installation
+RequestExecutionLevel admin
+
+;--------------------------------
+; Variables
+
+Var StartMenuFolder
+
+;--------------------------------
+; Interface Settings
+
+!define MUI_ABORTWARNING
+
+;--------------------------------
+; Pages
+!insertmacro MUI_PAGE_WELCOME
+;Page custom InstallScopePage InstallScopePageLeave
+!insertmacro MUI_PAGE_LICENSE "..\LICENSE.txt"
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_DIRECTORY
+
+;Start Menu Folder Page Configuration
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT "HKLM"
+!define MUI_STARTMENUPAGE_REGISTRY_KEY "Software\pdfpc"
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "StartMenuEntry"
+!define MUI_STARTMENUPAGE_DEFAULTFOLDER "pdfpc"
+
+!insertmacro MUI_PAGE_STARTMENU Application $StartMenuFolder
+
+!insertmacro MUI_PAGE_INSTFILES
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+;--------------------------------
+; Languages
+
+!insertmacro MUI_LANGUAGE "English"
+
+;-------------------------------
+; Uninstall previous version
+
+Section "" SecUninstallPrevious
+	ReadRegStr $R0 HKLM "Software\pdfpc" ""
+	${If} $R0 != ""
+        DetailPrint "Removing previous version located at $R0"
+		ExecWait '"$R0\Uninstall.exe /S"' 
+    ${EndIf}
+SectionEnd
+
+;-------------------------------
+; File association macros
+; see https://docs.microsoft.com/en-us/windows/win32/shell/fa-file-types#registering-a-file-type
+
+!macro SetDefaultExt EXT PROGID
+	WriteRegStr HKLM "Software\Classes\${EXT}" "" "${PROGID}"
+!macroend
+
+!macro RegisterExt EXT PROGID
+	WriteRegStr HKLM "Software\Classes\${EXT}\OpenWithProgIds" "${PROGID}" ""
+	WriteRegStr HKLM "Software\Classes\Applications\pdfpc.exe\SupportedTypes" "${EXT}" ""
+!macroend
+
+!macro AddProgId PROGID CMD DESC
+	; Define ProgId. See https://docs.microsoft.com/en-us/windows/win32/shell/fa-progids
+	WriteRegStr HKLM "Software\Classes\${PROGID}" "" "${DESC}"
+	WriteRegStr HKLM "Software\Classes\${PROGID}\DefaultIcon" "" '"${CMD}",0'
+	WriteRegStr HKLM "Software\Classes\${PROGID}\shell" "" "open"
+	WriteRegStr HKLM "Software\Classes\${PROGID}\shell\open\command" "" '"${CMD}" "%1"'
+	WriteRegStr HKLM "Software\Classes\${PROGID}\shell\edit" "" "Edit with pdfpc"
+	WriteRegStr HKLM "Software\Classes\${PROGID}\shell\edit\command" "" '"${CMD}" "%1"'
+!macroend
+
+!macro DeleteProgId PROGID
+	; See https://docs.microsoft.com/en-us/windows/win32/shell/fa-file-types#deleting-registry-information-during-uninstallation
+	DeleteRegKey HKLM "Software\Classes\${PROGID}"
+!macroend
+
+!define SHCNE_ASSOCCHANGED 0x08000000
+!define SHCNE_CREATE 0x2
+!define SHCNE_DELETE 0x4
+
+!define SHCNF_IDLIST 0x0
+!define SHCNF_PATH 0x1
+!define SHCNF_FLUSH 0x1000
+!macro RefreshShellIcons
+	; Refresh shell icons. See https://nsis.sourceforge.io/Refresh_shell_icons
+	DetailPrint "Refreshing shell file associations"
+	System::Call "shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_FLUSH} | ${SHCNF_IDLIST}, i 0, i 0)"
+!macroend
+
+!macro RefreshShellIconCreate FILEPATH
+	DetailPrint "Refreshing shell icon create ${FILEPATH}"
+	System::Call 'shell32::SHChangeNotify(i ${SHCNE_CREATE}, i ${SHCNF_FLUSH} | ${SHCNF_PATH}, w "${FILEPATH}", i 0)'
+!macroend
+
+!macro RefreshShellIconDelete FILEPATH
+	DetailPrint "Refreshing shell icon delete ${FILEPATH}"
+	System::Call 'shell32::SHChangeNotify(i ${SHCNE_DELETE}, i ${SHCNF_FLUSH} | ${SHCNF_PATH}, w "${FILEPATH}", i 0)'
+!macroend
+
+;-------------------------------
+; Installer Sections
+
+Section "Associate .pdf files with pdfpc" SecFilePdf
+	!insertmacro SetDefaultExt ".pdf" "pdfpc.pdf"
+SectionEnd
+
+
+Section "pdfpc" SecPdfpc
+	; Required
+	SectionIn RO
+
+	SetOutPath "$INSTDIR"
+
+	; Files to put into the setup
+	File /r "dist\*"
+
+	; Set install information
+	WriteRegStr HKLM "Software\pdfpc" "" '$INSTDIR'
+
+	; Set program information
+	WriteRegStr HKLM "Software\Classes\Applications\pdfpc.exe" "" '"$INSTDIR\bin\pdfpc.exe"'
+	WriteRegStr HKLM "Software\Classes\Applications\pdfpc.exe" "FriendlyAppName" "pdfpc"
+	WriteRegExpandStr HKLM "Software\Classes\Applications\pdfpc.exe" "DefaultIcon" '"$INSTDIR\bin\pdfpc.exe",0'
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\App Paths\pdfpc.exe" "" '"$INSTDIR\bin\pdfpc.exe"'
+
+	; Add file type information
+	!insertmacro RegisterExt ".pdf" "pdfpc.pdf"
+	push $R0
+	StrCpy $R0 "$INSTDIR\bin\pdfpc.exe"
+	!insertmacro AddProgId "pdfpc.pdf" "$R0" "PDF file"
+	pop $R0
+
+	; Create uninstaller
+	WriteUninstaller "$INSTDIR\Uninstall.exe"
+	; Add uninstall entry. See https://docs.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "DisplayIcon" '"$INSTDIR\bin\pdfpc.exe"'
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "DisplayName" "pdfpc"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "DisplayVersion" "${PDFPC_VERSION}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "Publisher" "The pdfpc Team"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "URLInfoAbout" "https://pdfpc.github.io"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "InstallLocation" '"$INSTDIR"'
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "UninstallString" '"$INSTDIR\Uninstall.exe"'
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "NoModify" 1
+	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc" "NoRepair" 1
+
+	!insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+	;Create shortcuts
+	CreateDirectory "$SMPROGRAMS\$StartMenuFolder"
+	CreateShortcut "$SMPROGRAMS\$StartMenuFolder\pdfpc.lnk" '"$INSTDIR\bin\pdfpc.exe"'
+	CreateShortcut "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk" '"$INSTDIR\Uninstall.exe"'
+		
+	!insertmacro RefreshShellIconCreate "$SMPROGRAMS\$StartMenuFolder\pdfpc.lnk"
+	!insertmacro RefreshShellIconCreate "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
+	!insertmacro MUI_STARTMENU_WRITE_END
+
+	!insertmacro RefreshShellIcons
+SectionEnd
+
+;--------------------------------
+; Descriptions
+
+; Language strings
+LangString DESC_SecPdfpc ${LANG_ENGLISH} "pdfpc executable"
+LangString DESC_SecFilePdf ${LANG_ENGLISH} "Open .pdf files with pdfpc"
+
+; Assign language strings to sections
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+	!insertmacro MUI_DESCRIPTION_TEXT ${SecPdfpc} $(DESC_SecPdfpc)
+	!insertmacro MUI_DESCRIPTION_TEXT ${SecFilePdf} $(DESC_SecFilePdf)
+!insertmacro MUI_FUNCTION_DESCRIPTION_END
+
+;--------------------------------
+; Uninstaller
+
+Section "Uninstall"
+
+	SetRegView 64
+
+	; Remove registry keys
+	DeleteRegKey HKLM "Software\pdfpc"
+	DeleteRegKey HKLM "Software\Classes\Applications\pdfpc.exe"
+	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\App Paths\pdfpc.exe"
+	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\pdfpc"
+
+	!insertmacro DeleteProgId "pdfpc.pdf"
+
+	; Clean up start menu
+	!insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
+	Delete "$SMPROGRAMS\$StartMenuFolder\pdfpc.lnk"
+	Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
+	RMDir "$SMPROGRAMS\$StartMenuFolder"
+
+	; Remove files
+	RMDir /r "$INSTDIR\bin"
+	RMDir /r "$INSTDIR\lib"
+	RMDir /r "$INSTDIR\share"
+	RMDir /r "$INSTDIR\etc"
+	Delete "$INSTDIR\Uninstall.exe"
+	RMDir "$INSTDIR"
+
+	!insertmacro RefreshShellIconDelete "$SMPROGRAMS\$StartMenuFolder\pdfpc.lnk"
+	!insertmacro RefreshShellIconDelete "$SMPROGRAMS\$StartMenuFolder\Uninstall.lnk"
+	!insertmacro RefreshShellIcons
+SectionEnd

--- a/windows-setup/pdfpc.nsi
+++ b/windows-setup/pdfpc.nsi
@@ -109,8 +109,6 @@ SectionEnd
 	WriteRegStr HKLM "Software\Classes\${PROGID}\DefaultIcon" "" '"${CMD}",0'
 	WriteRegStr HKLM "Software\Classes\${PROGID}\shell" "" "open"
 	WriteRegStr HKLM "Software\Classes\${PROGID}\shell\open\command" "" '"${CMD}" "%1"'
-	WriteRegStr HKLM "Software\Classes\${PROGID}\shell\edit" "" "Edit with pdfpc"
-	WriteRegStr HKLM "Software\Classes\${PROGID}\shell\edit\command" "" '"${CMD}" "%1"'
 !macroend
 
 !macro DeleteProgId PROGID


### PR DESCRIPTION
This pr adds a windows installer for pdfpc that is based on NSIS. In order to be able to install the program to different locations or on systems where "C:\\" isn't the system-drive, i had to add the functionality that the program searches for its resources relative to the executable. As a side-effect the program could now also be distributed as a "portable" version, since paths aren't compiled in the binary. I've updated the Github Windows workflow to create the installer and upload it as an artifact. In addition the console window which would open at launch gets now hidden.

(Some of the code for the installer is based on the work from Xournal++ which is also GPL)