### PR TITLE
feat: package for Windows

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -43,9 +43,26 @@ jobs:
           mingw-w64-x86_64-qrencode
           mingw-w64-x86_64-discount
           mingw-w64-x86_64-imagemagick
+          mingw-w64-x86_64-gst-plugins-good
+          mingw-w64-x86_64-gst-plugin-gtk
 
     - name: Configure CMake
       run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_MAKE_PROGRAM=ninja -DMDVIEW=OFF
 
     - name: Build
       run: cd build && ninja
+
+    - name: Package
+      working-directory: build
+      shell: powershell
+      run: |
+        cpack -G NSIS
+        cpack -G 7Z
+        rm -Recurse -Force packaged/_CPack_Packages
+
+    - name: Upload Packages
+      uses: actions/upload-artifact@v4
+      with:
+        # this will upload _one_ ZIP file
+        name: packages
+        path: build/packaged/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,48 @@ option(MOVIES "Compile support for movie playback (requires gstreamer)" ON)
 option(MDVIEW "Enable viewing Markdown notes (requires webkit2gtk)" ON)
 option(REST "Compile support for REST server (requires libsoup and libqrencode)" ON)
 
+set(CPACK_VERBATIM_VARIABLES YES)
+set(CPACK_PACKAGE_DIRECTORY "${CMAKE_BINARY_DIR}/packaged")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "PDF Presenter Console")
+set(CPACK_PACKAGE_VENDOR "pdfpc")
+
+# backslash is required for NSIS on Windows
+set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/icons\\pdfpc-presenter-small.bmp")
+set(CPACK_CREATE_DESKTOP_LINKS pdfpc)
+set(CPACK_PACKAGE_INSTALL_DIRECTORY pdfpc)
+
+# Options specifically for the NSIS installer (Windows)
+set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}/icons/pdfpc.ico")
+set(CPACK_NSIS_MUI_UNIICON "${CMAKE_SOURCE_DIR}/icons/pdfpc.ico")
+set(CPACK_NSIS_INSTALLED_ICON_NAME "$<TARGET_FILE:pdfpc>")
+set(CPACK_NSIS_MODIFY_PATH On) # "Add pdfpc to PATH?"
+set(CPACK_NSIS_CONTACT "https://github.com/pdfpc/pdfpc/issues")
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON) # ask about previously installed versions
+set(CPACK_NSIS_DEFINES "RequestExecutionLevel user")
+
+# File association
+# See https://learn.microsoft.com/en-us/windows/win32/shell/fa-file-types
+set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS [[
+    WriteRegStr SHCTX "Software\Classes\.pdf\OpenWithProgIds" "pdfpc.present" ""
+    WriteRegStr SHCTX "Software\Classes\Applications\pdfpc.exe\SupportedTypes" ".pdf" ""
+
+    WriteRegStr SHCTX "Software\Classes\pdfpc.present" "" "Present with pdfpc"
+    WriteRegStr SHCTX "Software\Classes\pdfpc.present\DefaultIcon" "" '"$INSTDIR\bin\pdfpc.exe",0'
+    WriteRegStr SHCTX "Software\Classes\pdfpc.present\shell" "" "open"
+    WriteRegStr SHCTX "Software\Classes\pdfpc.present\shell\open\command" "" '"$INSTDIR\bin\pdfpc.exe" "%1"'
+    System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
+]])
+
+set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS [[
+    DeleteRegKey SHCTX "Software\Classes\pdfpc.present"
+    System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
+]])
+
 add_subdirectory(src)
 add_subdirectory(icons)
 add_subdirectory(man)
 add_subdirectory(css)
 add_subdirectory(rc)
+
+include(CPack)

--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ On macOS with MacPorts, you can install all dependencies using the `port` comman
 
 On Windows with MSYS2/MinGW-w64, the dependencies are installed with::
 
