### PR TITLE
Restore the is_presenter flag of ControllableWindow

### DIFF
--- a/src/classes/action/movie.vala
+++ b/src/classes/action/movie.vala
@@ -766,7 +766,7 @@ namespace pdfpc {
                 Gst.Element queue = Gst.ElementFactory.make("queue", @"queue$n");
                 bin.add_many(queue, sink);
                 tee.link(queue);
-                if (conf.window.interactive) {
+                if (conf.window.is_presenter) {
                     Gst.Element ad_element = this.add_video_control(queue, bin,
                         conf.rect);
                     ad_element.link(sink);
@@ -777,7 +777,7 @@ namespace pdfpc {
 
                 // mark the video widget on the "frozen" presentation screen
                 // with a custom flag
-                if (!conf.window.interactive && controller.frozen) {
+                if (!conf.window.is_presenter && controller.frozen) {
                     video_area.set_data("pdfpc_frozen", true);
                 }
 
@@ -792,7 +792,7 @@ namespace pdfpc {
 
                         // Update the rectangle
                         conf.rect = rect;
-                        if (window.interactive) {
+                        if (window.is_presenter) {
                             this.rect = rect;
                             this.scalex = (double) this.video_w/rect.width;
                             this.scaley = (double) this.video_h/rect.height;

--- a/src/classes/window/controllable.vala
+++ b/src/classes/window/controllable.vala
@@ -48,9 +48,14 @@ namespace pdfpc.Window {
         }
 
         /**
-         * Whether the user directly interacts with this window
+         * Whether the user can directly interact with this window
          */
         public bool interactive { get; protected set; }
+
+        /**
+         * Whether this is the presenter window
+         */
+        public bool is_presenter { get; protected set; }
 
         /**
          * Drawing area for pointer mode
@@ -100,13 +105,18 @@ namespace pdfpc.Window {
          * Base constructor instantiating a new controllable window
          */
         public ControllableWindow(PresentationController controller,
-            bool interactive, int monitor_num, bool windowed,
+            bool interactive, bool is_presenter, int monitor_num, bool windowed,
             int width = -1, int height = -1) {
 
             base(monitor_num, windowed, width, height);
             this.controller = controller;
 
+            this.is_presenter = is_presenter;
             this.interactive = interactive;
+
+            this.title = "pdfpc - %s (%s)".
+                printf(is_presenter ? "presenter":"presentation",
+                    controller.metadata.get_title());
 
             this.overlay_layout = new Gtk.Overlay();
 

--- a/src/classes/window/presentation.vala
+++ b/src/classes/window/presentation.vala
@@ -39,10 +39,7 @@ namespace pdfpc.Window {
             if (Options.single_screen || Options.presentation_interactive) {
                 interactive = true;
             }
-            base(controller, interactive, screen_num, windowed, width, height);
-
-            this.title = "pdfpc - presentation (%s)".
-                printf(controller.metadata.get_title());
+            base(controller, interactive, false, screen_num, windowed, width, height);
 
             this.controller.update_request.connect(this.update);
 

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -448,10 +448,7 @@ namespace pdfpc.Window {
          */
         public Presenter(PresentationController controller,
             int screen_num, bool windowed) {
-            base(controller, true, screen_num, windowed);
-
-            this.title = "pdfpc - presenter (%s)".
-                printf(controller.metadata.get_title());
+            base(controller, true, true, screen_num, windowed);
 
             this.controller.reload_request.connect(this.on_reload);
             this.controller.update_request.connect(this.update);


### PR DESCRIPTION
The "interactive" flag is not a full equivalent, in particular, for the video playback controls.

This should fix bug #759.