### PR TITLE
Fix package name for libsoup in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ In order to compile and run pdfpc, the following requirements need to be met:
 
 E.g., on Ubuntu 22.04 onward, you can install these dependencies with::
 
-    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev libmarkdown2-dev libwebkit2gtk-4.1-dev libsoup3.0-dev libqrencode-dev gstreamer1.0-gtk3
+    sudo apt-get install cmake valac libgee-0.8-dev libpoppler-glib-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libjson-glib-dev libmarkdown2-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libqrencode-dev gstreamer1.0-gtk3
 
 (the last one is a run-time dependence). You should also consider installing all
 plugins to support required video formats; chances are they are already present


### PR DESCRIPTION
In Ubuntu/Debian the name for libsoup3.0-dev is libsoup-3.0-dev