-    pacman -S mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config mingw-w64-x86_64-vala mingw-w64-x86_64-libgee mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gstreamer mingw-w64-x86_64-gst-plugins-base mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsoup mingw-w64-x86_64-qrencode mingw-w64-x86_64-discount mingw-w64-x86_64-imagemagick
+    pacman -S mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config mingw-w64-x86_64-vala mingw-w64-x86_64-libgee mingw-w64-x86_64-poppler mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gstreamer mingw-w64-x86_64-gst-plugins-base mingw-w64-x86_64-json-glib mingw-w64-x86_64-libsoup mingw-w64-x86_64-qrencode mingw-w64-x86_64-discount mingw-w64-x86_64-imagemagick mingw-w64-x86_64-gst-plugins-good mingw-w64-x86_64-gst-plugin-gtk
 
 (change `x86_64` to `i686` if you want to compile the 32-bit variant).
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-link_directories(
+set(_link_directories 
     ${GOBJECT_LIBRARY_DIRS}
     ${GIO_LIBRARY_DIRS}
     ${GEE_LIBRARY_DIRS}
@@ -90,6 +90,8 @@ link_directories(
     ${SOUP_LIBRARY_DIRS}
     ${QRENCODE_LIBRARY_DIRS}
 )
+
+link_directories(${_link_directories})
 
 if(${WITH_X11})
     include_directories(${X11_INCLUDE_DIRS})
@@ -223,9 +225,100 @@ if(WIN32)
     set_property(SOURCE "${_windows_rc}" APPEND PROPERTY OBJECT_DEPENDS "${_windows_ico}")
 endif()
 
-install(TARGETS
-    pdfpc
-RUNTIME
-DESTINATION
-    bin
-)
+if(MINGW)
+    # Deployment of libraries for installation
+    list(REMOVE_DUPLICATES _link_directories) # there should only be one directory here
+    list(LENGTH _link_directories _len)
+    if(_len EQUAL 1)
+        # _link_directories is path/to/mingw64/lib
+        cmake_path(SET _mingw_dir NORMALIZE "${_link_directories}/..")
+    else()
+        if(PDFPC_MINGW_ROOT_DIR)
+            cmake_path(SET _mingw_dir NORMALIZE "${PDFPC_MINGW_ROOT_DIR}")
+        else()
+            message(FATAL_ERROR "The shared libraries come from different locations - set PDFPC_MINGW_ROOT_DIR")
+        endif()
+    endif()
+    set(_mingw_bin "${_mingw_dir}/bin")
+    set(_mingw_share "${_mingw_dir}/share")
+
+    # install gdbus.exe and gspawn-win64-helper*.exe
+    install(
+        PROGRAMS
+            "${_mingw_bin}/gdbus.exe"
+            "${_mingw_bin}/gspawn-win64-helper.exe"
+            "${_mingw_bin}/gspawn-win64-helper-console.exe"
+        DESTINATION
+            bin
+    )
+
+    # install mingw shared folders
+    install(
+        DIRECTORY
+            "${_mingw_share}/icons"
+            "${_mingw_share}/glib-2.0"
+            "${_mingw_share}/poppler"
+        DESTINATION
+            share
+    )
+    
+    # gdk-pixbuf
+    # some loaders (such as the svg loader) have additional dependencies
+    file(GLOB_RECURSE _additional_dlls "${_mingw_dir}/lib/gdk-pixbuf-2.0/**/*.dll")
+    file(GLOB_RECURSE _gst_dlls "${_mingw_dir}/lib/gstreamer-1.0/*.dll")
+    list(APPEND _additional_dlls ${_gst_dlls})
+    set(_install_tmpl [[
+        file(GET_RUNTIME_DEPENDENCIES
+            RESOLVED_DEPENDENCIES_VAR _pixbuf_deps
+            PRE_INCLUDE_REGEXES "^lib"
+            PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+            POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+            DIRECTORIES "@_mingw_bin@"
+            MODULES @_additional_dlls@
+        )
+        foreach(_dep IN LISTS _pixbuf_deps)
+            file(INSTALL 
+                DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
+                TYPE SHARED_LIBRARY
+                FILES ${_dep}
+                FOLLOW_SYMLINK_CHAIN
+            )
+        endforeach()
+    ]])
+    string(CONFIGURE "${_install_tmpl}" _install_code @ONLY)
+    install(CODE "${_install_code}")
+
+    install(
+        DIRECTORY
+            "${_mingw_dir}/lib/gdk-pixbuf-2.0"
+        DESTINATION
+            lib
+        PATTERN "*.a" EXCLUDE
+    )
+    install(
+        DIRECTORY
+            "${_mingw_dir}/lib/gstreamer-1.0"
+        DESTINATION
+            lib
+    )
+
+    # The actual executable
+    install(TARGETS
+            pdfpc
+        RUNTIME_DEPENDENCIES
+            PRE_INCLUDE_REGEXES "^lib"
+            PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-" # System DLLs
+            POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+            DIRECTORIES "${_mingw_bin}"
+        RUNTIME
+        DESTINATION
+            bin
+    )
+else()
+    install(TARGETS
+            pdfpc
+        RUNTIME
+        DESTINATION
+            bin
+    )
+endif()


### PR DESCRIPTION
This is quite big. It adds (proper) [`cpack`](https://cmake.org/cmake/help/latest/module/CPack.html) support for pdfpc. I chose the NSIS installer. The main other option would be InnoSetup. Both can do the same.
I moved `src/pdfpc.version` to CMake to avoid duplicating the project version. The installer will run in user mode, and it will add pdfpc as a file association for `.pdf`.

When installing, CMake will also install the dependencies from MinGW (this is equivalent to the dependencies that were installed in #700). Currently, only MingGW is "supported" for installing (once vcpkg can build glib, I could try to extend this).

I'll split up the `windows.rc` change, because it's not directly related, but this PR depends on it (done in #753).

Fixes #705.