### PR TITLE
Document workaround for notes not being shown

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -69,3 +69,15 @@ pdfpc in a dimensioned window such as::
 
 In this way we can see the tabs for presentation and presenter views, and manually drag them
 to the screens we desire.
+
+Notes are not shown
+===================
+
+If notes are not shown and appear only in editing mode (upon pressing
+``Ctrl + n``), you may have experienced WebKit bug.  As a workaround, try
+setting the ``WEBKIT_DISABLE_DMABUF_RENDERER`` environment variable, e.g.::
+
+    WEBKIT_DISABLE_DMABUF_RENDERER=1 pdfpc presentation.pdf
+
+For more information about the issue, see `Issue #718
+<https://github.com/pdfpc/pdfpc/issues/718>`_.

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -651,6 +651,9 @@ $ texdoc pdfpc
 .RE
 
 .SH BUGS
+.PP
+For a list of known bugs, see
+.URL https://github.com/pdfpc/pdfpc/blob/master/FAQ.rst "the FAQ" .
 
 .PP
 Bugs can be reported at

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -652,7 +652,7 @@ $ texdoc pdfpc
 
 .SH BUGS
 .PP
-For a list of known bugs, see
+Some known bugs and workarounds are listed in
 .URL https://github.com/pdfpc/pdfpc/blob/master/FAQ.rst "the FAQ" .
 
 .PP

--- a/man/pdfpc.in
+++ b/man/pdfpc.in
@@ -36,7 +36,7 @@ List action bindings defined
 Interpret the string as a pdfpcrc(5) statement. Multiple statements can be
 given.
 .TP
-.BI "\-C, \-\-time\-of\-day
+.BI "\-C, \-\-time\-of\-day"
 Display the time of the day
 .TP
 .BI "\-d, \-\-duration"=N
@@ -609,14 +609,20 @@ listed by \fB--list-actions\fR. It is also possible to control pdfpc from the
 command line (and write shell scripts) using the \fBdbus-send\fR(1) utility. For
 example, to advance to the next slide, run
 
-dbus-send --type=method_call --session --dest=io.github.pdfpc
- /io/github/pdfpc io.github.pdfpc.TriggerAction string:next
+.RS
+$ dbus-send --type=method_call --session \\
+    --dest=io.github.pdfpc /io/github/pdfpc \\
+    io.github.pdfpc.TriggerAction string:next
+.RE
 
 For actions that require an argument, use \fBTriggerActionArg\fR, e.g.,
 
-dbus-send --type=method_call --session --dest=io.github.pdfpc
- /io/github/pdfpc io.github.pdfpc.TriggerActionArg string:switchMode
- string:pointer
+.RS
+$ dbus-send --type=method_call --session \\
+    --dest=io.github.pdfpc /io/github/pdfpc \\
+    io.github.pdfpc.TriggerActionArg \\
+    string:switchMode string:pointer
+.RE
 
 In addition to \fBTriggerAction*\fR, the pdfpc DBus interface exposes
 the \fBGetNotes\fR method, three properties (\fBNumberOfOverlays\fR,


### PR DESCRIPTION
I’ve spent couple hours trying to figure out what I’m doing wrong
until I’ve stumbled upon the Issue describing the work-around.  Add
it to the man page so other people don’t have to suffer as I had.

Issue: https://github.com/pdfpc/pdfpc/issues/718
