### PR TITLE
FAQ.rst Mac presenter view workaround

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -56,7 +56,7 @@ set to "always":
     "system settings > desktop and dock > prefer tabs when opening documents" set to always
 
 This option forces pdfpc to open the presentation view as a second tab, the window is then
-maximized and it is longer visible. 
+maximized and the tabs are no longer visible. 
 
 Change this system setting to "never" on Mac to restore the expected behavior from pdfpc.
 

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -44,3 +44,28 @@ If you are using i3-wm add this to your config file::
 
     for_window [ title="^pdfpc - present" ] border none floating enable
 
+No presenter view showing (Mac only workaround)
+===========================================
+
+Current for Sonoma 14.5, updated 8/14/24.
+
+If no presenter view is showing, or if the presenter view flashes briefly then
+disappears, you likely have the Mac option "prefer tabs when opening documents"
+set to "always":
+
+    "system settings > desktop and dock > prefer tabs when opening documents" set to always
+
+This option forces pdfpc to open the presentation view as a second tab, the window is then
+maximized and it is longer visible. 
+
+Change this system setting to "never" on Mac to restore the expected behavior from pdfpc.
+
+    "system settings > desktop and dock > prefer tabs when opening documents" set to never
+
+An alternative to this, and potentially other window tiling managers, is to launch
+pdfpc in a dimensioned window such as:
+
+    pdfpc -Z 1000:1000 presentation.pdf
+
+In this way we can see the tabs for presentation and presenter views, and manually drag them
+to the screens we desire.

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -63,7 +63,7 @@ Change this system setting to "never" on Mac to restore the expected behavior fr
     "system settings > desktop and dock > prefer tabs when opening documents" set to never
 
 An alternative to this, and potentially other window tiling managers, is to launch
-pdfpc in a dimensioned window such as:
+pdfpc in a dimensioned window such as::
 
     pdfpc -Z 1000:1000 presentation.pdf
 

--- a/FAQ.rst
+++ b/FAQ.rst
@@ -44,7 +44,7 @@ If you are using i3-wm add this to your config file::
 
     for_window [ title="^pdfpc - present" ] border none floating enable
 
-No presenter view showing (Mac only workaround)
+No presenter view showing (Mac workaround)
 ===========================================
 
 Current for Sonoma 14.5, updated 8/14/24.


### PR DESCRIPTION
Added 2 workarounds for issues with Mac presenter view not opening properly. 

The first is the proper fix related to a global system setting, and the second is the pdfpc utility used to diagnose the issue. The latter may be helpful when diagnosing or using pdfpc with other window tiling managers.