### PR TITLE
Add Bash completion script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,5 +67,6 @@ add_subdirectory(icons)
 add_subdirectory(man)
 add_subdirectory(css)
 add_subdirectory(rc)
+add_subdirectory(completions)
 
 include(CPack)

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ In order to compile and run pdfpc, the following requirements need to be met:
 
 E.g., on Ubuntu 22.04 onward, you can install these dependencies with::
 
-    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev libmarkdown2-dev libwebkit2gtk-4.1-dev libsoup3.0-dev libqrencode-dev gstreamer1.0-gtk3
+    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev libmarkdown2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libqrencode-dev gstreamer1.0-gtk3
 
 (the last one is a run-time dependence). You should also consider installing all
 plugins to support required video formats; chances are they are already present

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ In order to compile and run pdfpc, the following requirements need to be met:
 
 E.g., on Ubuntu 22.04 onward, you can install these dependencies with::
 
-    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev libmarkdown2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libqrencode-dev gstreamer1.0-gtk3
+    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev libmarkdown2-dev libwebkit2gtk-4.1-dev libsoup3.0-dev libqrencode-dev gstreamer1.0-gtk3
 
 (the last one is a run-time dependence). You should also consider installing all
 plugins to support required video formats; chances are they are already present

--- a/completions/CMakeLists.txt
+++ b/completions/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(NOT (WIN32 OR APPLE)) # Skip Windows and macOS for now.
+    install(
+        FILES pdfpc.bash
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/bash-completion/completions"
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+    )
+endif()

--- a/completions/CMakeLists.txt
+++ b/completions/CMakeLists.txt
@@ -1,7 +1,4 @@
-if(NOT (WIN32 OR APPLE)) # Skip Windows and macOS for now.
-    install(
-        FILES pdfpc.bash
-        DESTINATION "${CMAKE_INSTALL_PREFIX}/share/bash-completion/completions"
-        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-    )
-endif()
+install(FILES pdfpc.bash
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+)

--- a/completions/pdfpc.bash
+++ b/completions/pdfpc.bash
@@ -1,0 +1,102 @@
+# Bash completion for pdfpc.
+#
+# The completion is static (defined for every option).
+# Written by Emanuele Petriglia (ema-pe) <inbox@emanuelepetriglia.com>.
+
+_pdfpc_complete() {
+    local cur prev opts nofile_opts
+
+    # Read by Bash at the end, contains the completions.
+    COMPREPLY=()
+
+    # Current and previous word in the prompt.
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # All available options supported by pdfpc (v4.7.0).
+    opts="
+        -h --help
+        -B --list-bindings
+        -c --cfg-statement
+        -C --time-of-day
+        -d --duration
+        -e --end-time
+        -f --note-format
+        -g --disable-auto-grouping
+        -l --last-minutes
+        -L --list-actions
+        -M --list-monitors
+        -n --notes
+        -N --no-install
+        -p --rest-port
+        -P --page
+        -r --page-transition
+        -R --pdfpc-location
+        -s --switch-screens
+        -S --single-screen
+        -t --start-time
+        -T --enable-auto-srt-load
+        -v --version
+        -V --enable-rest-server
+        -w --windowed
+        -W --wayland-workaround
+        -X --external-script
+        -Z --size
+        -1 --presenter-screen
+        -2 --presentation-screen
+    "
+
+    # Handle completion for (short and long) options that take a value.
+    if [[ "${prev}" == "-f" || "${prev}" == "--note-format" ]]; then
+        # shellcheck disable=SC2207
+        # See: https://www.shellcheck.net/wiki/SC2207
+        COMPREPLY=( $(compgen -W "plain markdown" -- "${cur}") )
+        return 0
+    fi
+    if [[ "${prev}" == "-n" || "${prev}" == "--notes" ]]; then
+        # shellcheck disable=SC2207
+        COMPREPLY=( $(compgen -W "left right top bottom none" -- "${cur}") )
+        return 0
+    fi
+    if [[ "${prev}" == "-w" || "${prev}" == "--windowed" ]]; then
+        # shellcheck disable=SC2207
+        COMPREPLY=( $(compgen -W "presenter presentation both none" -- "${cur}") )
+        return 0
+    fi
+    if [[ "${prev}" == "-R" || "${prev}" == "--pdfpc-location" || \
+          "${prev}" == "-X" || "${prev}" == "--external-script" ]]; then
+        mapfile -t COMPREPLY < <(compgen -f -- "${cur}")
+        return 0
+    fi
+
+    # Complete with options (do not suggest '=' at end for long options).
+    if [[ "${cur}" == -* && "${cur}" != *=* ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${opts}" -- "${cur}")
+        return 0
+    fi
+
+    # Array of options after which PDF completion shouldn't happen.
+    nofile_opts=(
+        "-c" "--cfg-statement"
+        "-d" "--duration"
+        "-e" "--end-time"
+        "-l" "--last-minutes"
+        "-r" "--page-transition"
+        "-t" "--start-time"
+        "-w" "--windowed"
+        "-1" "--presenter-screen"
+        "-2" "--presentation-screen"
+    )
+
+    # Do not suggest PDF files if previous word is an option that expects a value.
+    for opt in "${nofile_opts[@]}"; do
+        if [[ "${prev}" == "${opt}" ]]; then
+            return 0
+        fi
+    done
+
+    # Otherwise, suggest PDF files for first non-option argument.
+    mapfile -t COMPREPLY < <(compgen -G "*.pdf" -- "${cur}")
+}
+
+complete -F _pdfpc_complete pdfpc


### PR DESCRIPTION
Hello!

This pull request adds a basic Bash completion script for pdfpc. I wrote a static completion script, meaning I defined every supported option. Long options with an "=" character at the end are not supported because it is too tricky to support them, however I do not think this is a significant limitation. I updated CMake to install the script in the correct directory, but only for Linux and FreeBSD. I also added a completions directory in case other shells are supported in the future. This pull request solves #748.

I'm waiting for feedback!
