### PR TITLE
fix: CMake 4 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.7...3.20)
 project("pdfpc" C)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/vala)


### PR DESCRIPTION
From https://github.com/pdfpc/pdfpc/pull/750#discussion_r2074850888 - this sets the polixy max to 3.20 to avoid a warning about removed compatibility with older versions in CMake 4. This isn't a strict minimum or maximum version. Looking at [repology for `cmake`](https://repology.org/project/cmake/badges), this seems like a sane choice.