### PR TITLE
Allow compiling with markdown3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
 project("pdfpc" C)
+cmake_minimum_required(VERSION 3.7)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/vala)
 

--- a/README.rst
+++ b/README.rst
@@ -97,14 +97,14 @@ Requirements
 
 In order to compile and run pdfpc, the following requirements need to be met:
 
-- cmake >= 3.5
+- cmake >= 3.7
 - vala  >= 0.48
 - gtk+  >= 3.22
 - gee   >= 0.8
 - poppler >= 0.8 with glib bindings
 - pangocairo
 - gstreamer >= 1.0 with gst-plugins-good
-- discount (aka markdown2)
+- discount (aka markdown2 or 3)
 - webkit2gtk
 - json-glib
 - libsoup3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,10 @@ if (MDVIEW OR REST)
     pkg_check_modules(MARKDOWN REQUIRED libmarkdown)
 endif ()
 
+if ("${MARKDOWN_VERSION}" VERSION_GREATER_EQUAL 3)
+    set(EXTRA_VALA_OPTIONS ${EXTRA_VALA_OPTIONS} -D MARKDOWN3)
+endif ()
+
 if (MDVIEW)
     pkg_check_modules(WEBKIT REQUIRED webkit2gtk-4.1)
     set(MDVIEW_PACKAGES webkit2gtk-4.1)

--- a/src/classes/renderer/markdown.vala
+++ b/src/classes/renderer/markdown.vala
@@ -23,7 +23,12 @@
 namespace pdfpc.Renderer {
     public class MD {
         public static string render(string? text = "", bool plain_text = false) {
+#if MARKDOWN3
+            var flags = new Markdown.DocumentFlags();
+            flags.set(Markdown.DocumentFlag.NO_EXT);
+#else
             Markdown.DocumentFlags flags = Markdown.DocumentFlags.NO_EXT;
+#endif
 
             string html;
             if (text != "" && plain_text) {

--- a/src/libmarkdown.vapi
+++ b/src/libmarkdown.vapi
@@ -95,9 +95,23 @@ namespace Markdown
 		public void ref_prefix (string prefix);
 	}
 
+#if MARKDOWN3
+	[Compact]
+	[CCode (cname = "mkd_flag_t", free_function = "mkd_free_flags")]
+	public class DocumentFlags {
+		[CCode (cname = "mkd_flags")]
+        public DocumentFlags();
+		[CCode (cname = "mkd_set_flag_num")]
+		public void set (DocumentFlag flag);
+    }
+
+	[CCode (cprefix = "MKD_")]
+	public enum DocumentFlag
+#else
 	[Flags]
 	[CCode (cname = "mkd_flag_t", cprefix = "MKD_")]
 	public enum DocumentFlags
+#endif
 	{
 		NOLINKS,
 		NOIMAGE,


### PR DESCRIPTION
Currently compilation fails with:

    /build/src/classes/renderer/markdown.c:191:20: error: variable or field 'flags' declared void

According to comment [1], markdown3 introduces backward incompatibility with respect to document flags.

This commit adds conditionally compiled code that allows building pdfpc with both markdown versions 2 and 3.

Fixes #682

[1]: https://github.com/pdfpc/pdfpc/issues/682#issuecomment-1931300154