### PR TITLE
Make windowed mode toggle apply to all windows

### DIFF
--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -1868,7 +1868,8 @@ namespace pdfpc {
         protected void toggle_windowed() {
             if (this.presenter != null) {
                 this.presenter.toggle_windowed();
-            } else if (this.presentation != null) {
+            }
+            if (this.presentation != null) {
                 this.presentation.toggle_windowed();
             }
         }


### PR DESCRIPTION
This fixes #715.

One use case for this making presentations over video conference when you only have a single monitor. You can have presenter and presentation windows on different desktops and share just the presentation window. This PR allows you to make the presentation window fullscreen so that window decoration doesn't get included in the screen share.

It might be better if presenter and presentation windows can be toggled separately, but that would be a more substantial change. I can try to revise the PR to do that if needed.