### PR TITLE
feat: save drawings to PDF

### DIFF
--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -311,6 +311,9 @@ Select previous slide
 .TP
 .B Cursor right / Page down
 Select next slide
+.TP
+.B Ctrl + s
+Save drawings to PDF.
 
 .P
 See \fBpdfpcrc\fR(5) if you want to customize the key or mouse bindings. Please
@@ -538,8 +541,10 @@ different color, it shades the background.
 It is possible to turn on a mode which allows drawing over slides with the mouse
 cursor or a connected tablet.  When drawing mode is enabled, drawings can be made on
 the presenter screen. A separate drawing will be kept in memory for each slide
-(based on user slide numbers, so consolidating overlay slides). Drawings are presently not
-saved between sessions.
+(based on user slide numbers, so consolidating overlay slides). Drawings can be
+saved between sessions in the associated .pdfpc file. Enable this with \fBpersist-drawings\fR
+in your \fBpdfpcrc\fR(5). Drawings can also be exported to a PDF with \[aq]Ctrl + s\[aq].
+This opens a file dialog to save the annotated PDF.
 
 In the drawing mode, there are two drawing tools, a pen and an eraser. An indicator in the
 bottom-left corner of the presenter screen will indicate which is active. When in the pen mode,

--- a/man/pdfpcrc.in
+++ b/man/pdfpcrc.in
@@ -137,6 +137,9 @@ next slide view instead of the last slide of that group (bool, Default is false)
 .B overview-min-size
 Minimum width for the overview miniatures, in pixels (int, Default is 150).
 .TP
+.B persist-drawings
+Save the drawings to the associated .pdfpc file as JSON (bool, Default is false).
+.TP
 .B pointer-color
 Set the pointer color. Can be a literal color name or a #rrggbb representation
 (default is red).
@@ -182,6 +185,11 @@ generated one is used).
 Root path to serve static HTML content. If begins with "/", it is interpreted as
 the absolute path; otherwise, relative to @CMAKE_INSTALL_PREFIX@/share/pdfpc
 (string, Default is "www").
+.TP
+.B save-drawings-on-exit
+When closing pdfpc, save the drawings next to the PDF. They will be saved as
+"{pdf-name}-annotated-{date}.pdf" if enabled (string enum, one of "always",
+"never", Default is "never").
 .TP
 .B spotlight-opacity
 Set opacity of the area outside of the spotlight, in percent (int, default is

--- a/rc/pdfpcrc
+++ b/rc/pdfpcrc
@@ -110,6 +110,7 @@ bind C                  customize
 # Drawings
 bind c                  clearDrawing
 bind d                  toggleDrawings
+bind C+s                saveDrawings
 
 # Pen colors
 # Can be set by

--- a/src/classes/config_file_reader.vala
+++ b/src/classes/config_file_reader.vala
@@ -293,6 +293,9 @@ namespace pdfpc {
                 case "overview-min-size":
                     Options.min_overview_width = int.parse(fields[2]);
                     break;
+                case "persist-drawings":
+                    Options.persist_drawings = bool.parse(fields[2]);
+                    break;
                 case "pointer-color":
                     Options.pointer_color = fields[2];
                     break;
@@ -340,6 +343,9 @@ namespace pdfpc {
                     Options.rest_static_root = fields[2];
                     break;
 #endif
+                case "save-drawings-on-exit":
+                    Options.save_drawings_on_exit = Options.DrawingSaveOnExit.parse(fields[2]);
+                    break;
                 case "spotlight-opacity":
                     Options.spotlight_opacity = int.parse(fields[2]);
                     break;

--- a/src/classes/drawings/drawing.vala
+++ b/src/classes/drawings/drawing.vala
@@ -179,6 +179,65 @@ namespace pdfpc.Drawings {
             this.drawing_command_list.paint_in_surface(this.surface);
         }
 
+        public void store_all() {
+            if (this.surface != null) {
+                storage.store(this.current_slide, this.drawing_command_list);
+            }
+        }
+
+        /**
+         * Are there any slides with drawings?
+         */
+        public bool has_any() {
+            if (storage.has_any()) {
+                return true;
+            }
+
+            return this.surface != null && this.drawing_command_list.drawing_commands.length() != 0;
+        }
+
+        /**
+         * Does `page` have a drawing?
+         */
+        public bool has_any_on(int page) {
+            return storage.has_any_on(page);
+        }
+
+        /**
+         * Serialize the drawings on `page` into an array.
+         * Assumes that `builder` is currently building an array.
+         */
+        public void serialize(int page, Json.Builder builder) {
+            if (this.current_slide == page) {
+                this.store_all();
+            }
+            storage.serialize(page, builder);
+        }
+
+        /**
+         * Deserialize the drawings on `page`.
+         */
+        public void deserialize(int page, Json.Array content) {
+            this.storage.deserialize(page, content);
+            if (this.current_slide == page) {
+                this.drawing_command_list = storage.retrieve(page);
+                if (this.drawing_command_list == null) {
+                    this.drawing_command_list = new DrawingCommandList();
+                }
+                set_new_surface();
+                this.drawing_command_list.paint_in_surface(this.surface);
+                this.current_slide = page;
+            }
+        }
+
+        /**
+         * Export all drawings to a PDF at `path`.
+         */
+        public void export(string path) {
+            this.store_all();
+            storage.export(path);
+        }
+
         /*
          * Switch to a user slide, based on its number; all slides in an
          * overlay set share the same drawing.

--- a/src/classes/drawings/drawing_commands.vala
+++ b/src/classes/drawings/drawing_commands.vala
@@ -106,6 +106,10 @@ namespace pdfpc {
             cr.set_operator(Cairo.Operator.CLEAR);
             cr.paint();
 
+            this.paint_on_context(cr, surface.get_width(), surface.get_height());
+        }
+
+        public void paint_on_context(Cairo.Context cr, int width, int height) {
             // Default settings
             cr.set_operator(Cairo.Operator.OVER);
             cr.set_source_rgba(1, 0, 0, 1);
@@ -114,8 +118,6 @@ namespace pdfpc {
             cr.set_line_join(Cairo.LineJoin.ROUND);
 
             // Loop over commands and carry them out
-            int width = surface.get_width();
-            int height = surface.get_height();
             drawing_commands.foreach((dc) => {
                 if (dc.is_eraser) {
                     cr.set_operator(Cairo.Operator.CLEAR);
@@ -134,6 +136,148 @@ namespace pdfpc {
 
                 cr.stroke();
             });
+        }
+
+        public void occupied_rect(out double x1, out double y1, out double x2, out double y2) {
+            double min_x = 1.0, min_y = 1.0, max_x = 0.0, max_y = 0.0;
+
+            foreach (var dc in this.drawing_commands) {
+                if (dc.is_eraser) {
+                    continue;
+                }
+
+                // XXX: this isn't correct for all aspect ratios (because the line width isn't stretched)
+                min_x = Math.fmin(Math.fmin(dc.x1, dc.x2) - dc.lwidth, min_x);
+                min_y = Math.fmin(Math.fmin(dc.y1, dc.y2) - dc.lwidth, min_y);
+                max_x = Math.fmax(Math.fmax(dc.x1, dc.x2) + dc.lwidth, max_x);
+                max_y = Math.fmax(Math.fmax(dc.y1, dc.y2) + dc.lwidth, max_y);
+            }
+
+            x1 = Math.fmax(min_x, 0.0);
+            y1 = Math.fmax(min_y, 0.0);
+            x2 = Math.fmin(max_x, 1.0);
+            y2 = Math.fmin(max_y, 1.0);
+        }
+
+        public void serialize(Json.Builder builder) {
+            if (this.drawing_commands.is_empty()) {
+                return;
+            }
+
+            var sb = new StringBuilder();
+            size_t i = 0;
+            foreach (var dc in this.drawing_commands) {
+                if (dc.new_path) {
+                    if (i != 0) {
+                        sb.append_c(' ');
+                        sb.append(dc.x2.to_string());
+                        sb.append_c(' ');
+                        sb.append(dc.y2.to_string());
+                        sb.append_c(' ');
+                        sb.append(dc.lwidth.to_string());
+                        builder.add_string_value(sb.free_and_steal());
+                        sb = new StringBuilder();
+                        builder.end_object();
+                    }
+                    builder.begin_object();
+                    builder.set_member_name("is_eraser");
+                    builder.add_boolean_value(dc.is_eraser);
+                    builder.set_member_name("red");
+                    builder.add_double_value(dc.red);
+                    builder.set_member_name("green");
+                    builder.add_double_value(dc.green);
+                    builder.set_member_name("blue");
+                    builder.add_double_value(dc.blue);
+                    builder.set_member_name("alpha");
+                    builder.add_double_value(dc.alpha);
+                    builder.set_member_name("path");
+                } else {
+                    sb.append_c(' ');
+                }
+                sb.append(dc.x1.to_string());
+                sb.append_c(' ');
+                sb.append(dc.y1.to_string());
+                sb.append_c(' ');
+                sb.append(dc.lwidth.to_string());
+                i++;
+            }
+
+            unowned var last = this.drawing_commands.last().data;
+            sb.append_c(' ');
+            sb.append(last.x2.to_string());
+            sb.append_c(' ');
+            sb.append(last.y2.to_string());
+            sb.append_c(' ');
+            sb.append(last.lwidth.to_string());
+            builder.add_string_value(sb.free_and_steal());
+            builder.end_object();
+        }
+
+        public void deserialize(Json.Array content) {
+            for (uint i = 0; i < content.get_length(); i++) {
+                unowned var path = content.get_object_element(i);
+                var is_eraser = path.get_boolean_member("is_eraser");
+                var red = path.get_double_member("red");
+                var green = path.get_double_member("green");
+                var blue = path.get_double_member("blue");
+                var alpha = path.get_double_member("alpha");
+                unowned var str = path.get_string_member("path");
+                if (str.length < 5) {
+                    continue;
+                }
+                
+                bool initial = true;
+                while (str.data[0] != '\0') {
+                    unowned string end;
+                    double x1 = 0.0;
+                    double y1 = 0.0;
+                    double lwidth = 0.0;
+                    // A point is defined like "{x1} {x2} {lwidth}" with a 
+                    // space or null terminator afterwards.
+                    double.try_parse(str, out x1, out end);
+                    if (str == end) {
+                        break;
+                    }
+                    str = end.offset(1);
+                    double.try_parse(str, out y1, out end);
+                    if (str == end) {
+                        break;
+                    }
+                    str = end.offset(1);
+                    double.try_parse(str, out lwidth, out end);
+                    if (str == end) {
+                        break;
+                    }
+                    if (end.data[0] != '\0') {
+                        str = end.offset(1);
+                    }
+
+                    if (!initial) {
+                        unowned var last = this.drawing_commands.last().data;
+                        last.x2 = x1;
+                        last.y2 = y1;
+                    }
+                    this.drawing_commands.append(DrawingCommand() {
+                        new_path = initial,
+                        is_eraser = is_eraser,
+                        red = red,
+                        green = green,
+                        blue = blue,
+                        alpha = alpha,
+                        x1 = x1,
+                        y1 = y1,
+                        lwidth = lwidth
+                    });
+
+                    initial = false;
+                }
+
+                // The last point we receive in a path only sets {x,y} but
+                // doesn't define a new command.
+                if (this.drawing_commands.length() >= 2) {
+                    this.drawing_commands.remove_link(this.drawing_commands.last());
+                }
+            }
         }
 
         public void undo() {

--- a/src/classes/drawings/storage.vala
+++ b/src/classes/drawings/storage.vala
@@ -55,6 +55,31 @@ namespace pdfpc.Drawings.Storage {
          * Clear the storage
          */
         public abstract void clear();
+
+        /**
+         * Does this storage contain any drawing?
+         */
+        public abstract bool has_any();
+
+        /**
+         * Does this storage contain any drawing on this `page`?
+         */
+        public abstract bool has_any_on(int page);
+
+        /**
+         * Export the drawings as a PDF to `path`.
+         */
+        public abstract void export(string path);
+
+        /**
+         * Serialize the drawings on `page`.
+         */
+        public abstract void serialize(int page, Json.Builder builder);
+
+        /**
+         * Deserialize the drawings on `page`.
+         */
+        public abstract void deserialize(int page, Json.Array content);
     }
 
     public class MemoryUncompressed : Drawings.Storage.Base {
@@ -87,6 +112,86 @@ namespace pdfpc.Drawings.Storage {
             // of bounds if the number of user slides is changed due to overlay marking
             // changing.
             drawing_commands_storage = new pdfpc.DrawingCommandList[this.metadata.get_slide_count()];
+        }
+
+        public override bool has_any_on(int page) {
+            return this.drawing_commands_storage[page] != null &&
+                   this.drawing_commands_storage[page].drawing_commands.length() != 0;
+        }
+
+        public override bool has_any() {
+            for (int i = 0; i < this.metadata.get_slide_count(); i++) {
+                if (this.has_any_on(i)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public override void export(string out_file) {
+            var surface = new Cairo.PdfSurface(out_file, 0, 0);
+            var cr = new Cairo.Context(surface);
+    
+            surface.set_metadata(Cairo.PdfMetadata.AUTHOR, this.metadata.document.author);
+            surface.set_metadata(Cairo.PdfMetadata.CREATE_DATE, this.metadata.document.creation_datetime.to_string());
+            surface.set_metadata(Cairo.PdfMetadata.CREATOR, Release.app_name());
+            surface.set_metadata(Cairo.PdfMetadata.KEYWORDS, this.metadata.document.keywords);
+            surface.set_metadata(Cairo.PdfMetadata.MOD_DATE, new GLib.DateTime.now_local().to_string());
+            surface.set_metadata(Cairo.PdfMetadata.SUBJECT, this.metadata.document.subject);
+            surface.set_metadata(Cairo.PdfMetadata.TITLE, this.metadata.get_title());
+    
+            for (int i = 0; i < this.metadata.get_slide_count(); i++) {
+                var page = this.metadata.document.get_page(i);
+                double width_pt, height_pt;
+                page.get_size(out width_pt, out height_pt);
+                surface.set_size(width_pt, height_pt);
+                page.render_for_printing(cr);
+
+                if (this.has_any_on(i)) {
+                    double factor = 2; // what's the correct factor here?
+                    int base_width = (int)(width_pt * factor);
+                    int base_height = (int)(height_pt * factor);
+        
+                    double occ_x1, occ_y1, occ_x2, occ_y2;
+                    this.drawing_commands_storage[i].occupied_rect(out occ_x1, out occ_y1, out occ_x2, out occ_y2);
+                    int width = (int)((occ_x2 - occ_x1) * (double)base_width);
+                    int height = (int)((occ_y2 - occ_y1) * (double)base_height);
+        
+                    Cairo.ImageSurface drawing_surface = new Cairo.ImageSurface(Cairo.Format.ARGB32, width, height);
+                    {
+                        Cairo.Context drawing_cr = new Cairo.Context(drawing_surface);
+                        drawing_cr.set_source_rgba(1.0, 1.0, 1.0, 0.0);
+                        drawing_cr.rectangle(0, 0, width, height);
+                        drawing_cr.fill();
+                        drawing_cr.translate(-occ_x1 * (double)base_width, -occ_y1 * (double)base_height);
+                        this.drawing_commands_storage[i].paint_on_context(drawing_cr, base_width, base_height);
+                    }
+
+                    cr.save();
+                    cr.translate(occ_x1 * width_pt, occ_y1 * height_pt);
+                    cr.scale(1.0/factor, 1.0/factor);
+                    cr.set_source(new Cairo.Pattern.for_surface(drawing_surface));
+                    cr.paint();
+                    cr.restore();
+                }
+
+                cr.show_page();
+            }
+        }
+
+        public override void serialize(int page, Json.Builder builder) {
+            if (this.has_any_on(page)) {
+                this.drawing_commands_storage[page].serialize(builder);
+            }
+        }
+
+        public override void deserialize(int page, Json.Array content) {
+            if (content.get_length() == 0) {
+                return;
+            }
+            var l = new DrawingCommandList();
+            l.deserialize(content);
+            this.drawing_commands_storage[page] = l;
         }
     }
 

--- a/src/classes/metadata/pdf.vala
+++ b/src/classes/metadata/pdf.vala
@@ -186,6 +186,12 @@ namespace pdfpc.Metadata {
             get; protected set;
         }
 
+        /**
+         * Drawings saved from the last session (page -> drawings).
+         * Cleared by `apply_saved_drawings()`.
+         */
+        private GLib.HashTable<int, Json.Array>? saved_drawings = null;
+
         // END .pdfpc meta
 
         protected PageMeta? get_page_meta(int slide_number) {
@@ -256,6 +262,18 @@ namespace pdfpc.Metadata {
             }
         }
 
+        public bool apply_saved_drawings() {
+            if (this.saved_drawings == null) {
+                return false;
+            }
+
+            this.saved_drawings.for_each((slide_number, drawing) => {
+                this.controller.pen_drawing.deserialize(slide_number, drawing);
+            });
+            this.saved_drawings = null;
+            return true;
+        }
+
         /**
          * Save the metadata to disk
          */
@@ -323,7 +341,9 @@ namespace pdfpc.Metadata {
                 if (page.forced_overlay || page.hidden ||
                     (page.note != null    &&
                      !page.note.is_native &&
-                     page.note.note_text != null)) {
+                     page.note.note_text != null) ||
+                    (controller.pen_drawing.has_any_on(idx) && 
+                     Options.persist_drawings)) {
 
                     builder.begin_object();
                     builder.set_member_name("idx");
@@ -346,6 +366,15 @@ namespace pdfpc.Metadata {
                         builder.set_member_name("note");
                         builder.add_string_value(page.note.note_text);
                     }
+                    // Only include the drawings if we're asked to do so.
+                    if (controller.pen_drawing.has_any_on(idx) &&
+                        Options.persist_drawings) {
+                        builder.set_member_name("drawings");
+                        builder.begin_array();
+                        controller.pen_drawing.serialize(idx, builder);
+                        builder.end_array();
+                    }
+                    
                     builder.end_object();
                 }
 
@@ -381,6 +410,7 @@ namespace pdfpc.Metadata {
             string page_label = "", note = "";
             int idx = -1, overlay = 0, slide_number = -1;
             bool forced_overlay = false, hidden = false;
+            unowned Json.Array? drawing_arr = null;
             foreach (unowned string name in obj.get_members()) {
                 unowned Json.Node item = obj.get_member(name);
                 switch (name) {
@@ -402,6 +432,12 @@ namespace pdfpc.Metadata {
                 case "note":
 		    note = item.get_string();
 		    break;
+                case "drawings":
+                    if (this.saved_drawings == null) {
+                        this.saved_drawings = new GLib.HashTable<int, Json.Array>(null, null);
+                    }
+                    drawing_arr = item.get_array();
+                    break;
 		default:
                     GLib.printerr("Unknown page item \"%s\"\n", name);
 		    break;
@@ -440,6 +476,9 @@ namespace pdfpc.Metadata {
             }
             if (note != "") {
                 this.set_note(note, slide_number);
+            }
+            if (drawing_arr != null) {
+                this.saved_drawings.insert(slide_number, drawing_arr);
             }
         }
 
@@ -887,6 +926,8 @@ namespace pdfpc.Metadata {
          * Called on quit
          */
         public void quit() {
+            bool needs_drawings = this.controller.pen_drawing.has_any() && Options.persist_drawings;
+            this.dirty_state = this.dirty_state || needs_drawings;
             if (this.is_ready && this.dirty_state) {
                 this.save_to_disk();
             }

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -412,5 +412,36 @@ namespace pdfpc {
          */
         public static bool toolbox_shown = false;
         public static bool toolbox_minimized = false;
+
+        public enum DrawingSaveOnExit {
+            Always,
+            Never;
+
+            public static DrawingSaveOnExit parse(string? mode) {
+                if (mode == null) {
+                    return Never;
+                }
+
+                switch (mode.down()) {
+                    case "always":
+                        return Always;
+                    case "never":
+                        return Never;
+                    default:
+                        return Never;
+                }
+            }
+        }
+
+        /**
+         * When exiting the application, automatically save the drawings 
+         * next to the PDF.
+         */
+        public static DrawingSaveOnExit save_drawings_on_exit = DrawingSaveOnExit.Never;
+
+        /**
+         * Remember the drawings between sessions in JSON metadata.
+         */
+        public static bool persist_drawings = false;
     }
 }

--- a/src/classes/presentation_controller.vala
+++ b/src/classes/presentation_controller.vala
@@ -885,6 +885,34 @@ namespace pdfpc {
             }
         }
 
+        public void apply_saved_drawings() {
+            if (metadata.apply_saved_drawings()) {
+                pen_drawing_present = true;
+                hide_or_show_pen_surfaces();
+            }
+        }
+
+        public void export_drawings() {
+            var chooser = new Gtk.FileChooserNative("Save Drawings", this.presenter, Gtk.FileChooserAction.SAVE, null, null);
+            chooser.set_do_overwrite_confirmation(true);
+            chooser.set_current_folder(GLib.Path.get_dirname(this.metadata.pdf_fname));
+
+            var filename = GLib.Path.get_basename(this.metadata.pdf_fname);
+            if (filename.has_suffix(".pdf")) {
+                filename = filename.slice(0, filename.length - 4);
+            }
+
+            filename = filename + "-annotated.pdf";
+            chooser.set_current_name(filename);
+
+            var res = chooser.run();
+            if (res != Gtk.ResponseType.ACCEPT) {
+                return;
+            }
+
+            this.pen_drawing.export(chooser.get_filename());
+        }
+
         private void init_pen_and_pointer() {
             this.pointer   = new PointerTool(false);
             this.spotlight = new PointerTool(true);
@@ -950,6 +978,8 @@ namespace pdfpc {
         public double pointer_x;
         public double pointer_y;
 
+        private bool anything_painted = false;
+
         private void queue_pointer_surface_draws() {
             if (presenter != null) {
                 presenter.pointer_drawing_surface.queue_draw();
@@ -966,6 +996,7 @@ namespace pdfpc {
             // restart the pointer timeout timer
             this.restart_pointer_timer();
             this.pointer_hidden = false;
+            this.anything_painted = true;
 
             move_pen(pointer_x, pointer_y);
 
@@ -1175,6 +1206,25 @@ namespace pdfpc {
          * Inform metadata of quit, and then quit.
          */
         public void quit() {
+            // save drawings
+            this.pen_drawing.store_all();
+            switch (Options.save_drawings_on_exit) {
+            case pdfpc.Options.DrawingSaveOnExit.Always: {
+                if (this.pen_drawing.has_any() && this.anything_painted) {
+                    var base_name = this.metadata.pdf_fname;
+                    if (base_name.has_suffix(".pdf")) {
+                        base_name = base_name.substring(0, base_name.length - 4);
+                    }
+                    var now = new GLib.DateTime.now_local();
+                    var file = base_name + "-annotated-" + now.format("%FT%H-%M-%S") + ".pdf";
+                    this.pen_drawing.export(file);
+                }
+                break;
+            };
+            case pdfpc.Options.DrawingSaveOnExit.Never:
+                break;
+            }
+
             this.metadata.quit();
             if (this.screensaver != null && this.screensaver_cookie != 0) {
                 try {
@@ -1300,6 +1350,8 @@ namespace pdfpc {
                 "Clear drawing on the current slide");
             add_action("toggleDrawings", this.toggle_drawings,
                 "Toggle all drawings on all slides");
+            add_action("saveDrawings", this.export_drawings,
+                "Save the current file with drawings");
 
             add_action("toggleToolbox", this.toggle_toolbox,
                 "Toggle the toolbox");

--- a/src/pdfpc.vala
+++ b/src/pdfpc.vala
@@ -491,6 +491,8 @@ namespace pdfpc {
                 this.controller.presentation.show_all();
             }
 
+            this.controller.apply_saved_drawings();
+
             if (page_hnum >= 1 &&
                 page_hnum <= metadata.get_end_user_slide() + 1) {
                 int u = metadata.user_slide_to_real_slide(page_hnum - 1,

--- a/src/release.vala.in
+++ b/src/release.vala.in
@@ -22,6 +22,10 @@
 
 namespace pdfpc {
     public class Release {
+        public static string app_name() {
+            return "pdfpc ${PDFPC_VERSION_STRING}";
+        }
+
         public static void print_version() {
             GLib.print("pdfpc ${PDFPC_VERSION_STRING}\n"
                         + "Copyright (C) 2010-${PDFPC_VERSION_YEAR} see CONTRIBUTORS\n\n"


### PR DESCRIPTION
This adds <kbd>CTRL</kbd>+<kbd>S</kbd> to save drawings and functionality to persist drawings in the `.pdfpc` file. It uses Cairo's PDF backend for rendering.

Both the PDF export and the JSON (`.pdfpc`) export can be configured to happen automatically at exit.
- Set `option save-drawings-on-exit always` to always save the drawings as a PDF (`{pdf-name}-annotated-{date}.pdf`).
- Set `option persist-drawings true` to export the drawing commands to the `.pdfpc` file.

Related issue: https://github.com/pdfpc/pdfpc/issues/437